### PR TITLE
Make "Move in First Person" require "Right Stick Aiming"

### DIFF
--- a/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
+++ b/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
@@ -1379,7 +1379,7 @@ void SohInputEditorWindow::DrawCameraControlPanel() {
                      .Tooltip("Allows for aiming with the right stick in:\n-First-Person/C-Up view\n-Weapon Aiming"));
     CVarCheckbox("Allow moving while in first-person mode", CVAR_SETTING("MoveInFirstPerson"),
                  CheckboxOptions({ { .disabled = !CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0),
-                                     .disabledTooltip = "Requires \"Right Stick Aiming\" to be enabled." } })
+                                     .disabledTooltip = "Forced off because Right Stick Aiming is disabled." } })
                      .Color(THEME_COLOR)
                      .Tooltip("Changes the left stick to move the player while in first-person mode"));
     CVarCheckbox("Invert Aiming X Axis", CVAR_SETTING("Controls.InvertAimingXAxis"),

--- a/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
+++ b/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
@@ -1377,12 +1377,11 @@ void SohInputEditorWindow::DrawCameraControlPanel() {
                  CheckboxOptions()
                      .Color(THEME_COLOR)
                      .Tooltip("Allows for aiming with the right stick in:\n-First-Person/C-Up view\n-Weapon Aiming"));
-    if (CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0)) {
-        CVarCheckbox("Allow moving while in first-person mode", CVAR_SETTING("MoveInFirstPerson"),
-                     CheckboxOptions()
-                         .Color(THEME_COLOR)
-                         .Tooltip("Changes the left stick to move the player while in first-person mode"));
-    }
+    CVarCheckbox("Allow moving while in first-person mode", CVAR_SETTING("MoveInFirstPerson"),
+                 CheckboxOptions({ { .disabled = !CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0),
+                                     .disabledTooltip = "Requires \"Right Stick Aiming\" to be enabled." } })
+                     .Color(THEME_COLOR)
+                     .Tooltip("Changes the left stick to move the player while in first-person mode"));
     CVarCheckbox("Invert Aiming X Axis", CVAR_SETTING("Controls.InvertAimingXAxis"),
                  CheckboxOptions()
                      .Color(THEME_COLOR)

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12745,7 +12745,7 @@ s16 func_8084ABD8(PlayState* play, Player* this, s32 arg2, s16 arg3) {
 
     if (!func_8002DD78(this) && !func_808334B4(this) && (arg2 == 0)) { // First person without weapon
         // Y Axis
-        if (!CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0)) {
+        if (!(CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0) && CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0))) {
             temp2 += sControlInput->rel.stick_y * 240.0f * invertYAxisMulti * yAxisMulti;
         }
         if (CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0)) {
@@ -12763,7 +12763,7 @@ s16 func_8084ABD8(PlayState* play, Player* this, s32 arg2, s16 arg3) {
 
         // X Axis
         temp2 = 0;
-        if (!CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0)) {
+        if (!(CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0) && CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0))) {
             temp2 += sControlInput->rel.stick_x * -16.0f * invertXAxisMulti * xAxisMulti;
         }
         if (CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0)) {
@@ -12778,7 +12778,7 @@ s16 func_8084ABD8(PlayState* play, Player* this, s32 arg2, s16 arg3) {
         // Y Axis
         temp1 = (this->stateFlags1 & PLAYER_STATE1_ON_HORSE) ? 3500 : 14000;
 
-        if (!CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0)) {
+        if (!(CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0) && CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0))) {
             temp3 += ((sControlInput->rel.stick_y >= 0) ? 1 : -1) *
                      (s32)((1.0f - Math_CosS(sControlInput->rel.stick_y * 200)) * 1500.0f) * invertYAxisMulti *
                      yAxisMulti;
@@ -12798,7 +12798,7 @@ s16 func_8084ABD8(PlayState* play, Player* this, s32 arg2, s16 arg3) {
         temp1 = 19114;
         temp2 = this->actor.focus.rot.y - this->actor.shape.rot.y;
         temp3 = 0;
-        if (!CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0)) {
+        if (!(CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0) && CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0))) {
             temp3 = ((sControlInput->rel.stick_x >= 0) ? 1 : -1) *
                     (s32)((1.0f - Math_CosS(sControlInput->rel.stick_x * 200)) * -1500.0f) * invertXAxisMulti *
                     xAxisMulti;
@@ -12815,7 +12815,7 @@ s16 func_8084ABD8(PlayState* play, Player* this, s32 arg2, s16 arg3) {
         this->actor.focus.rot.y = CLAMP(temp2, -temp1, temp1) + this->actor.shape.rot.y;
     }
 
-    if (CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0)) {
+    if (CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0) && CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0)) {
         f32 movementSpeed = LINK_IS_ADULT ? 9.0f : 8.25f;
         if (CVarGetInteger(CVAR_ENHANCEMENT("MMBunnyHood"), BUNNY_HOOD_VANILLA) != BUNNY_HOOD_VANILLA &&
             this->currentMask == PLAYER_MASK_BUNNY) {

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12745,7 +12745,8 @@ s16 func_8084ABD8(PlayState* play, Player* this, s32 arg2, s16 arg3) {
 
     if (!func_8002DD78(this) && !func_808334B4(this) && (arg2 == 0)) { // First person without weapon
         // Y Axis
-        if (!(CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0) && CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0))) {
+        if (!(CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0) &&
+              CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0))) {
             temp2 += sControlInput->rel.stick_y * 240.0f * invertYAxisMulti * yAxisMulti;
         }
         if (CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0)) {
@@ -12763,7 +12764,8 @@ s16 func_8084ABD8(PlayState* play, Player* this, s32 arg2, s16 arg3) {
 
         // X Axis
         temp2 = 0;
-        if (!(CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0) && CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0))) {
+        if (!(CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0) &&
+              CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0))) {
             temp2 += sControlInput->rel.stick_x * -16.0f * invertXAxisMulti * xAxisMulti;
         }
         if (CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0)) {
@@ -12778,7 +12780,8 @@ s16 func_8084ABD8(PlayState* play, Player* this, s32 arg2, s16 arg3) {
         // Y Axis
         temp1 = (this->stateFlags1 & PLAYER_STATE1_ON_HORSE) ? 3500 : 14000;
 
-        if (!(CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0) && CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0))) {
+        if (!(CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0) &&
+              CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0))) {
             temp3 += ((sControlInput->rel.stick_y >= 0) ? 1 : -1) *
                      (s32)((1.0f - Math_CosS(sControlInput->rel.stick_y * 200)) * 1500.0f) * invertYAxisMulti *
                      yAxisMulti;
@@ -12798,7 +12801,8 @@ s16 func_8084ABD8(PlayState* play, Player* this, s32 arg2, s16 arg3) {
         temp1 = 19114;
         temp2 = this->actor.focus.rot.y - this->actor.shape.rot.y;
         temp3 = 0;
-        if (!(CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0) && CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0))) {
+        if (!(CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0) &&
+              CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0))) {
             temp3 = ((sControlInput->rel.stick_x >= 0) ? 1 : -1) *
                     (s32)((1.0f - Math_CosS(sControlInput->rel.stick_x * 200)) * -1500.0f) * invertXAxisMulti *
                     xAxisMulti;
@@ -12815,7 +12819,8 @@ s16 func_8084ABD8(PlayState* play, Player* this, s32 arg2, s16 arg3) {
         this->actor.focus.rot.y = CLAMP(temp2, -temp1, temp1) + this->actor.shape.rot.y;
     }
 
-    if (CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0) && CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0)) {
+    if (CVarGetInteger(CVAR_SETTING("MoveInFirstPerson"), 0) &&
+        CVarGetInteger(CVAR_SETTING("Controls.RightStickAim"), 0)) {
         f32 movementSpeed = LINK_IS_ADULT ? 9.0f : 8.25f;
         if (CVarGetInteger(CVAR_ENHANCEMENT("MMBunnyHood"), BUNNY_HOOD_VANILLA) != BUNNY_HOOD_VANILLA &&
             this->currentMask == PLAYER_MASK_BUNNY) {


### PR DESCRIPTION
Gates First person movement behind the Right Stick Aiming cvar, so turning off right stick aiming won't leave you walking in first person with no way to aim

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5037152337.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5037160608.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5037240126.zip)
<!--- section:artifacts:end -->