### PR TITLE
Emote PoC

### DIFF
--- a/soh/soh/Enhancements/cosmetics/Emote.cpp
+++ b/soh/soh/Enhancements/cosmetics/Emote.cpp
@@ -1,50 +1,235 @@
-#include <libultraship/bridge.h>
+#include <libultraship/libultraship.h>
+#include <libultraship/controller/controldeck/ControlDeck.h>
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
+#include "soh/SohGui/MenuTypes.h"
+#include "soh/SohGui/SohMenu.h"
+#include "soh/SohGui/SohGui.hpp"
+#include "soh/SohGui/UIWidgets.hpp"
 
 extern "C" {
 #include "assets/objects/gameplay_keep/gameplay_keep.h"
-
 #include "macros.h"
+#include "libultraship/libultra/controller.h"
 extern PlayState* gPlayState;
-void Player_AnimPlayLoop(PlayState* play, Player* player, LinkAnimationHeader* anim);
+void LinkAnimation_PlayLoopSetSpeed(PlayState* play, SkelAnime* skelAnime, LinkAnimationHeader* animation,
+                                    f32 playSpeed);
+void LinkAnimation_PlayOnceSetSpeed(PlayState* play, SkelAnime* skelAnime, LinkAnimationHeader* animation,
+                                    f32 playSpeed);
 }
 
