### PR TITLE
Mod Menu: Fix empty list crash

### DIFF
--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -96,6 +96,8 @@ void ModsHandleDragAndDrop(std::vector<std::string>& objectList, int targetIndex
 
 std::vector<std::string> GetEnabledModsFromCVar() {
     std::string enabledModsCVarValue = CVAR_ENABLED_MODS_VALUE;
+    if (enabledModsCVarValue.empty())
+        return {};
     return StringHelper::Split(enabledModsCVarValue, SEPARATOR);
 }
 


### PR DESCRIPTION
This pull request fixes a minor crash in Copper Bravo (9.1.1).

**Steps to reproduce:**
1. Ensure your `mods` folder is empty.
2. Open the Mod Menu.
3. Click **Edit**.
4. Click **Cancel**.

**Video:**
* https://github.com/user-attachments/assets/b372fa22-74f2-4724-b222-a46a61292ce1

**Cause:**
When there are no mods installed, `CVAR_ENABLED_MODS_VALUE` is an empty string. As such, [line 99](https://github.com/HarbourMasters/Shipwright/blob/9d8addca0483567bbee693e8b64ddeb1a24eaac1/soh/soh/Enhancements/mod_menu.cpp#L99) evaluates to a list containing one empty string, i.e. `{ "" }`.

When starting the game, [line 169](https://github.com/HarbourMasters/Shipwright/blob/9d8addca0483567bbee693e8b64ddeb1a24eaac1/soh/soh/Enhancements/mod_menu.cpp#L169) removes any mods from this list that can’t be found in the filesystem (e.g. have been uninstalled), which incidentally removes the `""` from the list.

But when clicking **Edit** and then **Cancel**, line 99 is executed but line 169 is not. As a result, the `enabledModFiles` variable remains a list containing one empty string. Somewhere down the line when rendering the UI, this causes an out of range error.

**Fix:**
If `CVAR_ENABLED_MODS_VALUE` is an empty string, then `GetEnabledModsFromCVar` should just return an empty list. This seems most likely to be the “intended” behaviour; the removal logic on 169 was likely obscuring this error before.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4844126453.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4844133636.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4844819615.zip)
<!--- section:artifacts:end -->