### PR TITLE
Default Log Level Init Fix

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -297,10 +297,12 @@ void OTRGlobals::Initialize() {
 #else
     auto defaultLogLevel = spdlog::level::info;
 #endif
-    context->InitLogging(defaultLogLevel, defaultLogLevel);
+    auto logLevel =
+        static_cast<spdlog::level::level_enum>(CVarGetInteger(CVAR_DEVELOPER_TOOLS("LogLevel"), defaultLogLevel));
+    context->InitLogging(logLevel, logLevel);
+    Ship::Context::GetInstance()->GetLogger()->set_pattern("[%H:%M:%S.%e] [%s:%#] [%l] %v");
     context->InitConfiguration();
     context->InitConsoleVariables();
-    Ship::Context::GetInstance()->GetLogger()->set_pattern("[%H:%M:%S.%e] [%s:%#] [%l] %v");
 
     context->InitGfxDebugger();
     context->InitFileDropMgr();


### PR DESCRIPTION
Forgot to feed `defaultLogLevel` into the CVar lookup for LogLevel to then pass into `InitLogging()` rather than passing `defaultLogLevel` directly.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4533712575.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4533771851.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4533915058.zip)
<!--- section:artifacts:end -->