-std::map<ImGuiKey, std::string> emoteMap = {
-    { ImGuiKey_0, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_0" },
-    { ImGuiKey_1, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_1" },
-    { ImGuiKey_2, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_2" },
-    { ImGuiKey_3, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_3" },
-    { ImGuiKey_4, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_4" },
-    { ImGuiKey_5, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_5" },
-    { ImGuiKey_6, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_6" },
-    { ImGuiKey_7, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_7" },
-    { ImGuiKey_8, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_8" },
-    { ImGuiKey_9, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_9" },
+namespace SohGui {
+extern std::shared_ptr<SohMenu> mSohMenu;
+} // namespace SohGui
+
+struct EmoteSlot {
+    std::string animationPath;
+    bool playOnce;
+    float speed;
+    std::string displayName;
 };
 
-void RegisterEmote() {
-    // Loop over map, check if each animation exists, if not remove it from the map
-    std::vector<ImGuiKey> keysToRemove;
-    for (const auto& [key, animPath] : emoteMap) {
-        auto file = Ship::Context::GetInstance()->GetResourceManager()->LoadResource(animPath);
-        if (file == nullptr) {
-            keysToRemove.push_back(key);
+static EmoteSlot emoteSlots[4] = {
+    { "", false, 1.0f, "C-Up" },
+    { "", false, 1.0f, "C-Right" },
+    { "", false, 1.0f, "C-Down" },
+    { "", false, 1.0f, "C-Left" },
+};
+
+static std::vector<std::string> availableAnimations;
+
+static bool wheelActive = false;
+static EmoteSlot targetSlot;
+static std::string activeAnimation = "";
+
+// CVars for persistence
+#define CVAR_EMOTE(slot, field) ("gEmoteWheel.Slot" + std::to_string(slot) + "." + field).c_str()
+
+void LoadEmoteConfiguration() {
+    for (int i = 0; i < 4; i++) {
+        std::string animPath = CVarGetString(CVAR_EMOTE(i, "Animation"), emoteSlots[i].animationPath.c_str());
+        if (!animPath.empty()) {
+            emoteSlots[i].animationPath = animPath;
         }
+        emoteSlots[i].playOnce = CVarGetInteger(CVAR_EMOTE(i, "PlayOnce"), emoteSlots[i].playOnce ? 1 : 0);
+        emoteSlots[i].speed = CVarGetFloat(CVAR_EMOTE(i, "Speed"), emoteSlots[i].speed);
     }
-    for (auto key : keysToRemove) {
-        emoteMap.erase(key);
+}
+
+void SaveEmoteConfiguration() {
+    for (int i = 0; i < 4; i++) {
+        CVarSetString(CVAR_EMOTE(i, "Animation"), emoteSlots[i].animationPath.c_str());
+        CVarSetInteger(CVAR_EMOTE(i, "PlayOnce"), emoteSlots[i].playOnce ? 1 : 0);
+        CVarSetFloat(CVAR_EMOTE(i, "Speed"), emoteSlots[i].speed);
+    }
+    CVarSave();
+}
+
+void LoadAvailableAnimations() {
+    availableAnimations.clear();
+
+    // Get all available animations
+    auto result =
+        Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->ListFiles("*gPlayerAnim_link*");
+
+    availableAnimations.clear();
+    for (const auto& path : *result.get()) {
+        availableAnimations.push_back("__OTR__" + path);
+    }
+}
+
+std::string GetAnimationDisplayName(const std::string& path) {
+    // Extract a friendly name from the path
+    size_t lastSlash = path.find_last_of('/');
+    std::string name = (lastSlash != std::string::npos) ? path.substr(lastSlash + 1) : path;
+
+    // Remove common prefixes
+    if (name.find("gPlayerAnim_link") == 0) {
+        name = name.substr(17);
     }
 
-    COND_HOOK(OnPlayerUpdate, true, [] {
+    return name;
+}
+
+int GetSelectedSlotFromCButtons(uint16_t buttons) {
+    if (buttons & BTN_CUP) {
+        return 0;
+    } else if (buttons & BTN_CRIGHT) {
+        return 1;
+    } else if (buttons & BTN_CDOWN) {
+        return 2;
+    } else if (buttons & BTN_CLEFT) {
+        return 3;
+    }
+    return -1;
+}
+
+void RegisterEmote() {
+    LoadAvailableAnimations();
+    LoadEmoteConfiguration();
+
+    COND_HOOK(OnPlayerUpdate, CVarGetInteger("gEmoteWheel.Enabled", 0), []() {
         Player* player = GET_PLAYER(gPlayState);
-
-        for (const auto& [key, animPath] : emoteMap) {
-            if (ImGui::IsKeyDown(key)) {
-                Player_AnimPlayLoop(gPlayState, player, (LinkAnimationHeader*)animPath.c_str());
+        if (targetSlot.animationPath != "") {
+            activeAnimation = targetSlot.animationPath;
+            if (targetSlot.playOnce) {
+                LinkAnimation_PlayOnceSetSpeed(gPlayState, &player->skelAnime,
+                                               (LinkAnimationHeader*)activeAnimation.c_str(), targetSlot.speed);
+            } else {
+                LinkAnimation_PlayLoopSetSpeed(gPlayState, &player->skelAnime,
+                                               (LinkAnimationHeader*)activeAnimation.c_str(), targetSlot.speed);
             }
+            targetSlot.animationPath = "";
+        }
+    });
+
+    COND_HOOK(OnGameStateMainStart, CVarGetInteger("gEmoteWheel.Enabled", 0), []() {
+        if (!gPlayState)
+            return;
+
+        Player* player = GET_PLAYER(gPlayState);
+        if (!player)
+            return;
+
+        Input* input = &gPlayState->state.input[0];
+
+        if (input->press.button & BTN_L) {
+            input->press.button &= ~BTN_L; // Capture
+            wheelActive = true;
+        }
+
+        if (!(input->cur.button & BTN_L) && wheelActive) {
+            wheelActive = false;
+        }
+
+        if (wheelActive) {
+            auto slot = GetSelectedSlotFromCButtons(input->cur.button);
+            if (slot >= 0 && slot < 4) {
+                targetSlot = emoteSlots[slot];
+            }
+            input->press.button &= ~BTN_CUP & ~BTN_CRIGHT & ~BTN_CDOWN & ~BTN_CLEFT; // Capture
         }
     });
 }
 
-static RegisterShipInitFunc initFunc(RegisterEmote, {});
+void DrawEmoteConfiguration(WidgetInfo& info) {
+    ImGui::Text("Hold L button and press a C-button to select an emote");
+    UIWidgets::CVarCheckbox("Enabled", "gEmoteWheel.Enabled");
+
+    if (!CVarGetInteger("gEmoteWheel.Enabled", 0)) {
+        return;
+    }
+
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    const char* slotNames[] = { "C-Up", "C-Right", "C-Down", "C-Left" };
+
+    for (int i = 0; i < 4; i++) {
+        ImGui::PushID(i);
+
+        ImGui::Text("%s Slot", slotNames[i]);
+
+        std::string currentAnimName = GetAnimationDisplayName(emoteSlots[i].animationPath);
+        UIWidgets::PushStyleCombobox();
+        if (ImGui::BeginCombo("Animation", currentAnimName.c_str())) {
+            for (const auto& animPath : availableAnimations) {
+                bool isSelected = (emoteSlots[i].animationPath == animPath);
+                std::string displayName = GetAnimationDisplayName(animPath);
+                if (ImGui::Selectable(displayName.c_str(), isSelected)) {
+                    emoteSlots[i].animationPath = animPath;
+                    SaveEmoteConfiguration();
+                }
+                if (isSelected) {
+                    ImGui::SetItemDefaultFocus();
+                }
+            }
+            ImGui::EndCombo();
+        }
+        UIWidgets::PopStyleCombobox();
+
+        // Play once checkbox
+        bool playOnce = emoteSlots[i].playOnce;
+        UIWidgets::PushStyleCheckbox();
+        if (ImGui::Checkbox("Play Once", &playOnce)) {
+            emoteSlots[i].playOnce = playOnce;
+            SaveEmoteConfiguration();
+        }
+        UIWidgets::PopStyleCheckbox();
+
+        // Speed slider
+        float speed = emoteSlots[i].speed;
+        ImGui::SetNextItemWidth(200.0f);
+        UIWidgets::PushStyleSlider();
+        if (ImGui::SliderFloat("Speed", &speed, 0.1f, 3.0f, "%.2f")) {
+            emoteSlots[i].speed = speed;
+            SaveEmoteConfiguration();
+        }
+        UIWidgets::PopStyleSlider();
+
+        ImGui::Spacing();
+        ImGui::Separator();
+        ImGui::Spacing();
+
+        ImGui::PopID();
+    }
+
+    if (UIWidgets::Button("Reset to Defaults", { .size = UIWidgets::Sizes::Inline })) {
+        emoteSlots[0] = { "", false, 1.0f, "Up" };
+        emoteSlots[1] = { "", false, 1.0f, "Right" };
+        emoteSlots[2] = { "", false, 1.0f, "Down" };
+        emoteSlots[3] = { "", false, 1.0f, "Left" };
+        SaveEmoteConfiguration();
+    }
+}
+
+void RegisterEmoteWidgets() {
+    SohGui::mSohMenu->AddSidebarEntry("Settings", "Emotes", 1);
+    WidgetPath path = { "Settings", "Emotes", SECTION_COLUMN_1 };
+    SohGui::mSohMenu->AddWidget(path, "Emote Wheel Config", WIDGET_CUSTOM)
+        .CustomFunction(DrawEmoteConfiguration)
+        .HideInSearch(true);
+}
+
+static RegisterMenuInitFunc menuInitFunc(RegisterEmoteWidgets);
+static RegisterShipInitFunc initFunc(RegisterEmote, { "gEmoteWheel.Enabled" });

--- a/soh/soh/Enhancements/cosmetics/Emote.cpp
+++ b/soh/soh/Enhancements/cosmetics/Emote.cpp
@@ -1,0 +1,50 @@
+#include <libultraship/bridge.h>
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+
+extern "C" {
+#include "assets/objects/gameplay_keep/gameplay_keep.h"
+
+#include "macros.h"
+extern PlayState* gPlayState;
+void Player_AnimPlayLoop(PlayState* play, Player* player, LinkAnimationHeader* anim);
+}
+
+std::map<ImGuiKey, std::string> emoteMap = {
+    { ImGuiKey_0, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_0" },
+    { ImGuiKey_1, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_1" },
+    { ImGuiKey_2, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_2" },
+    { ImGuiKey_3, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_3" },
+    { ImGuiKey_4, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_4" },
+    { ImGuiKey_5, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_5" },
+    { ImGuiKey_6, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_6" },
+    { ImGuiKey_7, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_7" },
+    { ImGuiKey_8, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_8" },
+    { ImGuiKey_9, "__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_9" },
+};
+
+void RegisterEmote() {
+    // Loop over map, check if each animation exists, if not remove it from the map
+    std::vector<ImGuiKey> keysToRemove;
+    for (const auto& [key, animPath] : emoteMap) {
+        auto file = Ship::Context::GetInstance()->GetResourceManager()->LoadResource(animPath);
+        if (file == nullptr) {
+            keysToRemove.push_back(key);
+        }
+    }
+    for (auto key : keysToRemove) {
+        emoteMap.erase(key);
+    }
+
+    COND_HOOK(OnPlayerUpdate, true, [] {
+        Player* player = GET_PLAYER(gPlayState);
+
+        for (const auto& [key, animPath] : emoteMap) {
+            if (ImGui::IsKeyDown(key)) {
+                Player_AnimPlayLoop(gPlayState, player, (LinkAnimationHeader*)animPath.c_str());
+            }
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterEmote, {});

--- a/soh/soh/Enhancements/cosmetics/Emote.cpp
+++ b/soh/soh/Enhancements/cosmetics/Emote.cpp
@@ -38,6 +38,9 @@ static EmoteSlot emoteSlots[4] = {
 
 static std::vector<std::string> availableAnimations;
 
+static char animationSearchString[64] = "";
+static int16_t animationSearchDebounceFrames = -1;
+static bool doAnimationSearch = false;
 static bool wheelActive = false;
 static EmoteSlot targetSlot;
 static std::string activeAnimation = "";
@@ -69,8 +72,8 @@ void LoadAvailableAnimations() {
     availableAnimations.clear();
 
     // Get all available animations
-    auto result =
-        Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->ListFiles("*gPlayerAnim_link*");
+    auto result = Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->ListFiles(
+        "*gPlayerAnim_link*" + std::string(animationSearchString) + "*");
 
     availableAnimations.clear();
     for (const auto& path : *result.get()) {
@@ -110,6 +113,12 @@ void RegisterEmote() {
 
     COND_HOOK(OnPlayerUpdate, CVarGetInteger("gEmoteWheel.Enabled", 0), []() {
         Player* player = GET_PLAYER(gPlayState);
+
+        if (player->stateFlags1 & PLAYER_STATE1_GETTING_ITEM || player->stateFlags1 & PLAYER_STATE1_CLIMBING_LADDER ||
+            player->stateFlags1 & PLAYER_STATE1_IN_WATER || player->stateFlags1 & PLAYER_STATE1_IN_ITEM_CS) {
+            return;
+        }
+
         if (targetSlot.animationPath != "") {
             activeAnimation = targetSlot.animationPath;
             if (targetSlot.playOnce) {
@@ -158,6 +167,23 @@ void DrawEmoteConfiguration(WidgetInfo& info) {
 
     if (!CVarGetInteger("gEmoteWheel.Enabled", 0)) {
         return;
+    }
+
+    UIWidgets::PushStyleInput(THEME_COLOR);
+
+    if (ImGui::InputText("Search Animations", animationSearchString, ARRAY_COUNT(animationSearchString))) {
+        doAnimationSearch = true;
+        animationSearchDebounceFrames = 30;
+    }
+    UIWidgets::PopStyleInput();
+
+    if (doAnimationSearch) {
+        if (animationSearchDebounceFrames == 0) {
+            doAnimationSearch = false;
+            LoadAvailableAnimations();
+        }
+
+        animationSearchDebounceFrames--;
     }
 
     ImGui::Separator();


### PR DESCRIPTION
Proof of concept to allow the player to play custom animations placed at `__OTR__objects/gameplay_keep/gPlayerAnim_link_emote_0-9` using the [animation o2r tool](https://o2r-animation-editor.garrettcox.dev/) by pressing their associated numkey.

Anchor transmits limb information over the network, so other players would see the emote play without needing to download anything on their end.

Ideally we implement some sort of emote wheel UI for this, but just using numkeys works for the proof of concept.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4856528612.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4856576312.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4856947492.zip)
<!--- section:artifacts:end -->