### PR TITLE
Add setting updater for rando logic setting

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1271,6 +1271,7 @@ extern "C" void InitOTR(int argc, char* argv[]) {
     conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion2Updater>());
     conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion3Updater>());
     conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion4Updater>());
+    conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion5Updater>());
     conf->RunVersionUpdates();
 
     SohGui::SetupGuiElements();

--- a/soh/soh/config/ConfigUpdaters.cpp
+++ b/soh/soh/config/ConfigUpdaters.cpp
@@ -11,6 +11,8 @@ ConfigVersion3Updater::ConfigVersion3Updater() : ConfigVersionUpdater(3) {
 }
 ConfigVersion4Updater::ConfigVersion4Updater() : ConfigVersionUpdater(4) {
 }
+ConfigVersion5Updater::ConfigVersion5Updater() : ConfigVersionUpdater(5) {
+}
 
 void ConfigVersion1Updater::Update(Ship::Config* conf) {
     if (conf->GetInt("Window.Width", 640) == 640) {
@@ -120,6 +122,13 @@ void ConfigVersion4Updater::Update(Ship::Config* conf) {
             CVarCopy(migration.from.c_str(), migration.to.value().c_str());
         }
         CVarClear(migration.from.c_str());
+    }
+}
+
+void ConfigVersion5Updater::Update(Ship::Config* conf) {
+    // After removal of Vanilla, make sure it doesn't crash because of an out of range on the combobox
+    if (CVarGetInteger("gRandoSettings.LogicRules", 0) == 2) {
+        CVarSetInteger("gRandoSettings.LogicRules", 0);
     }
 }
 } // namespace SOH

--- a/soh/soh/config/ConfigUpdaters.h
+++ b/soh/soh/config/ConfigUpdaters.h
@@ -24,4 +24,10 @@ class ConfigVersion4Updater final : public Ship::ConfigVersionUpdater {
     ConfigVersion4Updater();
     void Update(Ship::Config* conf);
 };
+
+class ConfigVersion5Updater final : public Ship::ConfigVersionUpdater {
+  public:
+    ConfigVersion5Updater();
+    void Update(Ship::Config* conf);
+};
 } // namespace SOH


### PR DESCRIPTION
After removal of vanilla logic in the rando settings, if someone which had it set to vanilla before and then updated, the game would crash on opening the rando settings tab with that in it because of an out of range error on the combobox.

This resets it to 0 when a config still has that old value.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4918271976.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4918310301.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4918419660.zip)
<!--- section:artifacts:end -->