### PR TITLE
Fix miss in previous `hookify cosmetics editor` PR

### DIFF
--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -2573,15 +2573,6 @@ void CosmeticsEditorWindow::DrawElement() {
     UIWidgets::PopStyleTabs();
 }
 
-void RegisterOnLoadGameHook() {
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnLoadGame>(
-        [](int32_t fileNum) { ApplyOrResetCustomGfxPatches(); });
-}
-
-void RegisterOnGameFrameUpdateHook() {
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameFrameUpdate>([]() { CosmeticsUpdateTick(); });
-}
-
 void CosmeticsEditorWindow::InitElement() {
     // Convert the `current color` into the format that the ImGui color picker expects
     for (auto& [id, cosmeticOption] : cosmeticOptions) {
@@ -2652,6 +2643,8 @@ void RegisterCosmeticHooks() {
 
     COND_HOOK(OnGenerationCompletion, CVarGetInteger(CVAR_COSMETIC("RandomizeAllOnRandoGen"), 0),
               []() { CosmeticsEditor_RandomizeAll(); });
+
+    COND_HOOK(OnLoadGame, true, [](int32_t fileNum) { ApplyOrResetCustomGfxPatches(); });
 
     COND_HOOK(OnGameFrameUpdate, true, CosmeticsUpdateTick);
 }


### PR DESCRIPTION
Thanks @Glought for noticing in #5900

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4756839692.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4756869753.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4757127735.zip)
<!--- section:artifacts:end -->