### PR TITLE
Convert "Big Four" hook register functions to init functions

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
@@ -2,7 +2,6 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/Enhancements/randomizer/context.h"
 #include "soh/ShipInit.hpp"
-#include "soh/Enhancements/timesaver_hook_handlers.h"
 
 extern "C" {
 #include "macros.h"
@@ -15,6 +14,8 @@ extern "C" {
 
 extern "C" PlayState* gPlayState;
 static bool sEnteredBlueWarp = false;
+
+extern void TimeSaverQueueItem(RandomizerGet randoGet);
 
 // Todo: Move item queueing here
 

--- a/soh/soh/Enhancements/TimeSavers/SkipTimerDelay.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipTimerDelay.cpp
@@ -1,16 +1,10 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
-#include "soh/cvar_prefixes.h"
 #include "soh/ShipInit.hpp"
-
-#include "tables/actor_table.h"
-#include "tables/scene_table.h"
 
 extern "C" {
 #include "src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.h"
 #include "src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.h"
 #include "src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.h"
-#include "z64.h"
-#include "z64save.h"
 extern PlayState* gPlayState;
 }
 

--- a/soh/soh/Enhancements/TimeSavers/SkipTimerDelay.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipTimerDelay.cpp
@@ -1,0 +1,48 @@
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/cvar_prefixes.h"
+#include "soh/ShipInit.hpp"
+
+#include "tables/actor_table.h"
+#include "tables/scene_table.h"
+
+extern "C" {
+#include "src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.h"
+#include "src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.h"
+#include "src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.h"
+#include "z64.h"
+#include "z64save.h"
+extern PlayState* gPlayState;
+}
+
+#define SKIP_MISC_INTERACTIONS_NAME CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions")
+#define SKIP_MISC_INTERACTIONS_VALUE CVarGetInteger(SKIP_MISC_INTERACTIONS_NAME, IS_RANDO)
+
+static void RegisterSkipTimerDelay() {
+    // Skip Water Temple gate delay
+    COND_ID_HOOK(OnActorUpdate, ACTOR_BG_SPOT06_OBJECTS, SKIP_MISC_INTERACTIONS_VALUE, [](void* actor) {
+        auto spot06 = static_cast<BgSpot06Objects*>(actor);
+        if (spot06->dyna.actor.params == 0) {
+            spot06->timer = 0;
+        }
+    });
+
+    // Skip Spirit Sun on Floor activation delay
+    COND_ID_HOOK(OnActorUpdate, ACTOR_BG_JYA_BOMBCHUIWA, SKIP_MISC_INTERACTIONS_VALUE, [](void* actor) {
+        auto jya = static_cast<BgJyaBombchuiwa*>(actor);
+        if (!(jya->drawFlags & 4) && jya->timer > 0 && jya->timer < 9) {
+            jya->timer = 9;
+        }
+    });
+
+    // Skip Spirit Sun on Floor & Sun on Block activation delay
+    COND_ID_HOOK(OnActorUpdate, ACTOR_OBJ_LIGHTSWITCH, SKIP_MISC_INTERACTIONS_VALUE, [](void* actor) {
+        if (gPlayState->sceneNum == SCENE_SPIRIT_TEMPLE &&
+            (gPlayState->roomCtx.curRoom.num == 4 || gPlayState->roomCtx.curRoom.num == 8)) {
+            auto sun = static_cast<ObjLightswitch*>(actor);
+            sun->toggleDelay = 0;
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc_SkipTimerDelay(RegisterSkipTimerDelay,
+                                                    { SKIP_MISC_INTERACTIONS_NAME, "IS_RANDO" });

--- a/soh/soh/Enhancements/kaleido.cpp
+++ b/soh/soh/Enhancements/kaleido.cpp
@@ -1,6 +1,7 @@
 #include "kaleido.h"
 
 #include "soh/frame_interpolation.h"
+#include "soh/ShipInit.hpp"
 #include "soh/ShipUtils.h"
 
 extern "C" {
@@ -443,7 +444,9 @@ void KaleidoEntryOcarinaButtons::Draw(PlayState* play, std::vector<Gfx>* mEntryD
 }
 } // namespace Rando
 
-void RandoKaleido_RegisterHooks() {
+static void RandoKaleido_RegisterHooks() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnKaleidoscopeUpdate>(
         RandoKaleido_UpdateMiscCollectibles);
 }
+
+static RegisterShipInitFunc initFunc(RandoKaleido_RegisterHooks);

--- a/soh/soh/Enhancements/kaleido.h
+++ b/soh/soh/Enhancements/kaleido.h
@@ -175,6 +175,5 @@ void RandoKaleido_UpdateMiscCollectibles(int16_t inDungeonScene);
 #ifdef __cplusplus
 }
 #endif
-void RandoKaleido_RegisterHooks();
 
 #endif // KALEIDO_H

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -1,13 +1,10 @@
 #include "mods.h"
 #include <libultraship/bridge.h>
 #include "game-interactor/GameInteractor.h"
-#include "tts/tts.h"
 #include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/boss-rush/BossRush.h"
 #include "soh/Enhancements/enhancementTypes.h"
 #include <soh/Enhancements/item-tables/ItemTableManager.h>
-#include "soh/Enhancements/timesaver_hook_handlers.h"
-#include "soh/Enhancements/randomizer/hook_handlers.h"
 
 #include "src/overlays/actors/ovl_En_Bb/z_en_bb.h"
 #include "src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.h"
@@ -26,7 +23,6 @@
 #include "src/overlays/actors/ovl_Door_Gerudo/z_door_gerudo.h"
 #include "src/overlays/actors/ovl_En_Elf/z_en_elf.h"
 #include "soh_assets.h"
-#include "kaleido.h"
 
 extern "C" {
 #include <z64.h>
@@ -471,13 +467,9 @@ void RegisterRandomizedEnemySizes() {
 }
 
 void InitMods() {
-    RandomizerRegisterHooks();
-    TimeSaverRegisterHooks();
-    RegisterTTS();
     RegisterOcarinaTimeTravel();
     RegisterHyperBosses();
     UpdateHyperEnemiesState();
     RegisterEnemyDefeatCounts();
     RegisterRandomizedEnemySizes();
-    RandoKaleido_RegisterHooks();
 }

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -13,6 +13,7 @@
 #include "soh/SohGui/ImGuiUtils.h"
 #include "soh/Notification/Notification.h"
 #include "soh/SaveManager.h"
+#include "soh/ShipInit.hpp"
 
 extern "C" {
 #include "macros.h"
@@ -2423,7 +2424,7 @@ void RandomizerOnCuccoOrChickenHatch() {
     }
 }
 
-void RandomizerRegisterHooks() {
+static void RandomizerRegisterHooks() {
     static uint32_t onFlagSetHook = 0;
     static uint32_t onSceneFlagSetHook = 0;
     static uint32_t onPlayerUpdateForRCQueueHook = 0;
@@ -2573,3 +2574,5 @@ void RandomizerRegisterHooks() {
         }
     });
 }
+
+static RegisterShipInitFunc initFunc_RegisterHooks(RandomizerRegisterHooks);

--- a/soh/soh/Enhancements/randomizer/hook_handlers.h
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.h
@@ -1,6 +1,0 @@
-#ifndef RANDOMIZER_HOOK_HANDLERS_H
-#define RANDOMIZER_HOOK_HANDLERS_H
-
-void RandomizerRegisterHooks();
-
-#endif // RANDOMIZER_HOOK_HANDLERS_H

--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -8,7 +8,6 @@ extern "C" {
 #include "src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.h"
 #include "src/overlays/actors/ovl_Elf_Msg/z_elf_msg.h"
 #include "src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h"
-#include "src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.h"
 #include "src/overlays/actors/ovl_Bg_Bdan_Switch/z_bg_bdan_switch.h"
 #include "src/overlays/actors/ovl_Bg_Treemouth/z_bg_treemouth.h"
 #include "src/overlays/actors/ovl_En_Owl/z_en_owl.h"
@@ -29,9 +28,7 @@ extern "C" {
 #include "src/overlays/actors/ovl_En_Daiku/z_en_daiku.h"
 #include "src/overlays/actors/ovl_Bg_Spot02_Objects/z_bg_spot02_objects.h"
 #include "src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.h"
-#include "src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.h"
 #include "src/overlays/actors/ovl_Bg_Hidan_Kousi/z_bg_hidan_kousi.h"
-#include "src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.h"
 #include "src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.h"
 #include "src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.h"
 #include "src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.h"
@@ -1204,7 +1201,7 @@ void TimeSaverOnSceneInitHandler(int16_t sceneNum) {
 
 static GetItemEntry vanillaQueuedItemEntry = GET_ITEM_NONE;
 
-void TimeSaverQueueItem(RandomizerGet randoGet) {
+extern void TimeSaverQueueItem(RandomizerGet randoGet) {
     vanillaQueuedItemEntry = Rando::StaticData::RetrieveItem(randoGet).GetGIEntry_Copy();
 }
 
@@ -1287,15 +1284,13 @@ void TimeSaverOnFlagSetHandler(int16_t flagType, int16_t flag) {
             case FLAG_ITEM_GET_INF:
                 switch (flag) {
                     case ITEMGETINF_OBTAINED_STICK_UPGRADE_FROM_STAGE: {
-                        RandomizerGet stickUpgrade =
-                            CUR_UPG_VALUE(UPG_STICKS) == 2 ? RG_DEKU_STICK_CAPACITY_30 : RG_DEKU_STICK_CAPACITY_20;
-                        vanillaQueuedItemEntry = Rando::StaticData::RetrieveItem(stickUpgrade).GetGIEntry_Copy();
+                        TimeSaverQueueItem(CUR_UPG_VALUE(UPG_STICKS) == 2 ? RG_DEKU_STICK_CAPACITY_30
+                                                                          : RG_DEKU_STICK_CAPACITY_20);
                         break;
                     }
                     case ITEMGETINF_OBTAINED_NUT_UPGRADE_FROM_STAGE: {
-                        RandomizerGet nutUpgrade =
-                            CUR_UPG_VALUE(UPG_NUTS) == 2 ? RG_DEKU_NUT_CAPACITY_40 : RG_DEKU_NUT_CAPACITY_30;
-                        vanillaQueuedItemEntry = Rando::StaticData::RetrieveItem(nutUpgrade).GetGIEntry_Copy();
+                        TimeSaverQueueItem(CUR_UPG_VALUE(UPG_NUTS) == 2 ? RG_DEKU_NUT_CAPACITY_40
+                                                                        : RG_DEKU_NUT_CAPACITY_30);
                         break;
                     }
                 }
@@ -1395,7 +1390,7 @@ static uint32_t onGameFrameUpdate = 0;
 static uint32_t onFlagSetHook = 0;
 static uint32_t onPlayerUpdateHook = 0;
 static uint32_t onItemReceiveHook = 0;
-void TimeSaverRegisterHooks() {
+static void TimeSaverRegisterHooks() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnLoadGame>([](int32_t fileNum) mutable {
         vanillaQueuedItemEntry = GET_ITEM_NONE;
 
@@ -1436,35 +1431,4 @@ void TimeSaverRegisterHooks() {
     });
 }
 
-void RegisterSkipTimerDelay() {
-    // Skip Water Temple gate delay
-    COND_ID_HOOK(OnActorUpdate, ACTOR_BG_SPOT06_OBJECTS,
-                 CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions"), IS_RANDO), [](void* actor) {
-                     auto spot06 = static_cast<BgSpot06Objects*>(actor);
-                     if (spot06->dyna.actor.params == 0) {
-                         spot06->timer = 0;
-                     }
-                 });
-
-    // Skip Spirit Sun on Floor activation delay
-    COND_ID_HOOK(OnActorUpdate, ACTOR_BG_JYA_BOMBCHUIWA,
-                 CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions"), IS_RANDO), [](void* actor) {
-                     auto jya = static_cast<BgJyaBombchuiwa*>(actor);
-                     if (!(jya->drawFlags & 4) && jya->timer > 0 && jya->timer < 9) {
-                         jya->timer = 9;
-                     }
-                 });
-
-    // Skip Spirit Sun on Floor & Sun on Block activation delay
-    COND_ID_HOOK(OnActorUpdate, ACTOR_OBJ_LIGHTSWITCH,
-                 CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions"), IS_RANDO), [](void* actor) {
-                     if (gPlayState->sceneNum == SCENE_SPIRIT_TEMPLE &&
-                         (gPlayState->roomCtx.curRoom.num == 4 || gPlayState->roomCtx.curRoom.num == 8)) {
-                         auto sun = static_cast<ObjLightswitch*>(actor);
-                         sun->toggleDelay = 0;
-                     }
-                 });
-}
-
-static RegisterShipInitFunc initFunc(RegisterSkipTimerDelay,
-                                     { CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions"), "IS_RANDO" });
+static RegisterShipInitFunc initFunc_RegisterHooks(TimeSaverRegisterHooks);

--- a/soh/soh/Enhancements/timesaver_hook_handlers.h
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.h
@@ -1,9 +1,0 @@
-#ifndef TIMESAVER_HOOK_HANDLERS_H
-#define TIMESAVER_HOOK_HANDLERS_H
-
-#include "soh/Enhancements/randomizer/randomizerTypes.h"
-
-void TimeSaverRegisterHooks();
-void TimeSaverQueueItem(RandomizerGet randoGet);
-
-#endif // TIMESAVER_HOOK_HANDLERS_H

--- a/soh/soh/Enhancements/tts/tts.cpp
+++ b/soh/soh/Enhancements/tts/tts.cpp
@@ -9,6 +9,7 @@
 #include <spdlog/fmt/fmt.h>
 
 #include "soh/OTRGlobals.h"
+#include "soh/ShipInit.hpp"
 #include "message_data_static.h"
 #include "overlays/gamestates/ovl_file_choose/file_choose.h"
 #include "soh/Enhancements/boss-rush/BossRush.h"
@@ -1199,7 +1200,7 @@ void RegisterOnSetDoAction() {
     });
 }
 
-void RegisterTTSModHooks() {
+static void RegisterTTSModHooks() {
     RegisterOnSetGameLanguageHook();
     RegisterOnDialogMessageHook();
     RegisterOnSceneInitHook();
@@ -1210,7 +1211,9 @@ void RegisterTTSModHooks() {
     RegisterOnSetDoAction();
 }
 
-void RegisterTTS() {
+static void RegisterTTS() {
     InitTTSBank();
     RegisterTTSModHooks();
 }
+
+static RegisterShipInitFunc initFunc(RegisterTTS);

--- a/soh/soh/Enhancements/tts/tts.h
+++ b/soh/soh/Enhancements/tts/tts.h
@@ -1,6 +1,0 @@
-#ifndef TTS_H
-#define TTS_H
-
-void RegisterTTS();
-
-#endif


### PR DESCRIPTION
As a consequence, I've deleted three of four header files associated with the "Big Four". I also moved timer delay skipping to its own hook file.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4667662693.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4667670488.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4667716491.zip)
<!--- section:artifacts:end -->