### PR TITLE
Disable Screen Flash for Finishing Blow option

### DIFF
--- a/soh/soh/Enhancements/cosmetics/A11yNoScreenFlashForFinishingBlow.cpp
+++ b/soh/soh/Enhancements/cosmetics/A11yNoScreenFlashForFinishingBlow.cpp
@@ -1,0 +1,25 @@
+#include <libultraship/bridge.h>
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+
+extern "C" {
+#include "functions.h"
+#include "macros.h"
+
+extern PlayState* gPlayState;
+}
+
+static constexpr int32_t CVAR_A11YNOSCREENFLASHFORFINISHINGBLOW_DEFAULT = 0;
+#define CVAR_A11YNOSCREENFLASHFORFINISHINGBLOW_NAME CVAR_SETTING("A11yNoScreenFlashForFinishingBlow")
+#define CVAR_A11YNOSCREENFLASHFORFINISHINGBLOW_VALUE \
+    CVarGetInteger(CVAR_A11YNOSCREENFLASHFORFINISHINGBLOW_NAME, CVAR_A11YNOSCREENFLASHFORFINISHINGBLOW_DEFAULT)
+
+static void RegisterA11yNoScreenFlashForFinishingBlow() {
+    COND_VB_SHOULD(VB_FLASH_SCREEN_FOR_FINISHING_BLOW, CVAR_A11YNOSCREENFLASHFORFINISHINGBLOW_VALUE, {
+        *should = false;
+        gPlayState->envCtx.fillScreen = false; // Force screen fill disabled
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterA11yNoScreenFlashForFinishingBlow,
+                                     { CVAR_A11YNOSCREENFLASHFORFINISHINGBLOW_NAME });

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -540,6 +540,14 @@ typedef enum {
     // true
     // ```
     // #### `args`
+    // - None
+    VB_FLASH_SCREEN_FOR_FINISHING_BLOW,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
     // - `*BgHeavyBlock`
     VB_FREEZE_LINK_FOR_BLOCK_THROW,
 

--- a/soh/soh/SohGui/SohMenuSettings.cpp
+++ b/soh/soh/SohGui/SohMenuSettings.cpp
@@ -231,6 +231,10 @@ void SohMenu::AddMenuSettings() {
         .CVar(CVAR_SETTING("A11yDisableIdleCam"))
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip("Disables the automatic re-centering of the camera when idle."));
+    AddWidget(path, "Disable Screen Flash for Finishing Blow", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_SETTING("A11yNoScreenFlashForFinishingBlow"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Disables the white screen flash on enemy kill."));
     AddWidget(path, "EXPERIMENTAL", WIDGET_SEPARATOR_TEXT).Options(TextOptions().Color(Colors::Orange));
     AddWidget(path, "ImGui Menu Scaling", WIDGET_CVAR_COMBOBOX)
         .CVar(CVAR_SETTING("ImGuiScale"))

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -1180,15 +1180,17 @@ void Play_Update(PlayState* play) {
                 }
 
                 if (play->actorCtx.freezeFlashTimer && (play->actorCtx.freezeFlashTimer-- < 5)) {
-                    osSyncPrintf("FINISH=%d\n", play->actorCtx.freezeFlashTimer);
+                    if (GameInteractor_Should(VB_FLASH_SCREEN_FOR_FINISHING_BLOW, true)) {
+                        osSyncPrintf("FINISH=%d\n", play->actorCtx.freezeFlashTimer);
 
-                    if ((play->actorCtx.freezeFlashTimer > 0) && ((play->actorCtx.freezeFlashTimer % 2) != 0)) {
-                        play->envCtx.fillScreen = true;
-                        play->envCtx.screenFillColor[0] = play->envCtx.screenFillColor[1] =
-                            play->envCtx.screenFillColor[2] = 150;
-                        play->envCtx.screenFillColor[3] = 80;
-                    } else {
-                        play->envCtx.fillScreen = false;
+                        if ((play->actorCtx.freezeFlashTimer > 0) && ((play->actorCtx.freezeFlashTimer % 2) != 0)) {
+                            play->envCtx.fillScreen = true;
+                            play->envCtx.screenFillColor[0] = play->envCtx.screenFillColor[1] =
+                                play->envCtx.screenFillColor[2] = 150;
+                            play->envCtx.screenFillColor[3] = 80;
+                        } else {
+                            play->envCtx.fillScreen = false;
+                        }
                     }
                 } else {
                     PLAY_LOG(3606);


### PR DESCRIPTION
This Pull Request adds "Disable Screen Flash for Finishing Blow" option to Accessibility settings (reduces epilepsy concern). Enabling this checkbox will disable the white screen flash on enemy kill. This is purely cosmetic and the gameplay is still paused for 4 frames when killing an enemy.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4686698995.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4686748510.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4686809825.zip)
<!--- section:artifacts:end -->