### PR TITLE
Make Custom Tunic Local

### DIFF
--- a/soh/soh/resource/type/Skeleton.cpp
+++ b/soh/soh/resource/type/Skeleton.cpp
@@ -75,6 +75,11 @@ void SkeletonPatcher::RegisterSkeleton(std::string& path, SkelAnime* skelAnime) 
 
     if (IsLinkSkeletonPath(info.vanillaSkeletonPath)) {
         info.isLocalPlayer = IsLocalPlayerSkelAnime(skelAnime);
+
+        // Skip registering skeletons that do not belong to the local player (e.g. Anchor dummy actors)
+        if (!info.isLocalPlayer) {
+            return;
+        }
     }
 
     skeletons.push_back(info);
@@ -115,11 +120,7 @@ void SkeletonPatcher::UpdateSkeletons() {
 }
 
 void SkeletonPatcher::UpdateCustomSkeletons() {
-    for (auto& skel : skeletons) {
-        if (IsLinkSkeletonPath(skel.vanillaSkeletonPath)) {
-            skel.isLocalPlayer = IsLocalPlayerSkelAnime(skel.skelAnime);
-        }
-
+    for (auto skel : skeletons) {
         if (!skel.isLocalPlayer) {
             continue;
         }

--- a/soh/soh/resource/type/Skeleton.cpp
+++ b/soh/soh/resource/type/Skeleton.cpp
@@ -9,6 +9,7 @@
 
 extern "C" {
 #include "variables.h"
+#include "z64.h"
 #include "z64player.h"
 extern PlayState* gPlayState;
 }
@@ -52,7 +53,10 @@ bool SkeletonPatcher::IsLocalPlayerSkelAnime(SkelAnime* skelAnime) {
         return false;
     }
 
-    return (skelAnime == &player->skelAnime) || (skelAnime == &player->upperSkelAnime);
+    PauseContext* pauseCtx = &gPlayState->pauseCtx;
+
+    return (skelAnime == &player->skelAnime) || (skelAnime == &player->upperSkelAnime) ||
+           (skelAnime == &pauseCtx->playerSkelAnime);
 }
 
 void SkeletonPatcher::RegisterSkeleton(std::string& path, SkelAnime* skelAnime) {

--- a/soh/soh/resource/type/Skeleton.cpp
+++ b/soh/soh/resource/type/Skeleton.cpp
@@ -5,6 +5,13 @@
 #include <soh_assets.h>
 #include <objects/object_link_child/object_link_child.h>
 #include <objects/object_link_boy/object_link_boy.h>
+#include "macros.h"
+
+extern "C" {
+#include "variables.h"
+#include "z64player.h"
+extern PlayState* gPlayState;
+}
 
 extern "C" SaveContext gSaveContext;
 extern "C" u16 gEquipMasks[4];
@@ -30,12 +37,29 @@ size_t Skeleton::GetPointerSize() {
 
 std::vector<SkeletonPatchInfo> SkeletonPatcher::skeletons;
 
+bool SkeletonPatcher::IsLinkSkeletonPath(const std::string& path) {
+    return (sOtr + path == std::string(gLinkAdultSkel)) || (sOtr + path == std::string(gLinkChildSkel));
+}
+
+bool SkeletonPatcher::IsLocalPlayerSkelAnime(SkelAnime* skelAnime) {
+    if (gPlayState == nullptr) {
+        return false;
+    }
+
+    Player* player = GET_PLAYER(gPlayState);
+
+    if (player == nullptr) {
+        return false;
+    }
+
+    return (skelAnime == &player->skelAnime) || (skelAnime == &player->upperSkelAnime);
+}
+
 void SkeletonPatcher::RegisterSkeleton(std::string& path, SkelAnime* skelAnime) {
     SkeletonPatchInfo info;
 
     info.skelAnime = skelAnime;
-
-    static const std::string sOtr = "__OTR__";
+    info.isLocalPlayer = false;
 
     if (path.starts_with(sOtr)) {
         path = path.substr(sOtr.length());
@@ -47,6 +71,10 @@ void SkeletonPatcher::RegisterSkeleton(std::string& path, SkelAnime* skelAnime) 
                                                path.size() - Ship::IResource::gAltAssetPrefix.length());
     } else {
         info.vanillaSkeletonPath = path;
+    }
+
+    if (IsLinkSkeletonPath(info.vanillaSkeletonPath)) {
+        info.isLocalPlayer = IsLocalPlayerSkelAnime(skelAnime);
     }
 
     skeletons.push_back(info);
@@ -87,7 +115,15 @@ void SkeletonPatcher::UpdateSkeletons() {
 }
 
 void SkeletonPatcher::UpdateCustomSkeletons() {
-    for (auto skel : skeletons) {
+    for (auto& skel : skeletons) {
+        if (IsLinkSkeletonPath(skel.vanillaSkeletonPath)) {
+            skel.isLocalPlayer = IsLocalPlayerSkelAnime(skel.skelAnime);
+        }
+
+        if (!skel.isLocalPlayer) {
+            continue;
+        }
+
         UpdateTunicSkeletons(skel);
     }
 }

--- a/soh/soh/resource/type/Skeleton.h
+++ b/soh/soh/resource/type/Skeleton.h
@@ -78,6 +78,7 @@ class Skeleton : public Ship::Resource<SkeletonData> {
 struct SkeletonPatchInfo {
     SkelAnime* skelAnime;
     std::string vanillaSkeletonPath;
+    bool isLocalPlayer;
 };
 
 class SkeletonPatcher {
@@ -92,6 +93,8 @@ class SkeletonPatcher {
 
   private:
     inline static const std::string sOtr = "__OTR__";
+    static bool IsLinkSkeletonPath(const std::string& path);
+    static bool IsLocalPlayerSkelAnime(SkelAnime* skelAnime);
     static void UpdateTunicSkeletons(SkeletonPatchInfo& skel);
     static void UpdateCustomSkeletonFromPath(const std::string& skeletonPath, SkeletonPatchInfo& skel);
 };


### PR DESCRIPTION
Crashes seems to have been same issue as the Custom Equipment PR.

When anchor is enabled and Dummy Actors are enabled. The custom tunic code (and custom equipment code) were being ran by dummy actors and eventually causes a memory corruption due to how patching works in ship.

I added a similar fix to Skeleton.cpp as i have done to customequipment in my own pr. Essentially enforce so custom tunic can only be ran by the local player and not dummy actors so code is cannot be ran at unfortunate time and place.

Custom tunics not updating between players if both have custom tunic mods are NOT affected here and is just a side effect of how that system works. It only looks at the save file to see which tunic to load. Dummy actors technically dont have a save file so custom tunic does not get applied to them anyway. Will not do anything about it this pr

On a quick playtest it seemed to have stabilized.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5004347369.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5004348110.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5004352814.zip)
<!--- section:artifacts:end -->