### PR TITLE
HasItem Pocket Cucco

### DIFF
--- a/soh/soh/Enhancements/randomizer/logic.cpp
+++ b/soh/soh/Enhancements/randomizer/logic.cpp
@@ -223,7 +223,8 @@ bool Logic::HasItem(RandomizerGet itemName) {
         case RG_GOLDEN_SCALE:
             return CurrentUpgrade(UPG_SCALE) >= 2;
         case RG_POCKET_EGG:
-            return CheckRandoInf(RAND_INF_ADULT_TRADES_HAS_POCKET_EGG);
+            return CheckRandoInf(RAND_INF_ADULT_TRADES_HAS_POCKET_EGG) ||
+                   CheckRandoInf(RAND_INF_ADULT_TRADES_HAS_POCKET_CUCCO);
         case RG_COJIRO:
         case RG_ODD_MUSHROOM:
         case RG_ODD_POTION:


### PR DESCRIPTION
The hatched pocket egg wasn't showing Trade Pocket Cucco as available, only the pocket egg.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4977519227.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4977521623.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/4977551377.zip)
<!--- section:artifacts:end -->