### PR TITLE
Adds a toggle for the entrance labels on signs near loading zones.

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -2270,7 +2270,8 @@ extern "C" int CustomMessage_RetrieveIfExists(PlayState* play) {
     s16 actorParams = 0;
     if (IS_RANDO) {
         auto ctx = Rando::Context::GetInstance();
-        if (ctx->GetOption(RSK_SHUFFLE_ENTRANCES)) {
+        if (ctx->GetOption(RSK_SHUFFLE_ENTRANCES) &&
+            CVarGetInteger(CVAR_RANDOMIZER_ENHANCEMENT("EntrancesOnSigns"), 0)) {
             s16 entrance = -1;
             switch (textId) {
                 case TEXT_WATERFALL:

--- a/soh/soh/SohGui/SohMenuRandomizer.cpp
+++ b/soh/soh/SohGui/SohMenuRandomizer.cpp
@@ -97,6 +97,9 @@ void SohMenu::AddMenuRandomizer() {
         })
         .Options(FloatSliderOptions().Min(5.0f).Max(15.0f).Format("%.2f").DefaultValue(10.0f).Tooltip(
             "The size of the item when it is picked up."));
+    AddWidget(path, "Signs Hint Entrances", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_RANDOMIZER_ENHANCEMENT("EntrancesOnSigns"))
+        .Options(CheckboxOptions().Tooltip("If enabled, signs near loading zones will tell you where they lead to."));
 
     // Plandomizer
     path.sidebarName = "Plandomizer";


### PR DESCRIPTION
Adds a toggle to Randomizer->Enhancements for the feature where signs near loading zones tell you where the entrance will lead. Probably should have always been behind a toggle and we'll want to have it disabled for races and such.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4607038925.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4607056925.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4607114121.zip)
<!--- section:artifacts:end -->