### PR TITLE
Fix: Goron City Doors after Fire Temple

### DIFF
--- a/soh/soh/Enhancements/Fixes/GoronCityDoorFix.cpp
+++ b/soh/soh/Enhancements/Fixes/GoronCityDoorFix.cpp
@@ -24,10 +24,7 @@ static void OnInitGCDoor(void* refActor) {
 }
 
 void RegisterGoronTunicFix() {
-    COND_ID_HOOK(OnActorInit, 
-        ACTOR_BG_SPOT18_SHUTTER,
-        CVAR_GC_DOOR_FIX_VALUE, 
-        OnInitGCDoor);
+    COND_ID_HOOK(OnActorInit, ACTOR_BG_SPOT18_SHUTTER, CVAR_GC_DOOR_FIX_VALUE, OnInitGCDoor);
 }
 
 static RegisterShipInitFunc initFunc(RegisterGoronTunicFix, { CVAR_GC_DOOR_FIX_NAME });

--- a/soh/soh/Enhancements/Fixes/GoronCityDoorFix.cpp
+++ b/soh/soh/Enhancements/Fixes/GoronCityDoorFix.cpp
@@ -4,8 +4,8 @@
 extern "C" {
 #include "functions.h"
 #include "macros.h"
+#include "variables.h"
 #include "z64save.h"
-#include "src/overlays/actors/ovl_Bg_Spot18_Shutter/z_bg_spot18_shutter.h"
 }
 
 static constexpr int32_t CVAR_GC_DOOR_FIX_DEFAULT = 0;
