### PR TITLE
beans: fix generation for starting with planted beans

### DIFF
--- a/soh/soh/Enhancements/randomizer/location_access.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access.cpp
@@ -786,6 +786,8 @@ bool BeanPlanted(const RandomizerGet bean) {
     // flag irrelevant if plant won't spawn
     if (!logic->HasItem(bean)) {
         return false;
+    } else if (ctx->GetOption(RSK_SKIP_PLANTING_BEANS) && ctx->GetOption(RSK_STARTING_BEANS)) {
+        return true;
     }
 
     // swchFlag found using the Actor Viewer to get the Obj_Bean parameters & 0x3F


### PR DESCRIPTION
beans is 0 in inventory, confusing CanPlantBeanCheck, check for this specific scenario in BeanPlanted to mitigate

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5020491741.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5020497405.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5020523216.zip)
<!--- section:artifacts:end -->