### PR TITLE
Chest of Agony -> Set Key/Key Ring chests to large if Chest of Agony Size Only is Enabled

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Box/z_en_box.c
+++ b/soh/src/overlays/actors/ovl_En_Box/z_en_box.c
@@ -611,8 +611,13 @@ void EnBox_UpdateSizeAndTexture(EnBox* this, PlayState* play) {
     // Change size
     if (!isVanilla && (csmc == CSMC_BOTH || csmc == CSMC_SIZE)) {
         switch (getItemCategory) {
-            case ITEM_CATEGORY_JUNK:
             case ITEM_CATEGORY_SMALL_KEY:
+                // Change the size if and only if size is selected.
+                // Otherwise, the texture change is sufficient.
+                Actor_SetScale(&this->dyna.actor, csmc == CSMC_SIZE ? 0.01f : 0.005f);
+                Actor_SetFocus(&this->dyna.actor, csmc == CSMC_SIZE ? 40.0f : 20.0f);
+                break;
+            case ITEM_CATEGORY_JUNK:
             case ITEM_CATEGORY_SKULLTULA_TOKEN:
                 Actor_SetScale(&this->dyna.actor, 0.005f);
                 Actor_SetFocus(&this->dyna.actor, 20.0f);


### PR DESCRIPTION
Proposing changing the chest size of the small key item category to large
I've noticed that in standard settings, where chest of agony is enabled and size only is selected, you potentially need to check multiple small chests of junk before locating the small chest with a keyring.
This seems counterintuitive to the behavior that chest of agony is supposed to provide.
A caveat: if Both is enabled, then leave the size alone, as the texture alone should be sufficient.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4647284113.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4647293218.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4647311576.zip)
<!--- section:artifacts:end -->