### PR TITLE
Fix Boot With Networking Disabled

### DIFF
--- a/soh/soh/Network/Anchor/Menu.cpp
+++ b/soh/soh/Network/Anchor/Menu.cpp
@@ -222,6 +222,7 @@ void AnchorInstructionsMenu(WidgetInfo& info) {
         "the same randomizer seed, while players on different teams can use different seeds.");
 }
 
+#ifdef ENABLE_REMOTE_CONTROL
 void RegisterAnchorMenu() {
     WidgetPath path = { "Network", "Anchor", SECTION_COLUMN_1 };
     SohGui::mSohMenu->AddWidget(path, "AnchorMainMenu", WIDGET_CUSTOM)
@@ -237,3 +238,4 @@ void RegisterAnchorMenu() {
 }
 
 static RegisterMenuInitFunc menuInitFunc(RegisterAnchorMenu);
+#endif


### PR DESCRIPTION
Anchor was trying to register widgets regardless of whether networking was enabled, and this would crash because it was trying to add widgets to a non-existent sidebar. This just surrounds the menuInit stuff in Anchor/Menu.cpp with an #ifdef ENABLE_REMOTE_CONTROL block to prevent that.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4572848797.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4572894526.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4572995879.zip)
<!--- section:artifacts:end -->