### PR TITLE
Check tracker improvements

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1042,16 +1042,17 @@ void CheckTrackerWindow::DrawElement() {
 #else
     float headerHeight = 20.0f;
 #endif
-    ImVec2 size = ImGui::GetContentRegionMax();
-    size.y -= headerHeight;
-    if (!ImGui::BeginTable("Check Tracker", 1, 0, size)) {
+    if (!ImGui::BeginTable("Check Tracker", 1, 0)) {
         EndFloatWindows();
         return;
     }
 
-    ImGui::TableNextRow(0, headerHeight);
+    ImGui::SetWindowFontScale(CVarGetFloat(CVAR_TRACKER_CHECK("FontSize"), 1.0f));
+
+    ImGui::TableNextRow(0, 0);
     ImGui::TableNextColumn();
-    if (UIWidgets::CVarCheckbox(
+    if (CVarGetInteger(CVAR_TRACKER_CHECK("HiddenItemsToggleVisible"), 1) &&
+        UIWidgets::CVarCheckbox(
             "Show Hidden Items", CVAR_TRACKER_CHECK("ShowHidden"),
             UIWidgets::CheckboxOptions(
                 { { .tooltip = "When active, items will show hidden checks by default when updated to this state." } })
@@ -1060,7 +1061,7 @@ void CheckTrackerWindow::DrawElement() {
         showHidden = CVarGetInteger(CVAR_TRACKER_CHECK("ShowHidden"), 0);
         RecalculateAllAreaTotals();
     }
-    if (enableAvailableChecks) {
+    if (enableAvailableChecks && CVarGetInteger(CVAR_TRACKER_CHECK("AvailableChecksToggleVisible"), 1)) {
         if (UIWidgets::CVarCheckbox(
                 "Only Show Available Checks", CVAR_TRACKER_CHECK("OnlyShowAvailable"),
                 UIWidgets::CheckboxOptions({ { .tooltip = "When active, unavailable checks will be hidden." } })
@@ -1069,49 +1070,61 @@ void CheckTrackerWindow::DrawElement() {
             RecalculateAllAreaTotals();
         }
     }
-    UIWidgets::PaddedSeparator();
-    if (UIWidgets::Button("Expand All", UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(UIWidgets::Sizes::Inline))) {
-        optCollapseAll = false;
-        optExpandAll = true;
-        doAreaScroll = true;
-    }
-    ImGui::SameLine();
-    if (UIWidgets::Button("Collapse All",
-                          UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(UIWidgets::Sizes::Inline))) {
-        optExpandAll = false;
-        optCollapseAll = true;
-    }
-    ImGui::SameLine();
-    if (UIWidgets::Button("Clear", UIWidgets::ButtonOptions({ { .tooltip = "Clear the search field" } })
-                                       .Color(THEME_COLOR)
-                                       .Size(UIWidgets::Sizes::Inline))) {
-        checkSearch.Clear();
-        UpdateFilters();
-        doAreaScroll = true;
+    if (CVarGetInteger(CVAR_TRACKER_CHECK("ExpandCollapseButtonsVisible"), 0)) {
+        if (UIWidgets::Button(
+                "Expand All",
+                UIWidgets::ButtonOptions().Color(THEME_COLOR).Size({ ImGui::GetContentRegionAvail().x / 2 - 6, 0 }))) {
+            optCollapseAll = false;
+            optExpandAll = true;
+            doAreaScroll = true;
+        }
+        ImGui::SameLine();
+        if (UIWidgets::Button(
+                "Collapse All",
+                UIWidgets::ButtonOptions().Color(THEME_COLOR).Size({ ImGui::GetContentRegionAvail().x - 6, 0 }))) {
+            optExpandAll = false;
+            optCollapseAll = true;
+        }
     }
     UIWidgets::PushStyleCombobox(THEME_COLOR);
-    if (checkSearch.Draw()) {
-        UpdateFilters();
+    if (CVarGetInteger(CVAR_TRACKER_CHECK("SearchInputVisible"), 1)) {
+        if (checkSearch.Draw("", ImGui::GetContentRegionAvail().x - 6)) {
+            UpdateFilters();
+        }
+        std::string checkSearchText = "";
+        checkSearchText = checkSearch.InputBuf;
+        checkSearchText.erase(std::remove(checkSearchText.begin(), checkSearchText.end(), ' '), checkSearchText.end());
+        if (checkSearchText.length() < 1) {
+            ImGui::SameLine(20.0f);
+            ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, 0.4f), "Search...");
+        }
     }
     UIWidgets::PopStyleCombobox();
 
-    ImGui::Separator();
-
-    std::ostringstream totalChecksSS;
-    totalChecksSS << "Total Checks: ";
-    if (enableAvailableChecks) {
-        totalChecksSS << totalChecksAvailable << " Available / ";
+    if (CVarGetInteger(CVAR_TRACKER_CHECK("CheckTotalsVisible"), 1)) {
+        std::ostringstream totalChecksSS;
+        totalChecksSS << "";
+        if (enableAvailableChecks) {
+            totalChecksSS << totalChecksAvailable << " Available / ";
+        }
+        totalChecksSS << totalChecksGotten << " Checked / " << totalChecks << " Total";
+        ImGui::Text("%s", totalChecksSS.str().c_str());
     }
-    totalChecksSS << totalChecksGotten << " Checked / " << totalChecks << " Total";
-    ImGui::Text("%s", totalChecksSS.str().c_str());
 
-    UIWidgets::PaddedSeparator();
+    bool headerPresent =
+        CVarGetInteger(CVAR_TRACKER_CHECK("HiddenItemsToggleVisible"), 1) ||
+        (enableAvailableChecks && CVarGetInteger(CVAR_TRACKER_CHECK("AvailableChecksToggleVisible"), 1)) ||
+        CVarGetInteger(CVAR_TRACKER_CHECK("ExpandCollapseButtonsVisible"), 0) ||
+        CVarGetInteger(CVAR_TRACKER_CHECK("SearchInputVisible"), 1) ||
+        CVarGetInteger(CVAR_TRACKER_CHECK("CheckTotalsVisible"), 1);
+    if (headerPresent) {
+        ImGui::Separator();
+    }
 
     // Checks Section Lead-in
     ImGui::TableNextRow();
     ImGui::TableNextColumn();
-    size = ImGui::GetContentRegionAvail();
-    if (!ImGui::BeginTable("CheckTracker##Checks", 1, ImGuiTableFlags_ScrollY, size)) {
+    if (!ImGui::BeginTable("CheckTracker##Checks", 1, ImGuiTableFlags_ScrollY)) {
         ImGui::EndTable();
         EndFloatWindows();
         return;
@@ -1181,7 +1194,7 @@ void CheckTrackerWindow::DrawElement() {
             } else {
                 ImGui::SetNextItemOpen(!thisAreaFullyChecked, ImGuiCond_Once);
             }
-            doDraw = ImGui::TreeNode(stemp.c_str());
+            doDraw = ImGui::TreeNodeEx(stemp.c_str(), ImGuiTreeNodeFlags_NoTreePushOnOpen);
             ImGui::PopStyleColor();
             ImGui::SameLine();
             ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(extraColor.r / 255.0f, extraColor.g / 255.0f,
@@ -1229,10 +1242,6 @@ void CheckTrackerWindow::DrawElement() {
                 if (doDraw && isThisAreaSpoiled && !filterChecksHidden[rc]) {
                     DrawLocation(rc);
                 }
-            }
-
-            if (doDraw) {
-                ImGui::TreePop();
             }
         }
     }
@@ -2130,6 +2139,16 @@ void CheckTrackerSettingsWindow::DrawElement() {
 
         SohGui::mSohMenu->MenuDrawItem(windowTypeWidget, ImGui::GetContentRegionAvail().x, THEME_COLOR);
 
+        UIWidgets::CVarSliderFloat("Font Size", CVAR_TRACKER_CHECK("FontSize"),
+                                   UIWidgets::FloatSliderOptions()
+                                       .Tooltip("Sets the font size used in the check tracker.")
+                                       .Format("%.1f")
+                                       .Step(0.1f)
+                                       .Min(0.3f)
+                                       .Max(2.0f)
+                                       .Color(THEME_COLOR)
+                                       .DefaultValue(1.0f));
+
         if (CVarGetInteger(CVAR_TRACKER_CHECK("WindowType"), TRACKER_WINDOW_WINDOW) == TRACKER_WINDOW_FLOATING) {
             UIWidgets::CVarCheckbox("Enable Dragging", CVAR_TRACKER_CHECK("Draggable"),
                                     UIWidgets::CheckboxOptions().Color(THEME_COLOR));
@@ -2172,13 +2191,24 @@ void CheckTrackerSettingsWindow::DrawElement() {
         ImGui::EndDisabled();
 
         // Filtering settings
-        UIWidgets::PaddedSeparator();
         UIWidgets::CVarCheckbox(
             "Filter Empty Areas", CVAR_TRACKER_CHECK("HideFilteredAreas"),
             UIWidgets::CheckboxOptions()
                 .Tooltip("If enabled, will hide area headers that have no locations matching filter")
                 .Color(THEME_COLOR)
                 .DefaultValue(true));
+
+        ImGui::SeparatorText("Tracker Header Visibility");
+        UIWidgets::CVarCheckbox("Hidden Items Toggle", CVAR_TRACKER_CHECK("HiddenItemsToggleVisible"),
+                                UIWidgets::CheckboxOptions().Color(THEME_COLOR).DefaultValue(true));
+        UIWidgets::CVarCheckbox("Available Checks Toggle", CVAR_TRACKER_CHECK("AvailableChecksToggleVisible"),
+                                UIWidgets::CheckboxOptions().Color(THEME_COLOR).DefaultValue(true));
+        UIWidgets::CVarCheckbox("Expand/Collapse Buttons", CVAR_TRACKER_CHECK("ExpandCollapseButtonsVisible"),
+                                UIWidgets::CheckboxOptions().Color(THEME_COLOR).DefaultValue(false));
+        UIWidgets::CVarCheckbox("Search Input", CVAR_TRACKER_CHECK("SearchInputVisible"),
+                                UIWidgets::CheckboxOptions().Color(THEME_COLOR).DefaultValue(true));
+        UIWidgets::CVarCheckbox("Check Totals", CVAR_TRACKER_CHECK("CheckTotalsVisible"),
+                                UIWidgets::CheckboxOptions().Color(THEME_COLOR).DefaultValue(true));
 
         ImGui::TableNextColumn();
 


### PR DESCRIPTION
- Added the ability to toggle the visibility of header items (search, toggles, check counter)
- Added font size slider
- Removed indentation to give the check names a tiny bit more space
- Removed "Clear" button on search (unnecessary space), removed label and added `Search...` placeholder

Before
<img width="447" height="670" alt="Screenshot 2025-11-30 at 12 33 04 PM" src="https://github.com/user-attachments/assets/565ecff8-6d68-4dd0-8ba3-606d8857a080" />

After (with all visible)
<img width="481" height="674" alt="Screenshot 2025-11-30 at 11 38 17 AM" src="https://github.com/user-attachments/assets/75f36f79-eef5-4b20-be91-3ccc6487efe4" />

After (with all hidden)
<img width="481" height="674" alt="Screenshot 2025-11-30 at 11 38 35 AM" src="https://github.com/user-attachments/assets/8014ad3b-db0d-4496-99fe-8147434a572d" />

After (Smaller font size)
<img width="481" height="674" alt="Screenshot 2025-11-30 at 11 44 48 AM" src="https://github.com/user-attachments/assets/62b22cad-aa3c-4d9e-8b55-90a2700ca9d4" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4718039093.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4718057936.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4718142346.zip)
<!--- section:artifacts:end -->