### PR TITLE
Fix an assert and va_arg linux crash

### DIFF
--- a/soh/soh/Enhancements/cosmetics/FileSelectMoreInfo.cpp
+++ b/soh/soh/Enhancements/cosmetics/FileSelectMoreInfo.cpp
@@ -776,8 +776,8 @@ void RegisterFileSelectMoreInfo() {
 
     COND_VB_SHOULD(VB_FILE_SELECT_DRAW_QUEST_ITEMS, CVAR_FILE_SELECT_MORE_INFO_VALUE, {
         FileChooseContext* thisx = va_arg(args, FileChooseContext*);
-        s16 fileIndex = va_arg(args, s16);
-        u8 textAlpha = va_arg(args, u8);
+        s32 fileIndex = va_arg(args, s32);
+        u32 textAlpha = va_arg(args, u32);
 
         if (thisx->menuMode == FS_MENU_MODE_SELECT) {
             DrawMoreInfo(thisx, fileIndex, textAlpha);

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/desert_colossus.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/desert_colossus.cpp
@@ -23,7 +23,7 @@ void RegionTable_Init_DesertColossus() {
     }, {
         //Exits
         //You can kinda get the fairies without entering the water, but it relies on them cooperating and leevers are jerks. should be a trick
-        Entrance(RR_DESERT_COLOSSUS_OASIS,         []{return logic->CanUse(RG_SONG_OF_STORMS) && (logic->HasItem(RG_BRONZE_SCALE) || logic->CanUse(RG_IRON_BOOTS) || logic->CanUse(RG_EMPTY_BOTTLE));}),
+        Entrance(RR_DESERT_COLOSSUS_OASIS,         []{return logic->CanUse(RG_SONG_OF_STORMS) && (logic->HasItem(RG_BRONZE_SCALE) || logic->CanUse(RG_IRON_BOOTS) || logic->HasItem(RG_EMPTY_BOTTLE));}),
         Entrance(RR_COLOSSUS_GREAT_FAIRY_FOUNTAIN, []{return logic->HasExplosives();}),
         Entrance(RR_SPIRIT_TEMPLE_ENTRYWAY,        []{return true;}),
         Entrance(RR_WASTELAND_NEAR_COLOSSUS,       []{return true;}),


### PR DESCRIPTION
This PR fixes 2 small issues:
- A case where va-arg passed non-32 bit variables from a hook and crashed on linux
- an assert where no entry in HasItem existed for RG_EMPTY_BOTTLE