### PR TITLE
Fix custom tunics not updating on scene change

### DIFF
--- a/soh/soh/Enhancements/cosmetics/CustomSkeletons.cpp
+++ b/soh/soh/Enhancements/cosmetics/CustomSkeletons.cpp
@@ -8,19 +8,6 @@ extern "C" {
 extern PlayState* gPlayState;
 }
 
-static void UpdateCustomSkeletonOnEquipTunic() {
-    if (!GameInteractor::IsSaveLoaded() || gPlayState == NULL) {
-        return;
-    }
-
-    static int8_t previousTunic = -1;
-    int8_t equippedTunic = CUR_EQUIP_VALUE(EQUIP_TYPE_TUNIC);
-    if (equippedTunic != previousTunic) {
-        SOH::SkeletonPatcher::UpdateCustomSkeletons();
-        previousTunic = equippedTunic;
-    }
-}
-
 static void UpdateCustomSkeleton() {
     if (!GameInteractor::IsSaveLoaded(true) || gPlayState == NULL) {
         return;
@@ -30,9 +17,9 @@ static void UpdateCustomSkeleton() {
 }
 
 static void RegisterCustomSkeletons() {
-    COND_HOOK(OnGameFrameUpdate, true, UpdateCustomSkeletonOnEquipTunic);
     COND_HOOK(OnAssetAltChange, true, UpdateCustomSkeleton);
-    COND_HOOK(OnLinkSkeletonInit, true, UpdateCustomSkeleton);
+    COND_HOOK(OnLinkSkeletonInit, true, SOH::SkeletonPatcher::UpdateCustomSkeletons);
+    COND_HOOK(OnLinkEquipmentChange, true, SOH::SkeletonPatcher::UpdateCustomSkeletons);
 }
 
 static RegisterShipInitFunc initFunc(RegisterCustomSkeletons);

--- a/soh/soh/Enhancements/cosmetics/CustomSkeletons.cpp
+++ b/soh/soh/Enhancements/cosmetics/CustomSkeletons.cpp
@@ -32,7 +32,7 @@ static void UpdateCustomSkeleton() {
 static void RegisterCustomSkeletons() {
     COND_HOOK(OnGameFrameUpdate, true, UpdateCustomSkeletonOnEquipTunic);
     COND_HOOK(OnAssetAltChange, true, UpdateCustomSkeleton);
-    COND_HOOK(OnSceneSpawnActors, true, UpdateCustomSkeleton);
+    COND_HOOK(OnLinkSkeletonInit, true, UpdateCustomSkeleton);
 }
 
 static RegisterShipInitFunc initFunc(RegisterCustomSkeletons);

--- a/soh/soh/Enhancements/cosmetics/CustomSkeletons.cpp
+++ b/soh/soh/Enhancements/cosmetics/CustomSkeletons.cpp
@@ -21,15 +21,7 @@ static void UpdateCustomSkeletonOnEquipTunic() {
     }
 }
 
-static void UpdateCustomSkeletonOnAssetAltChange() {
-    if (!GameInteractor::IsSaveLoaded(true) || gPlayState == NULL) {
-        return;
-    }
-
-    SOH::SkeletonPatcher::UpdateCustomSkeletons();
-}
-
-static void UpdateCustomSkeletonOnSceneInit() {
+static void UpdateCustomSkeleton() {
     if (!GameInteractor::IsSaveLoaded(true) || gPlayState == NULL) {
         return;
     }
@@ -39,8 +31,8 @@ static void UpdateCustomSkeletonOnSceneInit() {
 
 static void RegisterCustomSkeletons() {
     COND_HOOK(OnGameFrameUpdate, true, UpdateCustomSkeletonOnEquipTunic);
-    COND_HOOK(OnAssetAltChange, true, UpdateCustomSkeletonOnAssetAltChange);
-    COND_HOOK(OnSceneSpawnActors, true, UpdateCustomSkeletonOnSceneInit);
+    COND_HOOK(OnAssetAltChange, true, UpdateCustomSkeleton);
+    COND_HOOK(OnSceneSpawnActors, true, UpdateCustomSkeleton);
 }
 
 static RegisterShipInitFunc initFunc(RegisterCustomSkeletons);

--- a/soh/soh/Enhancements/cosmetics/CustomSkeletons.cpp
+++ b/soh/soh/Enhancements/cosmetics/CustomSkeletons.cpp
@@ -22,7 +22,15 @@ static void UpdateCustomSkeletonOnEquipTunic() {
 }
 
 static void UpdateCustomSkeletonOnAssetAltChange() {
-    if (!GameInteractor::IsSaveLoaded() || gPlayState == NULL) {
+    if (!GameInteractor::IsSaveLoaded(true) || gPlayState == NULL) {
+        return;
+    }
+
+    SOH::SkeletonPatcher::UpdateCustomSkeletons();
+}
+
+static void UpdateCustomSkeletonOnSceneInit() {
+    if (!GameInteractor::IsSaveLoaded(true) || gPlayState == NULL) {
         return;
     }
 
@@ -32,6 +40,7 @@ static void UpdateCustomSkeletonOnAssetAltChange() {
 static void RegisterCustomSkeletons() {
     COND_HOOK(OnGameFrameUpdate, true, UpdateCustomSkeletonOnEquipTunic);
     COND_HOOK(OnAssetAltChange, true, UpdateCustomSkeletonOnAssetAltChange);
+    COND_HOOK(OnSceneSpawnActors, true, UpdateCustomSkeletonOnSceneInit);
 }
 
 static RegisterShipInitFunc initFunc(RegisterCustomSkeletons);

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_HookTable.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_HookTable.h
@@ -23,6 +23,7 @@ DEFINE_HOOK(OnFlagSet, (int16_t flagType, int16_t flag));
 DEFINE_HOOK(OnFlagUnset, (int16_t flagType, int16_t flag));
 DEFINE_HOOK(OnSceneSpawnActors, ());
 DEFINE_HOOK(OnLinkSkeletonInit, ());
+DEFINE_HOOK(OnLinkEquipmentChange, ());
 DEFINE_HOOK(OnPlayerUpdate, ());
 DEFINE_HOOK(OnSetDoAction, (uint16_t action));
 DEFINE_HOOK(OnPlayerSfx, (u16 sfxId));

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_HookTable.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_HookTable.h
@@ -22,6 +22,7 @@ DEFINE_HOOK(OnSceneFlagUnset, (int16_t sceneNum, int16_t flagType, int16_t flag)
 DEFINE_HOOK(OnFlagSet, (int16_t flagType, int16_t flag));
 DEFINE_HOOK(OnFlagUnset, (int16_t flagType, int16_t flag));
 DEFINE_HOOK(OnSceneSpawnActors, ());
+DEFINE_HOOK(OnLinkSkeletonInit, ());
 DEFINE_HOOK(OnPlayerUpdate, ());
 DEFINE_HOOK(OnSetDoAction, (uint16_t action));
 DEFINE_HOOK(OnPlayerSfx, (u16 sfxId));

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
@@ -86,6 +86,10 @@ void GameInteractor_ExecuteOnSceneSpawnActors() {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSceneSpawnActors>();
 }
 
+void GameInteractor_ExecuteOnLinkSkeletonInit() {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnLinkSkeletonInit>();
+}
+
 void GameInteractor_ExecuteOnPlayerUpdate() {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerUpdate>();
 }

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
@@ -90,6 +90,10 @@ void GameInteractor_ExecuteOnLinkSkeletonInit() {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnLinkSkeletonInit>();
 }
 
+void GameInteractor_ExecuteOnLinkEquipmentChange() {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnLinkEquipmentChange>();
+}
+
 void GameInteractor_ExecuteOnPlayerUpdate() {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerUpdate>();
 }

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
@@ -26,6 +26,7 @@ void GameInteractor_ExecuteOnFlagSet(int16_t flagType, int16_t flag);
 void GameInteractor_ExecuteOnFlagUnset(int16_t flagType, int16_t flag);
 void GameInteractor_ExecuteOnSceneSpawnActors();
 void GameInteractor_ExecuteOnLinkSkeletonInit();
+void GameInteractor_ExecuteOnLinkEquipmentChange();
 void GameInteractor_ExecuteOnPlayerUpdate();
 void GameInteractor_ExecuteOnSetDoAction(uint16_t action);
 void GameInteractor_ExecuteOnPlayerSfx(u16 sfxId);

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
@@ -25,6 +25,7 @@ void GameInteractor_ExecuteOnSceneFlagUnset(int16_t sceneNum, int16_t flagType, 
 void GameInteractor_ExecuteOnFlagSet(int16_t flagType, int16_t flag);
 void GameInteractor_ExecuteOnFlagUnset(int16_t flagType, int16_t flag);
 void GameInteractor_ExecuteOnSceneSpawnActors();
+void GameInteractor_ExecuteOnLinkSkeletonInit();
 void GameInteractor_ExecuteOnPlayerUpdate();
 void GameInteractor_ExecuteOnSetDoAction(uint16_t action);
 void GameInteractor_ExecuteOnPlayerSfx(u16 sfxId);

--- a/soh/src/code/z_inventory.c
+++ b/soh/src/code/z_inventory.c
@@ -187,6 +187,8 @@ u8 gItemSlots[] = {
 void Inventory_ChangeEquipment(s16 equipment, u16 value) {
     gSaveContext.equips.equipment &= gEquipNegMasks[equipment];
     gSaveContext.equips.equipment |= value << gEquipShifts[equipment];
+
+    GameInteractor_ExecuteOnLinkEquipmentChange();
 }
 
 u8 Inventory_DeleteEquipment(PlayState* play, s16 equipment) {

--- a/soh/src/code/z_skelanime.c
+++ b/soh/src/code/z_skelanime.c
@@ -1140,6 +1140,8 @@ void SkelAnime_InitLink(PlayState* play, SkelAnime* skelAnime, FlexSkeletonHeade
     }
 
     LinkAnimation_Change(play, skelAnime, animation, 1.0f, 0.0f, 0.0f, ANIMMODE_LOOP, 0.0f);
+
+    GameInteractor_ExecuteOnLinkSkeletonInit();
 }
 
 /**


### PR DESCRIPTION
Follows up on https://github.com/HarbourMasters/Shipwright/pull/6022

Fixes custom skeletons for tunics not applying after a scene change. This technically runs slightly more often because it runs on every room change, but it doesn't seem like it impacts that much to only run that often, and it's either that or make a new hook specifically for this because the OnSceneInit hook runs too early. If we want that though I could.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4932501100.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4932510564.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4932525019.zip)
<!--- section:artifacts:end -->