### PR TITLE
AnyAgeTime Entrance Rando Fix

### DIFF
--- a/soh/soh/Enhancements/randomizer/entrance.cpp
+++ b/soh/soh/Enhancements/randomizer/entrance.cpp
@@ -1082,12 +1082,14 @@ static std::array<std::vector<Entrance*>, 2> SplitEntrancesByRequirements(std::v
     ReachabilitySearch({});
 
     for (Entrance* entrance : entrancesToSplit) {
+        logic->CurrentRegionKey = entrance->GetParentRegionKey();
         // if an entrance is accessible at all times of day by both ages, it's a soft entrance with no restrictions
         if (entrance->ConditionsMet(true)) {
             softEntrances.push_back(entrance);
         } else {
             restrictiveEntrances.push_back(entrance);
         }
+        logic->CurrentRegionKey = RR_NONE;
     }
 
     // Reconnect all disconnected entrances


### PR DESCRIPTION
Set and unset `CurrentRegionKey` when checking an entrance.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5009741471.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5009764322.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5009778553.zip)
<!--- section:artifacts:end -->