### PR TITLE
Update macOS build instructions

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -239,7 +239,7 @@ cmake --build build-cmake --target ExtractAssetHeaders
 ```
 
 ## macOS
-Requires Xcode (or xcode-tools) && `sdl2, libpng, glew, ninja, cmake, tinyxml2, nlohmann-json, libzip` (can be installed via [homebrew](https://brew.sh/), macports, etc)
+Requires Xcode (or xcode-tools) && `sdl2, libpng, glew, ninja, cmake, tinyxml2, nlohmann-json, libzip, opusfile, libvorbis` (can be installed via [homebrew](https://brew.sh/), macports, etc)
 
 **Important: For maximum performance make sure you have ninja build tools installed!**
 
@@ -254,7 +254,7 @@ cd ShipWright
 git submodule update --init
 
 # Install development dependencies (assuming homebrew)
-brew install sdl2 libpng glew ninja cmake tinyxml2 nlohmann-json libzip
+brew install sdl2 libpng glew ninja cmake tinyxml2 nlohmann-json libzip opusfile libvorbis
 
 # Generate Ninja project
 # Add `-DCMAKE_BUILD_TYPE:STRING=Release` if you're packaging


### PR DESCRIPTION
This pull request updates the `brew install` instructions in BUILDING.md to include two dependencies new to 9.1: **`opusfile`** and **`libvorbis`**.

Note that installing these with Homebrew will also install `libogg` and `opus`.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4820062773.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4820103797.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4820598648.zip)
<!--- section:artifacts:end -->