### PR TITLE
fix build and run on OpenBSD

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -60,7 +60,7 @@ u32 Locale_IsRegionNative(void);
 void _assert(const char* exp, const char* file, s32 line);
 #elif defined(__linux__)
 void __assert(const char* exp, const char* file, s32 line) __THROW;
-#elif !defined(__APPLE__) && !defined(__SWITCH__)
+#elif !defined(__APPLE__) && !defined(__SWITCH__) && !defined(__OpenBSD__)
 void __assert(const char* exp, const char* file, s32 line);
 #endif
 #if defined(__APPLE__) && defined(NDEBUG)

--- a/soh/soh/GbiWrap.cpp
+++ b/soh/soh/GbiWrap.cpp
@@ -45,7 +45,7 @@ extern "C" void gSPSegment(void* value, int segNum, uintptr_t target) {
     if (res) {
         uintptr_t desiredTarget = (uintptr_t)ResourceMgr_LoadIfDListByName(imgData);
 
-        if (desiredTarget != NULL)
+        if (desiredTarget)
             target = desiredTarget;
     }
 

--- a/soh/src/buffers/heaps.c
+++ b/soh/src/buffers/heaps.c
@@ -1,6 +1,6 @@
 #include "z64.h"
 #include <assert.h>
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(__OpenBSD__)
 #include <malloc.h>
 #endif
 #include <stdlib.h>

--- a/soh/src/code/audio_synthesis.c
+++ b/soh/src/code/audio_synthesis.c
@@ -902,7 +902,7 @@ Acmd* AudioSynth_ProcessNote(s32 noteIndex, NoteSubEu* noteSubEu, NoteSynthesisS
 
 #if __SANITIZE_ADDRESS__ || defined(__OpenBSD__)
                     uintptr_t actualAddrLoaded = sampleData - sampleDataStartPad;
-                    uintptr_t offset = actualAddrLoaded - (uintptr_t) sampleAddr;
+                    uintptr_t offset = actualAddrLoaded - (uintptr_t)sampleAddr;
                     if (offset + aligned > audioFontSample->size) {
                         aligned -= (offset + aligned - audioFontSample->size);
                     }

--- a/soh/src/code/audio_synthesis.c
+++ b/soh/src/code/audio_synthesis.c
@@ -900,14 +900,6 @@ Acmd* AudioSynth_ProcessNote(s32 noteIndex, NoteSubEu* noteSubEu, NoteSynthesisS
                     aligned = ALIGN16((nFramesToDecode * frameSize) + 16);
                     addr = DMEM_COMPRESSED_ADPCM_DATA - aligned;
 
-#if __SANITIZE_ADDRESS__ || defined(__OpenBSD__)
-                    uintptr_t actualAddrLoaded = sampleData - sampleDataStartPad;
-                    uintptr_t offset = actualAddrLoaded - (uintptr_t)sampleAddr;
-                    if (offset + aligned > audioFontSample->size) {
-                        aligned -= (offset + aligned - audioFontSample->size);
-                    }
-#endif
-
                     aLoadBuffer(cmd++, sampleData - sampleDataStartPad, addr, aligned);
                 } else {
                     nSamplesToDecode = 0;

--- a/soh/src/code/audio_synthesis.c
+++ b/soh/src/code/audio_synthesis.c
@@ -900,6 +900,14 @@ Acmd* AudioSynth_ProcessNote(s32 noteIndex, NoteSubEu* noteSubEu, NoteSynthesisS
                     aligned = ALIGN16((nFramesToDecode * frameSize) + 16);
                     addr = DMEM_COMPRESSED_ADPCM_DATA - aligned;
 
+#if __SANITIZE_ADDRESS__ || defined(__OpenBSD__)
+                    uintptr_t actualAddrLoaded = sampleData - sampleDataStartPad;
+                    uintptr_t offset = actualAddrLoaded - (uintptr_t) sampleAddr;
+                    if (offset + aligned > audioFontSample->size) {
+                        aligned -= (offset + aligned - audioFontSample->size);
+                    }
+#endif
+
                     aLoadBuffer(cmd++, sampleData - sampleDataStartPad, addr, aligned);
                 } else {
                     nSamplesToDecode = 0;


### PR DESCRIPTION
Just like Apple, OpenBSD doesn't provide malloc.h header and already defines __assert() from the base system.
Hopefully the offending __assert() which doesn't have the same arguments isn't used, otherwise it would error out.

The cpp compiler on OpenBSD is more strict and raise an error on invalid operands to binary expression.
('uintptr_t' (aka 'unsigned long') and 'std::nullptr_t')
   48 |         if (desiredTarget != NULL)
      |             ~~~~~~~~~~~~~ ^  ~~~~

Finally, Shipwright has the same memory/alignment issue seen in Starship (which already have a workaround guarded by __SANITIZE_ADDRESS__). See https://github.com/HarbourMasters/Starship/pull/238.


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5146070702.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5146107655.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5146146009.zip)
<!--- section:artifacts:end -->