### PR TITLE
Add back Junk-category

### DIFF
--- a/soh/soh/Enhancements/randomizer/ShuffleCrates.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleCrates.cpp
@@ -78,6 +78,7 @@ extern "C" void ObjKibako2_RandomizerDraw(Actor* thisx, PlayState* play) {
         case ITEM_CATEGORY_LESSER:
             Gfx_DrawDListOpa(play, (Gfx*)gLargeMinorCrateDL);
             break;
+        case ITEM_CATEGORY_JUNK:
         default:
             Gfx_DrawDListOpa(play, (Gfx*)gLargeJunkCrateDL);
             break;


### PR DESCRIPTION
accidentally removed `case ITEM_CATEGORY_JUNK:`

from largecrate switch case