### PR TITLE
randomizer: bring back item pool options

### DIFF
--- a/soh/soh/Enhancements/Graphics/ToTMedallions.cpp
+++ b/soh/soh/Enhancements/Graphics/ToTMedallions.cpp
@@ -1,11 +1,11 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ResourceManagerHelpers.h"
 #include "soh/ShipInit.hpp"
 
 extern "C" {
 #include "align_asset_macro.h"
 #include "macros.h"
 #include "variables.h"
-#include "soh/ResourceManagerHelpers.h"
 extern PlayState* gPlayState;
 }
 

--- a/soh/soh/Enhancements/randomizer/location_access.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access.cpp
@@ -574,7 +574,7 @@ void Region::ResetVariables() {
  * In the second universe, the player went in as adult, possibly out of logic, and started wasting the keys to lock
  child out.
  * These Universes converge when the player has 7 keys (meaning adult can no longer lock child out) and adult is
- known to be able to reach Statue room. This creates "Certain Access", which is tracked seperatly for each age.
+ known to be able to reach Statue room. This creates "Certain Access", which is tracked separatly for each age.
  * Child Certain Access is simple, if we have 7 keys and child access, it's Certain Access.
  * Adult Certain Access is also simple, adult is not key locked, so if they make it to a location, it's Certain
  Access.

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -926,7 +926,7 @@ ItemObtainability Randomizer::GetItemObtainabilityFromRandomizerGet(RandomizerGe
             return OTRGlobals::Instance->gRandoContext->GetOption(RSK_BOMBCHU_BAG).Is(RO_BOMBCHU_BAG_NONE)
                        ? CAN_OBTAIN
                        : (INV_CONTENT(ITEM_BOMBCHU) != ITEM_NONE ? CAN_OBTAIN : CANT_OBTAIN_NEED_UPGRADE);
-        case RG_PROGRESSIVE_BOMBCHU_BAG: // RANDOTODO Do we want bombchu refills to exist seperatly from bombchu bags?
+        case RG_PROGRESSIVE_BOMBCHU_BAG: // RANDOTODO Do we want bombchu refills to exist separatly from bombchu bags?
                                          // If so, this needs changing.
             switch (OTRGlobals::Instance->gRandoContext->GetOption(RSK_BOMBCHU_BAG).Get()) {
                 case RO_BOMBCHU_BAG_NONE:

--- a/soh/soh/Enhancements/randomizer/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/settings.cpp
@@ -2196,6 +2196,7 @@ void Settings::CreateOptions() {
         WidgetContainerType::SECTION);
     mOptionGroups[RSG_MENU_COLUMN_LOGIC_WINCON] = OptionGroup::SubGroup("",
                                                                         std::initializer_list<OptionGroup*>{
+                                                                            &mOptionGroups[RSG_ITEM_POOL],
                                                                             &mOptionGroups[RSG_MENU_SECTION_LOGIC],
                                                                             &mOptionGroups[RSG_MENU_SECTION_WINCON],
                                                                         },
@@ -2998,7 +2999,7 @@ void Context::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocation
                     mqSet += 1;
                     break;
                 case RO_MQ_SET_RANDOM:
-                    // 50% per dungeon, rolled seperatly so people can either have a linear distribtuion
+                    // 50% per dungeon, rolled separatly so people can either have a linear distribtuion
                     // or a bell curve for the number of MQ dungeons per seed.
                     if (Random(0, 2)) {
                         dungeon->SetMQ();

--- a/soh/soh/Network/Anchor/Packets/AllClientState.cpp
+++ b/soh/soh/Network/Anchor/Packets/AllClientState.cpp
@@ -62,7 +62,7 @@ void Anchor::HandlePacket_AllClientState(nlohmann::json payload) {
             clientsToRemove.push_back(clientId);
         }
     }
-    // (seperate loop to avoid iterator invalidation)
+    // (separate loop to avoid iterator invalidation)
     for (auto& clientId : clientsToRemove) {
         clients.erase(clientId);
     }

--- a/soh/soh/frame_interpolation.cpp
+++ b/soh/soh/frame_interpolation.cpp
@@ -452,7 +452,7 @@ unordered_map<Mtx*, MtxF> FrameInterpolation_Interpolate(float step) {
 }
 
 void FrameInterpolation_StartRecord(void) {
-    previous_recording = move(current_recording);
+    previous_recording = std::move(current_recording);
     current_recording = {};
     current_path.clear();
     current_path.push_back(&current_recording.root_path);

--- a/soh/soh/resource/type/Skeleton.cpp
+++ b/soh/soh/resource/type/Skeleton.cpp
@@ -92,7 +92,7 @@ void SkeletonPatcher::RegisterSkeleton(std::string& path, SkelAnime* skelAnime) 
 void SkeletonPatcher::UnregisterSkeleton(SkelAnime* skelAnime) {
 
     // TODO: Should probably just use a dictionary here...
-    for (int i = 0; i < skeletons.size(); i++) {
+    for (size_t i = 0; i < skeletons.size(); i++) {
         auto skel = skeletons[i];
 
         if (skel.skelAnime == skelAnime) {


### PR DESCRIPTION
@Pepper0ni pointed out these options missing

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5011105139.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5011110120.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5011139789.zip)
<!--- section:artifacts:end -->