### PR TITLE
Add Expand All/Collapse All buttons to Hook Debugger

### DIFF
--- a/soh/soh/Enhancements/debugger/hookDebugger.cpp
+++ b/soh/soh/Enhancements/debugger/hookDebugger.cpp
@@ -1,4 +1,5 @@
 #include "hookDebugger.h"
+#include "soh/SohGui/SohGui.hpp"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/SohGui/UIWidgets.hpp"
 #include "soh/OTRGlobals.h"
@@ -6,6 +7,9 @@
 #include <version>
 
 static std::map<const char*, std::map<HOOK_ID, HookInfo>*> hookData;
+
+static bool hookOptCollapseAll; // A bool that will collapse all hook group once
+static bool hookOptExpandAll;   // A bool that will expand all hook group once
 
 const ImVec4 grey = ImVec4(0.75, 0.75, 0.75, 1);
 const ImVec4 yellow = ImVec4(1, 1, 0, 1);
@@ -77,6 +81,9 @@ void DrawHookRegisteringInfos(const char* hookName) {
 }
 
 void HookDebuggerWindow::DrawElement() {
+    bool collapseLogic = false;
+    bool doingCollapseOrExpand = hookOptExpandAll || hookOptCollapseAll;
+
     ImGui::BeginDisabled(CVarGetInteger(CVAR_SETTING("DisableChanges"), 0));
 #ifndef __cpp_lib_source_location
     ImGui::TextColored(yellow, "Some features of the Hook Debugger are unavailable because SoH was compiled "
@@ -84,9 +91,29 @@ void HookDebuggerWindow::DrawElement() {
                                "(\"__cpp_lib_source_location\" not defined in \"<version>\").");
 #endif
 
+    if (UIWidgets::Button("Expand All", UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(UIWidgets::Sizes::Inline))) {
+        hookOptCollapseAll = false;
+        hookOptExpandAll = true;
+    }
+    ImGui::SameLine();
+    if (UIWidgets::Button("Collapse All",
+                          UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(UIWidgets::Sizes::Inline))) {
+        hookOptExpandAll = false;
+        hookOptCollapseAll = true;
+    }
+
     ImGui::PushFont(OTRGlobals::Instance->fontMonoLarger);
 
     for (auto& [hookName, _] : hookData) {
+        if (doingCollapseOrExpand) {
+            if (hookOptExpandAll) {
+                collapseLogic = true;
+            } else if (hookOptCollapseAll) {
+                collapseLogic = false;
+            }
+            ImGui::SetNextItemOpen(collapseLogic, ImGuiCond_Always);
+        }
+
         if (ImGui::TreeNode(hookName)) {
             DrawHookRegisteringInfos(hookName);
             ImGui::TreePop();
@@ -95,9 +122,17 @@ void HookDebuggerWindow::DrawElement() {
 
     ImGui::PopFont();
     ImGui::EndDisabled();
+
+    if (doingCollapseOrExpand) {
+        hookOptExpandAll = false;
+        hookOptCollapseAll = false;
+    }
 }
 
 void HookDebuggerWindow::InitElement() {
+    hookOptExpandAll = false;
+    hookOptCollapseAll = false;
+
 #define DEFINE_HOOK(name, _) hookData.insert({ #name, GameInteractor::Instance->GetHookData<GameInteractor::name>() });
 
 #include "../game-interactor/GameInteractor_HookTable.h"

--- a/soh/soh/Enhancements/debugger/hookDebugger.h
+++ b/soh/soh/Enhancements/debugger/hookDebugger.h
@@ -1,3 +1,6 @@
+#ifndef hookDebugger_h
+#define hookDebugger_h
+
 #include <libultraship/libultraship.h>
 
 class HookDebuggerWindow final : public Ship::GuiWindow {
@@ -8,3 +11,5 @@ class HookDebuggerWindow final : public Ship::GuiWindow {
     void DrawElement() override;
     void UpdateElement() override{};
 };
+
+#endif // hookDebugger_h


### PR DESCRIPTION
Because sometimes I want to see all hook names currently loaded in game.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4736986713.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4737054641.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4737060922.zip)
<!--- section:artifacts:end -->