@@ -15,8 +15,6 @@ static constexpr int32_t CVAR_GC_DOOR_FIX_DEFAULT = 0;
 static void OnInitGCDoor(void* refActor) {
     // In the off chance that Fire Temple is completed before stopping Goron Link and getting
     // Goron Tunic / opening the city doors, open them the next time Link goes to Goron City.
-    // RefActor is needed since shutter checks inf flag during init.
-    BgSpot18Shutter* shutter = reinterpret_cast<BgSpot18Shutter*>(refActor);
     if (GameInteractor_Should(VB_GORONS_CONSIDER_FIRE_TEMPLE_FINISHED, CHECK_QUEST_ITEM(QUEST_MEDALLION_FIRE)) &&
         !Flags_GetInfTable(INFTABLE_GORON_CITY_DOORS_UNLOCKED)) {
         Flags_SetInfTable(INFTABLE_GORON_CITY_DOORS_UNLOCKED);
@@ -24,7 +22,7 @@ static void OnInitGCDoor(void* refActor) {
 }
 
 void RegisterGoronTunicFix() {
-    COND_ID_HOOK(OnActorInit, ACTOR_BG_SPOT18_SHUTTER, CVAR_GC_DOOR_FIX_VALUE, OnInitGCDoor);
+    COND_ID_HOOK(OnActorInit, ACTOR_BG_SPOT18_SHUTTER, !IS_RANDO && CVAR_GC_DOOR_FIX_VALUE, OnInitGCDoor);
 }
 
-static RegisterShipInitFunc initFunc(RegisterGoronTunicFix, { CVAR_GC_DOOR_FIX_NAME });
+static RegisterShipInitFunc initFunc(RegisterGoronTunicFix, { CVAR_GC_DOOR_FIX_NAME, "IS_RANDO" });

--- a/soh/soh/Enhancements/Fixes/GoronCityDoorFix.cpp
+++ b/soh/soh/Enhancements/Fixes/GoronCityDoorFix.cpp
@@ -1,0 +1,33 @@
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+
+extern "C" {
+#include "functions.h"
+#include "macros.h"
+#include "z64save.h"
+#include "src/overlays/actors/ovl_Bg_Spot18_Shutter/z_bg_spot18_shutter.h"
+}
+
+static constexpr int32_t CVAR_GC_DOOR_FIX_DEFAULT = 0;
+#define CVAR_GC_DOOR_FIX_NAME CVAR_ENHANCEMENT("GCDoorsAfterFireFix")
+#define CVAR_GC_DOOR_FIX_VALUE CVarGetInteger(CVAR_GC_DOOR_FIX_NAME, CVAR_GC_DOOR_FIX_DEFAULT)
+
+static void OnInitGCDoor(void* refActor) {
+    // In the off chance that Fire Temple is completed before stopping Goron Link and getting
+    // Goron Tunic / opening the city doors, open them the next time Link goes to Goron City.
+    // RefActor is needed since shutter checks inf flag during init.
+    BgSpot18Shutter* shutter = reinterpret_cast<BgSpot18Shutter*>(refActor);
+    if (GameInteractor_Should(VB_GORONS_CONSIDER_FIRE_TEMPLE_FINISHED, CHECK_QUEST_ITEM(QUEST_MEDALLION_FIRE)) &&
+        !Flags_GetInfTable(INFTABLE_GORON_CITY_DOORS_UNLOCKED)) {
+        Flags_SetInfTable(INFTABLE_GORON_CITY_DOORS_UNLOCKED);
+    }
+}
+
+void RegisterGoronTunicFix() {
+    COND_ID_HOOK(OnActorInit, 
+        ACTOR_BG_SPOT18_SHUTTER,
+        CVAR_GC_DOOR_FIX_VALUE, 
+        OnInitGCDoor);
+}
+
+static RegisterShipInitFunc initFunc(RegisterGoronTunicFix, { CVAR_GC_DOOR_FIX_NAME });

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1010,8 +1010,7 @@ void SohMenu::AddMenuEnhancements() {
         .CVar(CVAR_ENHANCEMENT("GCDoorsAfterFireFix"))
         .Options(CheckboxOptions().Tooltip(
             "Forces Goron City doors open if you somehow complete Fire Temple without talking to Goron Link "
-            " and receiving the Goron Tunic. "
-        ));
+            " and receiving the Goron Tunic. "));
         
     AddWidget(path, "Item-related Fixes", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Fix Deku Nut Upgrade", WIDGET_CVAR_CHECKBOX)

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1006,7 +1006,13 @@ void SohMenu::AddMenuEnhancements() {
         .CVar(CVAR_ENHANCEMENT("AnubisFix"))
         .Options(CheckboxOptions().Tooltip(
             "Make Anubis Fireballs do Fire damage when reflected back at them with the Mirror Shield."));
-
+    AddWidget(path, "Fix Goron City Doors After Fire Temple", WIDGET_CVAR_CHECKBOX)
+    .CVar(CVAR_ENHANCEMENT("GCDoorsAfterFireFix"))
+        .Options(CheckboxOptions().Tooltip(
+            "Forces Goron City doors open if you somehow complete Fire Temple without talking to Goron Link "
+            " and receiving the Goron Tunic. "
+        ));
+        
     AddWidget(path, "Item-related Fixes", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Fix Deku Nut Upgrade", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("DekuNutUpgradeFix"))

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1010,8 +1010,8 @@ void SohMenu::AddMenuEnhancements() {
         .CVar(CVAR_ENHANCEMENT("GCDoorsAfterFireFix"))
         .Options(CheckboxOptions().Tooltip(
             "Forces Goron City doors open if you somehow complete Fire Temple without talking to Goron Link "
-            " and receiving the Goron Tunic. "));
-        
+            " and receiving the Goron Tunic."));
+
     AddWidget(path, "Item-related Fixes", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Fix Deku Nut Upgrade", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("DekuNutUpgradeFix"))

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1007,7 +1007,7 @@ void SohMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip(
             "Make Anubis Fireballs do Fire damage when reflected back at them with the Mirror Shield."));
     AddWidget(path, "Fix Goron City Doors After Fire Temple", WIDGET_CVAR_CHECKBOX)
-    .CVar(CVAR_ENHANCEMENT("GCDoorsAfterFireFix"))
+        .CVar(CVAR_ENHANCEMENT("GCDoorsAfterFireFix"))
         .Options(CheckboxOptions().Tooltip(
             "Forces Goron City doors open if you somehow complete Fire Temple without talking to Goron Link "
             " and receiving the Goron Tunic. "


### PR DESCRIPTION
Apparently, there is a way for casual players to lock themselves out of obtaining Goron Tunic if they manage to complete Fire Temple before speaking to Link the Goron. (This can be achieved with Longshot and Scarecrow's Song.) This is more an exercise in using the new(ish) hook system, but it should help to ensure that the item can still be legitimately obtained.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4523440619.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4523475692.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4523515965.zip)
<!--- section:artifacts:end -->