### PR TITLE
Reverted removal of 'ClearItemLocations' to fix #6036

### DIFF
--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -466,6 +466,7 @@ void SaveManager::Init() {
         }
     }
     saveBlock = nlohmann::json::object();
+    OTRGlobals::Instance->gRandoContext->ClearItemLocations();
 }
 
 void SaveManager::StartupCheckAndInitMeta(int fileNum) {


### PR DESCRIPTION
Originally in the SaveManager::Init() function, each save file got loaded, and then the save block and item locations in the rando context got reset.
After the changes for #5817 only the save block got reset on init.

I'm guessing resetting the locations in the rando context was accidentally left out.
This commit puts that back and fixes the issues with having incorrect location data when creating a new randomizer save using the same seed (#6036)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4963322665.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4963327445.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4963345073.zip)
<!--- section:artifacts:end -->