### PR TITLE
Fix entrance value assigned to DMT sign outside Dodongo's for hinting.

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -2311,7 +2311,7 @@ extern "C" int CustomMessage_RetrieveIfExists(PlayState* play) {
                     entrance = ENTR_GROTTOS_13;
                     break;
                 case TEXT_DMT_DC_SIGN:
-                    entrance = ENTR_DEATH_MOUNTAIN_TRAIL_OUTSIDE_DODONGOS_CAVERN;
+                    entrance = ENTR_DODONGOS_CAVERN_ENTRANCE;
                     break;
                 case TEXT_DMT_GC_SIGN:
                     entrance = ENTR_GORON_CITY_UPPER_EXIT;


### PR DESCRIPTION
null

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4605478757.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4605487867.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4605660366.zip)
<!--- section:artifacts:end -->