### PR TITLE
Improvements to Custom Kaleido Menu

### DIFF
--- a/soh/soh/Enhancements/kaleido.cpp
+++ b/soh/soh/Enhancements/kaleido.cpp
@@ -1,5 +1,6 @@
 #include "kaleido.h"
 
+#include "objects/gameplay_keep/gameplay_keep.h"
 #include "soh/frame_interpolation.h"
 #include "soh/ShipUtils.h"
 
@@ -55,6 +56,10 @@ void KaleidoEntry::SetYOffset(int yOffset) {
     mY = yOffset;
 }
 
+void KaleidoEntry::SetSelected(bool val) {
+    mSelected = val;
+}
+
 void KaleidoEntryIcon::Draw(PlayState* play, std::vector<Gfx>* mEntryDl) {
     if (vtx == nullptr) {
         return;
@@ -73,14 +78,25 @@ void KaleidoEntryIcon::Draw(PlayState* play, std::vector<Gfx>* mEntryDl) {
 
     mEntryDl->push_back(gsSPMatrix(Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
                                    G_MTX_PUSH | G_MTX_LOAD | G_MTX_MODELVIEW));
-
+    
+    // cursor (if selected)
+    if (mSelected) {
+        mEntryDl->push_back(gsDPSetPrimColor(0, 0, 255, 255, 255, 255));
+        mEntryDl->push_back(gsSPVertex(vtx, 4, 0));
+        Gfx cursorIconTex[] = { gsDPLoadTextureBlock(gArrowCursorTex, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 24, 0,
+                                G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                                G_TX_NOLOD) };
+        mEntryDl->insert(mEntryDl->end(), std::begin(cursorIconTex), std::end(cursorIconTex));
+        mEntryDl->push_back(gsSP1Quadrangle(0, 2, 3, 1, 0));
+    }
+    
     // icon
     if (!mAchieved) {
         mEntryDl->push_back(gsDPSetGrayscaleColor(109, 109, 109, 255));
         mEntryDl->push_back(gsSPGrayscale(true));
     }
     mEntryDl->push_back(gsDPSetPrimColor(0, 0, mIconColor.r, mIconColor.g, mIconColor.b, mIconColor.a));
-    mEntryDl->push_back(gsSPVertex(vtx, 4, 0));
+    mEntryDl->push_back(gsSPVertex(&vtx[4], 4, 0));
     LoadIconTex(mEntryDl);
     mEntryDl->push_back(gsSP1Quadrangle(0, 2, 3, 1, 0));
     mEntryDl->push_back(gsSPGrayscale(false));
@@ -90,10 +106,10 @@ void KaleidoEntryIcon::Draw(PlayState* play, std::vector<Gfx>* mEntryDl) {
     for (size_t i = 0, vtxGroup = 0; i < numChar; i++) {
         // A maximum of 64 Vtx can be loaded at once by gSPVertex, or basically 16 characters
         // handle loading groups of 16 chars at a time until there are no more left to load.
-        // By this point 4 vertices have already been loaded for the preceding icon.
+        // By this point 8 vertices have already been loaded for the preceding icon and cursor.
         if (i % 16 == 0) {
             size_t numVtxToLoad = std::min<size_t>(numChar - i, 16) * 4;
-            mEntryDl->push_back(gsSPVertex(&vtx[4 + (vtxGroup * 16 * 4)], numVtxToLoad, 0));
+            mEntryDl->push_back(gsSPVertex(&vtx[8 + (vtxGroup * 16 * 4)], numVtxToLoad, 0));
             vtxGroup++;
         }
 
@@ -162,6 +178,7 @@ void Kaleido::Draw(PlayState* play) {
     mEntryDl.clear();
     OPEN_DISPS(play->state.gfxCtx);
     mEntryDl.push_back(gsDPPipeSync());
+    Gfx_SetupDL_39Opa(play->state.gfxCtx);
     Gfx_SetupDL_42Opa(play->state.gfxCtx);
     mEntryDl.push_back(gsDPSetCombineMode(G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM));
 
@@ -179,13 +196,23 @@ void Kaleido::Draw(PlayState* play) {
         if (!((pauseCtx->state != 6) || ((pauseCtx->stickRelX == 0) && (pauseCtx->stickRelY == 0)))) {
             if (pauseCtx->cursorSpecialPos == 0) {
                 if ((pauseCtx->stickRelY > 30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DUP))) {
-                    if (mTopIndex > 0) {
-                        mTopIndex--;
+                    if (mCursorPos > 0) {
+                        mCursorPos--;
+                        Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
+                                   &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+                    }
+                    if (mCursorPos < mTopIndex) {
+                        mTopIndex = mCursorPos;
                         shouldScroll = true;
                     }
                 } else if ((pauseCtx->stickRelY < -30) || (dpad && CHECK_BTN_ALL(input->press.button, BTN_DDOWN))) {
-                    if (mTopIndex + mNumVisible < mEntries.size()) {
-                        mTopIndex++;
+                    if (mCursorPos < mEntries.size() - 1) {
+                        mCursorPos++;
+                        Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
+                                   &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+                    }
+                    if (mCursorPos >= mTopIndex + mNumVisible && mTopIndex + mNumVisible < mEntries.size()) {
+                        mTopIndex = mCursorPos - mNumVisible + 1;
                         shouldScroll = true;
                     }
                 }
@@ -219,10 +246,9 @@ void Kaleido::Draw(PlayState* play) {
         if (shouldScroll) {
             entry->SetYOffset(yOffset);
             yOffset += 18;
-            Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
-                                   &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
         }
         Matrix_Push();
+        entry->SetSelected((i == mCursorPos) && !(pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_RIGHT || pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT));
         entry->Draw(play, &mEntryDl);
         Matrix_Pop();
     }
@@ -287,24 +313,31 @@ void KaleidoEntryIconCountRequired::BuildText() {
 void KaleidoEntryIcon::BuildVertices() {
     int offsetY = 0;
     int offsetX = 0;
-    // 4 vertices per character, plus one for the preceding icon.
-    Vtx* vertices = (Vtx*)calloc(sizeof(Vtx[4]), mText.length() + 1);
+    // 4 vertices per character, plus one for the preceding icon, plus one for the cursor.
+    Vtx* vertices = (Vtx*)calloc(sizeof(Vtx[4]), mText.length() + 2);
+    // Vertex for the cursor.
+    Ship_CreateQuadVertexGroup(vertices, offsetX, offsetY, 16, 24, 0);
+    offsetX += 18;
     // Vertex for the preceding icon.
-    Ship_CreateQuadVertexGroup(vertices, offsetX, offsetY, mIconWidth, mIconHeight, 0);
+    Ship_CreateQuadVertexGroup(&vertices[4], offsetX, offsetY, mIconWidth, mIconHeight, 0);
     offsetX += 18;
     for (size_t i = 0; i < mText.length(); i++) {
         int charWidth = static_cast<int>(Ship_GetCharFontWidth(mText[i]));
-        Ship_CreateQuadVertexGroup(&(vertices)[(i + 1) * 4], offsetX, offsetY, charWidth, 16, 0);
+        Ship_CreateQuadVertexGroup(&(vertices)[((i + 1) * 4) + 4], offsetX, offsetY, charWidth, 16, 0);
         offsetX += charWidth;
     }
     offsetY += FONT_CHAR_TEX_HEIGHT;
     mWidth = static_cast<int16_t>(offsetX);
     mHeight = static_cast<int16_t>(offsetY);
 
-    vertices[1].v.ob[0] = 16;
-    vertices[2].v.ob[1] = 16;
-    vertices[3].v.ob[0] = 16;
-    vertices[3].v.ob[1] = 16;
+    vertices[1].v.ob[0] = 15; //top-right x
+    vertices[2].v.ob[1] = 15; //bottom-left y
+    vertices[3].v.ob[0] = 15; //bottom-right x
+    vertices[3].v.ob[1] = 15; //bottom-right y
+    vertices[5].v.ob[0] = 32; //top-right x
+    vertices[6].v.ob[1] = 16; //bottom-left-y
+    vertices[7].v.ob[0] = 32; //bottom-right x
+    vertices[7].v.ob[1] = 16; //bottom-right y
     vtx = vertices;
 }
 

--- a/soh/soh/Enhancements/kaleido.cpp
+++ b/soh/soh/Enhancements/kaleido.cpp
@@ -149,6 +149,13 @@ Kaleido::Kaleido() {
             ctx->GetOption(RSK_TRIFORCE_HUNT_PIECES_TOTAL).Get() + 1));
         yOffset += 18;
     }
+    if (ctx->GetOption(RSK_SKELETON_KEY)) {
+        mEntries.push_back(std::make_shared<KaleidoEntryIconFlag>(
+            gSmallKeyCounterIconTex, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 16, Color_RGBA8{255,255,255,255},
+            FlagType::FLAG_RANDOMIZER_INF, static_cast<int>(RAND_INF_HAS_SKELETON_KEY), 0, yOffset, "Skeleton Key"
+        ));
+        yOffset += 18;
+    }
     if (ctx->GetOption(RSK_SHUFFLE_OCARINA_BUTTONS)) {
         mEntries.push_back(std::make_shared<KaleidoEntryOcarinaButtons>(0, yOffset));
         yOffset += 18;

--- a/soh/soh/Enhancements/kaleido.cpp
+++ b/soh/soh/Enhancements/kaleido.cpp
@@ -80,18 +80,18 @@ void KaleidoEntryIcon::Draw(PlayState* play, std::vector<Gfx>* mEntryDl) {
 
     mEntryDl->push_back(gsSPMatrix(Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
                                    G_MTX_PUSH | G_MTX_LOAD | G_MTX_MODELVIEW));
-    
+
     // cursor (if selected)
     if (mSelected) {
         mEntryDl->push_back(gsDPSetPrimColor(0, 0, 255, 255, 255, 255));
         mEntryDl->push_back(gsSPVertex(vtx, 4, 0));
         Gfx cursorIconTex[] = { gsDPLoadTextureBlock(gArrowCursorTex, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 24, 0,
-                                G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
-                                G_TX_NOLOD) };
+                                                     G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
+                                                     G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD) };
         mEntryDl->insert(mEntryDl->end(), std::begin(cursorIconTex), std::end(cursorIconTex));
         mEntryDl->push_back(gsSP1Quadrangle(0, 2, 3, 1, 0));
     }
-    
+
     // icon
     if (!mAchieved) {
         mEntryDl->push_back(gsDPSetGrayscaleColor(109, 109, 109, 255));
@@ -136,8 +136,7 @@ Kaleido::Kaleido() {
     if (ctx->GetOption(RSK_SHUFFLE_FISHING_POLE)) {
         mEntries.push_back(std::make_shared<KaleidoEntryIconFlag>(
             gItemIconFishingPoleTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, Color_RGBA8{ 255, 255, 255, 255 },
-            FlagType::FLAG_RANDOMIZER_INF, static_cast<int>(RAND_INF_FISHING_POLE_FOUND), "Fishing Pole"
-        ));
+            FlagType::FLAG_RANDOMIZER_INF, static_cast<int>(RAND_INF_FISHING_POLE_FOUND), "Fishing Pole"));
     }
     if (ctx->GetOption(RSK_TRIFORCE_HUNT)) {
         mEntries.push_back(std::make_shared<KaleidoEntryIconCountRequired>(
@@ -148,9 +147,8 @@ Kaleido::Kaleido() {
     }
     if (ctx->GetOption(RSK_SKELETON_KEY)) {
         mEntries.push_back(std::make_shared<KaleidoEntryIconFlag>(
-            gSmallKeyCounterIconTex, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 16, Color_RGBA8{255,255,255,255},
-            FlagType::FLAG_RANDOMIZER_INF, static_cast<int>(RAND_INF_HAS_SKELETON_KEY), "Skeleton Key"
-        ));
+            gSmallKeyCounterIconTex, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 16, Color_RGBA8{ 255, 255, 255, 255 },
+            FlagType::FLAG_RANDOMIZER_INF, static_cast<int>(RAND_INF_HAS_SKELETON_KEY), "Skeleton Key"));
     }
     if (ctx->GetOption(RSK_SHUFFLE_OCARINA_BUTTONS)) {
         mEntries.push_back(std::make_shared<KaleidoEntryOcarinaButtons>());
@@ -175,9 +173,9 @@ Kaleido::Kaleido() {
         int rg = RG_GUARD_HOUSE_KEY;
         for (int i = RAND_INF_GUARD_HOUSE_KEY_OBTAINED; i <= RAND_INF_FISHING_HOLE_KEY_OBTAINED; i += 2, rg++) {
             mEntries.push_back(std::make_shared<KaleidoEntryIconFlag>(
-                gSmallKeyCounterIconTex, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 16, Color_RGBA8{255, 255, 255, 255},
-                FlagType::FLAG_RANDOMIZER_INF, i, Rando::StaticData::RetrieveItem(static_cast<RandomizerGet>(rg)).GetName().english));
-        
+                gSmallKeyCounterIconTex, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 16, Color_RGBA8{ 255, 255, 255, 255 },
+                FlagType::FLAG_RANDOMIZER_INF, i,
+                Rando::StaticData::RetrieveItem(static_cast<RandomizerGet>(rg)).GetName().english));
         }
     }
 }
@@ -217,7 +215,7 @@ void Kaleido::Draw(PlayState* play) {
                     if (mCursorPos > 0) {
                         mCursorPos--;
                         Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
-                                   &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+                                               &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                     }
                     if (mCursorPos < mTopIndex) {
                         mTopIndex = mCursorPos;
@@ -227,7 +225,7 @@ void Kaleido::Draw(PlayState* play) {
                     if (mCursorPos < mEntries.size() - 1) {
                         mCursorPos++;
                         Audio_PlaySoundGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
-                                   &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+                                               &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                     }
                     if (mCursorPos >= mTopIndex + mNumVisible && mTopIndex + mNumVisible < mEntries.size()) {
                         mTopIndex = mCursorPos - mNumVisible + 1;
@@ -264,7 +262,8 @@ void Kaleido::Draw(PlayState* play) {
         entry->SetYOffset(yOffset);
         yOffset += 9;
         Matrix_Push();
-        entry->SetSelected((i == mCursorPos) && !(pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_RIGHT || pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT));
+        entry->SetSelected((i == mCursorPos) && !(pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_RIGHT ||
+                                                  pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT));
         entry->Draw(play, &mEntryDl);
         Matrix_Pop();
     }
@@ -295,8 +294,8 @@ extern "C" void RandoKaleido_UpdateMiscCollectibles(int16_t inDungeonScene) {
 KaleidoEntryIconFlag::KaleidoEntryIconFlag(const char* iconResourceName, int iconFormat, int iconSize, int iconWidth,
                                            int iconHeight, Color_RGBA8 iconColor, FlagType flagType, int flag,
                                            std::string name)
-    : mFlagType(flagType), mFlag(flag), KaleidoEntryIcon(iconResourceName, iconFormat, iconSize, iconWidth, iconHeight,
-                                                         iconColor, std::move(name)) {
+    : mFlagType(flagType), mFlag(flag),
+      KaleidoEntryIcon(iconResourceName, iconFormat, iconSize, iconWidth, iconHeight, iconColor, std::move(name)) {
     BuildVertices();
 }
 
@@ -346,25 +345,25 @@ void KaleidoEntryIcon::BuildVertices() {
     // mWidth = static_cast<int16_t>(offsetX);
     // mHeight = static_cast<int16_t>(offsetY);
 
-    vertices[1].v.ob[0] = 15; //top-right x
-    vertices[2].v.ob[1] = 15; //bottom-left y
-    vertices[3].v.ob[0] = 15; //bottom-right x
-    vertices[3].v.ob[1] = 15; //bottom-right y
-    vertices[5].v.ob[0] = 32; //top-right x
-    vertices[6].v.ob[1] = 16; //bottom-left-y
-    vertices[7].v.ob[0] = 32; //bottom-right x
-    vertices[7].v.ob[1] = 16; //bottom-right y
+    vertices[1].v.ob[0] = 15; // top-right x
+    vertices[2].v.ob[1] = 15; // bottom-left y
+    vertices[3].v.ob[0] = 15; // bottom-right x
+    vertices[3].v.ob[1] = 15; // bottom-right y
+    vertices[5].v.ob[0] = 32; // top-right x
+    vertices[6].v.ob[1] = 16; // bottom-left-y
+    vertices[7].v.ob[0] = 32; // bottom-right x
+    vertices[7].v.ob[1] = 16; // bottom-right y
 
     for (size_t i = 0; i < mText.length() + 2; i++) {
-        size_t j = i*4;
+        size_t j = i * 4;
         vertices[j].v.ob[0] = vertices[j].v.ob[0] / 2;
         vertices[j].v.ob[1] = vertices[j].v.ob[1] / 2;
-        vertices[j+1].v.ob[0] = vertices[j+1].v.ob[0] / 2;
-        vertices[j+1].v.ob[1] = vertices[j+1].v.ob[1] / 2;
-        vertices[j+2].v.ob[0] = vertices[j+2].v.ob[0] / 2;
-        vertices[j+2].v.ob[1] = vertices[j+2].v.ob[1] / 2;
-        vertices[j+3].v.ob[0] = vertices[j+3].v.ob[0] / 2;
-        vertices[j+3].v.ob[1] = vertices[j+3].v.ob[1] / 2;
+        vertices[j + 1].v.ob[0] = vertices[j + 1].v.ob[0] / 2;
+        vertices[j + 1].v.ob[1] = vertices[j + 1].v.ob[1] / 2;
+        vertices[j + 2].v.ob[0] = vertices[j + 2].v.ob[0] / 2;
+        vertices[j + 2].v.ob[1] = vertices[j + 2].v.ob[1] / 2;
+        vertices[j + 3].v.ob[0] = vertices[j + 3].v.ob[0] / 2;
+        vertices[j + 3].v.ob[1] = vertices[j + 3].v.ob[1] / 2;
     }
 
     mWidth = static_cast<int16_t>(offsetX / 2);
@@ -475,8 +474,8 @@ void KaleidoEntryOcarinaButtons::Draw(PlayState* play, std::vector<Gfx>* mEntryD
         mEntryDl->push_back(gsDPSetPrimColor(0, 0, 255, 255, 255, 255));
         mEntryDl->push_back(gsSPVertex(vtx, 4, 0));
         Gfx cursorIconTex[] = { gsDPLoadTextureBlock(gArrowCursorTex, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 24, 0,
-                                G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
-                                G_TX_NOLOD) };
+                                                     G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
+                                                     G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD) };
         mEntryDl->insert(mEntryDl->end(), std::begin(cursorIconTex), std::end(cursorIconTex));
         mEntryDl->push_back(gsSP1Quadrangle(0, 2, 3, 1, 0));
     }

--- a/soh/soh/Enhancements/kaleido.cpp
+++ b/soh/soh/Enhancements/kaleido.cpp
@@ -47,7 +47,7 @@ void KaleidoEntryIcon::LoadIconTex(std::vector<Gfx>* mEntryDl) {
     }
 }
 
-KaleidoEntry::KaleidoEntry(int16_t x, int16_t y, std::string text) : mX(x), mY(y), mText(std::move(text)) {
+KaleidoEntry::KaleidoEntry(std::string text) : mText(std::move(text)) {
     mHeight = 0;
     mWidth = 0;
     vtx = nullptr;
@@ -129,36 +129,31 @@ void KaleidoEntryIcon::Draw(PlayState* play, std::vector<Gfx>* mEntryDl) {
 
 Kaleido::Kaleido() {
     const auto ctx = Rando::Context::GetInstance();
-    int yOffset = 2;
+    int yOffset = 0;
     mEntries.push_back(std::make_shared<KaleidoEntryIconFlag>(
         gRupeeCounterIconTex, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 16, Color_RGBA8{ 0xC8, 0xFF, 0x64, 255 },
-        FlagType::FLAG_RANDOMIZER_INF, static_cast<int>(RAND_INF_GREG_FOUND), 0, yOffset, "Greg"));
-    yOffset += 18;
+        FlagType::FLAG_RANDOMIZER_INF, static_cast<int>(RAND_INF_GREG_FOUND), "Greg"));
     if (ctx->GetOption(RSK_SHUFFLE_FISHING_POLE)) {
         mEntries.push_back(std::make_shared<KaleidoEntryIconFlag>(
             gItemIconFishingPoleTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, Color_RGBA8{ 255, 255, 255, 255 },
-            FlagType::FLAG_RANDOMIZER_INF, static_cast<int>(RAND_INF_FISHING_POLE_FOUND), 0, yOffset, "Fishing Pole"
+            FlagType::FLAG_RANDOMIZER_INF, static_cast<int>(RAND_INF_FISHING_POLE_FOUND), "Fishing Pole"
         ));
-        yOffset += 18;
     }
     if (ctx->GetOption(RSK_TRIFORCE_HUNT)) {
         mEntries.push_back(std::make_shared<KaleidoEntryIconCountRequired>(
-            gTriforcePieceTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, Color_RGBA8{ 255, 255, 255, 255 }, 0, yOffset,
+            gTriforcePieceTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, Color_RGBA8{ 255, 255, 255, 255 },
             reinterpret_cast<int*>(&gSaveContext.ship.quest.data.randomizer.triforcePiecesCollected),
             ctx->GetOption(RSK_TRIFORCE_HUNT_PIECES_REQUIRED).Get() + 1,
             ctx->GetOption(RSK_TRIFORCE_HUNT_PIECES_TOTAL).Get() + 1));
-        yOffset += 18;
     }
     if (ctx->GetOption(RSK_SKELETON_KEY)) {
         mEntries.push_back(std::make_shared<KaleidoEntryIconFlag>(
             gSmallKeyCounterIconTex, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 16, Color_RGBA8{255,255,255,255},
-            FlagType::FLAG_RANDOMIZER_INF, static_cast<int>(RAND_INF_HAS_SKELETON_KEY), 0, yOffset, "Skeleton Key"
+            FlagType::FLAG_RANDOMIZER_INF, static_cast<int>(RAND_INF_HAS_SKELETON_KEY), "Skeleton Key"
         ));
-        yOffset += 18;
     }
     if (ctx->GetOption(RSK_SHUFFLE_OCARINA_BUTTONS)) {
-        mEntries.push_back(std::make_shared<KaleidoEntryOcarinaButtons>(0, yOffset));
-        yOffset += 18;
+        mEntries.push_back(std::make_shared<KaleidoEntryOcarinaButtons>());
     }
     if (ctx->GetOption(RSK_SHUFFLE_BOSS_SOULS).IsNot(RO_BOSS_SOULS_OFF)) {
         static const char* bossSoulNames[] = {
@@ -168,15 +163,22 @@ Kaleido::Kaleido() {
         for (int i = RAND_INF_GOHMA_SOUL; i < RAND_INF_GANON_SOUL; i++) {
             mEntries.push_back(std::make_shared<KaleidoEntryIconFlag>(
                 gBossSoulTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, Color_RGBA8{ 255, 255, 255, 255 },
-                FlagType::FLAG_RANDOMIZER_INF, i, 0, yOffset, bossSoulNames[i - RAND_INF_GOHMA_SOUL]));
-            yOffset += 18;
+                FlagType::FLAG_RANDOMIZER_INF, i, bossSoulNames[i - RAND_INF_GOHMA_SOUL]));
         }
     }
     if (ctx->GetOption(RSK_SHUFFLE_BOSS_SOULS).Is(RO_BOSS_SOULS_ON_PLUS_GANON)) {
         mEntries.push_back(std::make_shared<KaleidoEntryIconFlag>(
             gBossSoulTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, Color_RGBA8{ 255, 255, 255, 255 },
-            FlagType::FLAG_RANDOMIZER_INF, RAND_INF_GANON_SOUL, 0, yOffset, "Ganon's Soul"));
-        yOffset += 18;
+            FlagType::FLAG_RANDOMIZER_INF, RAND_INF_GANON_SOUL, "Ganon's Soul"));
+    }
+    if (ctx->GetOption(RSK_LOCK_OVERWORLD_DOORS)) {
+        int rg = RG_GUARD_HOUSE_KEY;
+        for (int i = RAND_INF_GUARD_HOUSE_KEY_OBTAINED; i <= RAND_INF_FISHING_HOLE_KEY_OBTAINED; i += 2, rg++) {
+            mEntries.push_back(std::make_shared<KaleidoEntryIconFlag>(
+                gSmallKeyCounterIconTex, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 16, Color_RGBA8{255, 255, 255, 255},
+                FlagType::FLAG_RANDOMIZER_INF, i, Rando::StaticData::RetrieveItem(static_cast<RandomizerGet>(rg)).GetName().english));
+        
+        }
     }
 }
 
@@ -256,13 +258,11 @@ void Kaleido::Draw(PlayState* play) {
             pauseCtx->cursorSpecialPos = 0;
         }
     }
-    int yOffset = 2;
+    int yOffset = 1;
     for (int i = mTopIndex; i < (mTopIndex + mNumVisible) && i < mEntries.size(); i++) {
         auto& entry = mEntries[i];
-        if (shouldScroll) {
-            entry->SetYOffset(yOffset);
-            yOffset += 18;
-        }
+        entry->SetYOffset(yOffset);
+        yOffset += 9;
         Matrix_Push();
         entry->SetSelected((i == mCursorPos) && !(pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_RIGHT || pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT));
         entry->Draw(play, &mEntryDl);
@@ -294,9 +294,9 @@ extern "C" void RandoKaleido_UpdateMiscCollectibles(int16_t inDungeonScene) {
 
 KaleidoEntryIconFlag::KaleidoEntryIconFlag(const char* iconResourceName, int iconFormat, int iconSize, int iconWidth,
                                            int iconHeight, Color_RGBA8 iconColor, FlagType flagType, int flag,
-                                           int16_t x, int16_t y, std::string name)
+                                           std::string name)
     : mFlagType(flagType), mFlag(flag), KaleidoEntryIcon(iconResourceName, iconFormat, iconSize, iconWidth, iconHeight,
-                                                         iconColor, x, y, std::move(name)) {
+                                                         iconColor, std::move(name)) {
     BuildVertices();
 }
 
@@ -306,9 +306,9 @@ void KaleidoEntryIconFlag::Update(PlayState* play) {
 
 KaleidoEntryIconCountRequired::KaleidoEntryIconCountRequired(const char* iconResourceName, int iconFormat, int iconSize,
                                                              int iconWidth, int iconHeight, Color_RGBA8 iconColor,
-                                                             int16_t x, int16_t y, int* watch, int required, int total)
+                                                             int* watch, int required, int total)
     : mWatch(watch), mRequired(required), mTotal(total),
-      KaleidoEntryIcon(iconResourceName, iconFormat, iconSize, iconWidth, iconHeight, iconColor, x, y) {
+      KaleidoEntryIcon(iconResourceName, iconFormat, iconSize, iconWidth, iconHeight, iconColor) {
     mCount = *mWatch;
     BuildText();
     BuildVertices();
@@ -343,8 +343,8 @@ void KaleidoEntryIcon::BuildVertices() {
         offsetX += charWidth;
     }
     offsetY += FONT_CHAR_TEX_HEIGHT;
-    mWidth = static_cast<int16_t>(offsetX);
-    mHeight = static_cast<int16_t>(offsetY);
+    // mWidth = static_cast<int16_t>(offsetX);
+    // mHeight = static_cast<int16_t>(offsetY);
 
     vertices[1].v.ob[0] = 15; //top-right x
     vertices[2].v.ob[1] = 15; //bottom-left y
@@ -354,13 +354,29 @@ void KaleidoEntryIcon::BuildVertices() {
     vertices[6].v.ob[1] = 16; //bottom-left-y
     vertices[7].v.ob[0] = 32; //bottom-right x
     vertices[7].v.ob[1] = 16; //bottom-right y
+
+    for (size_t i = 0; i < mText.length() + 2; i++) {
+        size_t j = i*4;
+        vertices[j].v.ob[0] = vertices[j].v.ob[0] / 2;
+        vertices[j].v.ob[1] = vertices[j].v.ob[1] / 2;
+        vertices[j+1].v.ob[0] = vertices[j+1].v.ob[0] / 2;
+        vertices[j+1].v.ob[1] = vertices[j+1].v.ob[1] / 2;
+        vertices[j+2].v.ob[0] = vertices[j+2].v.ob[0] / 2;
+        vertices[j+2].v.ob[1] = vertices[j+2].v.ob[1] / 2;
+        vertices[j+3].v.ob[0] = vertices[j+3].v.ob[0] / 2;
+        vertices[j+3].v.ob[1] = vertices[j+3].v.ob[1] / 2;
+    }
+
+    mWidth = static_cast<int16_t>(offsetX / 2);
+    mHeight = static_cast<int16_t>(8);
+
     vtx = vertices;
 }
 
 KaleidoEntryIcon::KaleidoEntryIcon(const char* iconResourceName, int iconFormat, int iconSize, int iconWidth,
-                                   int iconHeight, Color_RGBA8 iconColor, int16_t x, int16_t y, std::string text)
+                                   int iconHeight, Color_RGBA8 iconColor, std::string text)
     : mIconResourceName(iconResourceName), mIconFormat(iconFormat), mIconSize(iconSize), mIconWidth(iconWidth),
-      mIconHeight(iconHeight), mIconColor(iconColor), KaleidoEntry(x, y, std::move(text)) {
+      mIconHeight(iconHeight), mIconColor(iconColor), KaleidoEntry(std::move(text)) {
 }
 
 void KaleidoEntryIcon::RebuildVertices() {
@@ -378,9 +394,9 @@ void KaleidoEntryIconCountRequired::Update(PlayState* play) {
     }
 }
 
-KaleidoEntryOcarinaButtons::KaleidoEntryOcarinaButtons(int16_t x, int16_t y)
+KaleidoEntryOcarinaButtons::KaleidoEntryOcarinaButtons()
     : KaleidoEntryIcon(gItemIconOcarinaOfTimeTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32,
-                       Color_RGBA8{ 255, 255, 255, 255 }, x, y, "\x9F\xA5\xA6\xA7\xA8") {
+                       Color_RGBA8{ 255, 255, 255, 255 }, "\x9F\xA5\xA6\xA7\xA8") {
     CalculateColors();
     BuildVertices();
 }
@@ -454,13 +470,24 @@ void KaleidoEntryOcarinaButtons::Draw(PlayState* play, std::vector<Gfx>* mEntryD
     mEntryDl->push_back(gsSPMatrix(Matrix_NewMtx(play->state.gfxCtx, (char*)__FILE__, __LINE__),
                                    G_MTX_PUSH | G_MTX_LOAD | G_MTX_MODELVIEW));
 
+    // cursor (if selected)
+    if (mSelected) {
+        mEntryDl->push_back(gsDPSetPrimColor(0, 0, 255, 255, 255, 255));
+        mEntryDl->push_back(gsSPVertex(vtx, 4, 0));
+        Gfx cursorIconTex[] = { gsDPLoadTextureBlock(gArrowCursorTex, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 24, 0,
+                                G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                                G_TX_NOLOD) };
+        mEntryDl->insert(mEntryDl->end(), std::begin(cursorIconTex), std::end(cursorIconTex));
+        mEntryDl->push_back(gsSP1Quadrangle(0, 2, 3, 1, 0));
+    }
+
     // icon
     if (!mAchieved) {
         mEntryDl->push_back(gsDPSetGrayscaleColor(109, 109, 109, 255));
         mEntryDl->push_back(gsSPGrayscale(true));
     }
     mEntryDl->push_back(gsDPSetPrimColor(0, 0, mIconColor.r, mIconColor.g, mIconColor.b, mIconColor.a));
-    mEntryDl->push_back(gsSPVertex(vtx, 4, 0));
+    mEntryDl->push_back(gsSPVertex(&vtx[4], 4, 0));
     LoadIconTex(mEntryDl);
     mEntryDl->push_back(gsSP1Quadrangle(0, 2, 3, 1, 0));
     mEntryDl->push_back(gsSPGrayscale(false));
@@ -475,7 +502,7 @@ void KaleidoEntryOcarinaButtons::Draw(PlayState* play, std::vector<Gfx>* mEntryD
         // By this point 4 vertices have already been loaded for the preceding icon.
         if (i % 16 == 0) {
             size_t numVtxToLoad = std::min<size_t>(numChar - i, 16) * 4;
-            mEntryDl->push_back(gsSPVertex(&vtx[4 + (vtxGroup * 16 * 4)], numVtxToLoad, 0));
+            mEntryDl->push_back(gsSPVertex(&vtx[8 + (vtxGroup * 16 * 4)], numVtxToLoad, 0));
             vtxGroup++;
         }
 

--- a/soh/soh/Enhancements/kaleido.cpp
+++ b/soh/soh/Enhancements/kaleido.cpp
@@ -1,6 +1,7 @@
 #include "kaleido.h"
 
 #include "objects/gameplay_keep/gameplay_keep.h"
+#include "soh/Enhancements/randomizer/randomizerTypes.h"
 #include "soh/frame_interpolation.h"
 #include "soh/ShipUtils.h"
 
@@ -61,6 +62,7 @@ void KaleidoEntry::SetSelected(bool val) {
 }
 
 void KaleidoEntryIcon::Draw(PlayState* play, std::vector<Gfx>* mEntryDl) {
+    PauseContext* pauseCtx = &play->pauseCtx;
     if (vtx == nullptr) {
         return;
     }
@@ -132,6 +134,13 @@ Kaleido::Kaleido() {
         gRupeeCounterIconTex, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 16, Color_RGBA8{ 0xC8, 0xFF, 0x64, 255 },
         FlagType::FLAG_RANDOMIZER_INF, static_cast<int>(RAND_INF_GREG_FOUND), 0, yOffset, "Greg"));
     yOffset += 18;
+    if (ctx->GetOption(RSK_SHUFFLE_FISHING_POLE)) {
+        mEntries.push_back(std::make_shared<KaleidoEntryIconFlag>(
+            gItemIconFishingPoleTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, Color_RGBA8{ 255, 255, 255, 255 },
+            FlagType::FLAG_RANDOMIZER_INF, static_cast<int>(RAND_INF_FISHING_POLE_FOUND), 0, yOffset, "Fishing Pole"
+        ));
+        yOffset += 18;
+    }
     if (ctx->GetOption(RSK_TRIFORCE_HUNT)) {
         mEntries.push_back(std::make_shared<KaleidoEntryIconCountRequired>(
             gTriforcePieceTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, Color_RGBA8{ 255, 255, 255, 255 }, 0, yOffset,

--- a/soh/soh/Enhancements/kaleido.h
+++ b/soh/soh/Enhancements/kaleido.h
@@ -30,6 +30,7 @@ class KaleidoEntry {
     virtual void Draw(PlayState* play, std::vector<Gfx>* mEntryDl) = 0;
     virtual void Update(PlayState* play) = 0;
     void SetYOffset(int yOffset);
+    void SetSelected(bool val);
 
   protected:
     int16_t mX;
@@ -38,6 +39,7 @@ class KaleidoEntry {
     int16_t mWidth;
     Vtx* vtx;
     std::string mText;
+    bool mSelected = false;
     bool mAchieved = false;
 };
 
@@ -164,6 +166,7 @@ class Kaleido {
     std::vector<std::shared_ptr<KaleidoEntry>> mEntries;
     std::vector<Gfx> mEntryDl;
     int mTopIndex = 0;
+    int mCursorPos = 0;
     int mNumVisible = 7;
 };
 } // namespace Rando

--- a/soh/soh/Enhancements/kaleido.h
+++ b/soh/soh/Enhancements/kaleido.h
@@ -129,8 +129,7 @@ class KaleidoEntryIconCountRequired : public KaleidoEntryIcon {
      * @param total The amount of this collectible available in the seed. Set to 0 to not render.
      */
     KaleidoEntryIconCountRequired(const char* iconResourceName, int iconFormat, int iconSize, int iconWidth,
-                                  int iconHeight, Color_RGBA8 iconColor, int* watch,
-                                  int required = 0, int total = 0);
+                                  int iconHeight, Color_RGBA8 iconColor, int* watch, int required = 0, int total = 0);
     void Update(PlayState* play) override;
 
   private:

--- a/soh/soh/Enhancements/kaleido.h
+++ b/soh/soh/Enhancements/kaleido.h
@@ -26,15 +26,15 @@ class KaleidoEntry {
      * @param text the initial value of the line of text. Can be omitted for an
      * empty string.
      */
-    KaleidoEntry(int16_t x, int16_t y, std::string text = "");
+    KaleidoEntry(std::string text = "");
     virtual void Draw(PlayState* play, std::vector<Gfx>* mEntryDl) = 0;
     virtual void Update(PlayState* play) = 0;
     void SetYOffset(int yOffset);
     void SetSelected(bool val);
 
   protected:
-    int16_t mX;
-    int16_t mY;
+    int16_t mX = 0;
+    int16_t mY = 0;
     int16_t mHeight;
     int16_t mWidth;
     Vtx* vtx;
@@ -61,7 +61,7 @@ class KaleidoEntryIcon : public KaleidoEntry {
      * @param text text to draw to the right of the icon.
      */
     KaleidoEntryIcon(const char* iconResourceName, int iconFormat, int iconSize, int iconWidth, int iconHeight,
-                     Color_RGBA8 iconColor, int16_t x, int16_t y, std::string text = "");
+                     Color_RGBA8 iconColor, std::string text = "");
     void Draw(PlayState* play, std::vector<Gfx>* mEntryDl) override;
     void RebuildVertices();
 
@@ -97,8 +97,7 @@ class KaleidoEntryIconFlag : public KaleidoEntryIcon {
      * @param mName name to draw to the right of the icon. Leave blank to omit.
      */
     KaleidoEntryIconFlag(const char* iconResourceName, int iconFormat, int iconSize, int iconWidth, int iconHeight,
-                         Color_RGBA8 iconColor, FlagType flagType, int flag, int16_t x, int16_t y,
-                         std::string name = "");
+                         Color_RGBA8 iconColor, FlagType flagType, int flag, std::string name = "");
     void Update(PlayState* play) override;
 
   private:
@@ -130,7 +129,7 @@ class KaleidoEntryIconCountRequired : public KaleidoEntryIcon {
      * @param total The amount of this collectible available in the seed. Set to 0 to not render.
      */
     KaleidoEntryIconCountRequired(const char* iconResourceName, int iconFormat, int iconSize, int iconWidth,
-                                  int iconHeight, Color_RGBA8 iconColor, int16_t x, int16_t y, int* watch,
+                                  int iconHeight, Color_RGBA8 iconColor, int* watch,
                                   int required = 0, int total = 0);
     void Update(PlayState* play) override;
 
@@ -145,7 +144,7 @@ class KaleidoEntryIconCountRequired : public KaleidoEntryIcon {
 
 class KaleidoEntryOcarinaButtons : public KaleidoEntryIcon {
   public:
-    KaleidoEntryOcarinaButtons(int16_t x, int16_t y);
+    KaleidoEntryOcarinaButtons();
     void Update(PlayState* play) override;
     void Draw(PlayState* play, std::vector<Gfx>* mEntryDl) override;
 
@@ -167,7 +166,7 @@ class Kaleido {
     std::vector<Gfx> mEntryDl;
     int mTopIndex = 0;
     int mCursorPos = 0;
-    int mNumVisible = 7;
+    int mNumVisible = 14;
 };
 } // namespace Rando
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -1634,7 +1634,7 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
 
             if (pauseCtx->randoQuestMode) {
                 POLY_OPA_DISP =
-                    KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->saveVtx, sSaveTexs[gSaveContext.language]);
+                    KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->saveVtx, sGameOverTexs);
                 RandoKaleido_DrawMiscCollectibles(play);
             } else {
                 POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->questPageVtx,
@@ -1730,7 +1730,7 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
 
                 if (pauseCtx->randoQuestMode) {
                     POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->saveVtx,
-                                                                  sSaveTexs[gSaveContext.language]);
+                                                                  sGameOverTexs);
                     RandoKaleido_DrawMiscCollectibles(play);
                 } else {
                     POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->questPageVtx,

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -1633,8 +1633,7 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
             gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
             if (pauseCtx->randoQuestMode) {
-                POLY_OPA_DISP =
-                    KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->saveVtx, sGameOverTexs);
+                POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->saveVtx, sGameOverTexs);
                 RandoKaleido_DrawMiscCollectibles(play);
             } else {
                 POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->questPageVtx,
@@ -1729,8 +1728,7 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
                 gSPMatrix(POLY_OPA_DISP++, MATRIX_NEWMTX(gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
                 if (pauseCtx->randoQuestMode) {
-                    POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->saveVtx,
-                                                                  sGameOverTexs);
+                    POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->saveVtx, sGameOverTexs);
                     RandoKaleido_DrawMiscCollectibles(play);
                 } else {
                     POLY_OPA_DISP = KaleidoScope_DrawPageSections(POLY_OPA_DISP, pauseCtx->questPageVtx,


### PR DESCRIPTION
Improvements are as follows:

1. Adds a cursor for better indication of which one is "selected" and to better indicate that the user can scroll. This also could open the door for interactions in this subscreen down the road, though none currently exist. For instance, I'm interested in trying to make sub-menus for each category of thing that we're tracking instead of one big scrolling list (there's pros and cons there, but that's a discussion for another time).
2. Decreased the size of everything in the menu by half, so more can be seen at once.
3. Added some missing icons to the list, when they are relevant, specifically: Skeleton Key (with a regular key icon for now), Fishing Pole, and Overworld Keys.
4. Streamlined a few things to allow for smaller constructors and less state for people adding new entries to keep track of.
5. Changed to the game over textures for the frame (which are actually the exact same textures except for the save text being replaced by a plain gray block)

<img width="2560" height="1440" alt="20251129_122623" src="https://github.com/user-attachments/assets/25bcc525-98d5-4cfd-b226-f9767d520c41" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4713710248.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4713713425.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4713726459.zip)
<!--- section:artifacts:end -->