### PR TITLE
disable fixed camera fix

### DIFF
--- a/soh/soh/Enhancements/Graphics/DisableFixedCamera.cpp
+++ b/soh/soh/Enhancements/Graphics/DisableFixedCamera.cpp
@@ -45,6 +45,8 @@ static int16_t sSetNormalCam = -1;
 static bool sIsCamApplied = false;
 static int sCheckItemCamState = -1;
 static s16 sStoreLastCamType = -1;
+static bool sWasEnabled = false;
+static bool sWaitForSceneChange = false;
 
 extern "C" void DisableFixedCamera_CheckCameraState(PlayState* play);
 
@@ -62,6 +64,8 @@ static void DisableFixedCamera_ResetState() {
     sIsCamApplied = false;
     sCheckItemCamState = -1;
     sStoreLastCamType = -1;
+    sWasEnabled = false;
+    sWaitForSceneChange = false;
 }
 
 static void DisableFixedCamera_RestoreAllCameraData() {
@@ -144,9 +148,27 @@ extern "C" void DisableFixedCamera_SetNormalCamera(PlayState* play) {
 extern "C" void DisableFixedCamera_CheckCameraState(PlayState* play) {
     const bool disableFixedCamEnabled = CVarGetInteger(CVAR_DISABLE_FIXED_CAMERA_NAME, 0) != 0;
     if (!disableFixedCamEnabled) {
-        CollisionHeader* colHeader = BgCheck_GetCollisionHeader(&play->colCtx, BGCHECK_SCENE);
-        DisableFixedCamera_RestoreCameraData(colHeader);
+        DisableFixedCamera_RestoreAllCameraData();
+        DisableFixedCamera_ResetState();
         return;
+    }
+    if (!sWasEnabled) {
+        sWasEnabled = true;
+        sWaitForSceneChange = true;
+        sSetNormalCam = play->sceneNum;
+        sIsCamApplied = true;
+        sCheckItemCamState = -1;
+        sStoreLastCamType = -1;
+        return;
+    }
+    if (sWaitForSceneChange) {
+        if (play->sceneNum == sSetNormalCam) {
+            return;
+        }
+        sWaitForSceneChange = false;
+        sIsCamApplied = false;
+        sCheckItemCamState = -1;
+        sStoreLastCamType = -1;
     }
     // prevents normal cam from taking effect during open cutscene to avoid crash
     if (play->sceneNum == SCENE_LINKS_HOUSE && gSaveContext.cutsceneIndex == 0xFFF1) {
@@ -160,11 +182,8 @@ extern "C" void DisableFixedCamera_CheckCameraState(PlayState* play) {
             sSetNormalCam = play->sceneNum;
             sIsCamApplied = false;
             sStoreLastCamType = -1;
-            // Clean up backups when leaving fixed camera scenes
-            for (auto& [key, backup] : sCamDataBackups) {
-                delete[] backup.copy;
-            }
-            sCamDataBackups.clear();
+            // Restore camera data when leaving fixed camera scenes
+            DisableFixedCamera_RestoreAllCameraData();
         }
         DisableFixedCamera_RestoreCameraData(BgCheck_GetCollisionHeader(&play->colCtx, BGCHECK_SCENE));
         return;

--- a/soh/soh/Enhancements/Graphics/DisableFixedCamera.cpp
+++ b/soh/soh/Enhancements/Graphics/DisableFixedCamera.cpp
@@ -157,9 +157,6 @@ extern "C" void DisableFixedCamera_CheckCameraState(PlayState* play) {
         sWaitForSceneChange = true;
         sSetNormalCam = play->sceneNum;
         sIsCamApplied = true;
-        sCheckItemCamState = -1;
-        sStoreLastCamType = -1;
-        return;
     }
     if (sWaitForSceneChange) {
         if (play->sceneNum == sSetNormalCam) {


### PR DESCRIPTION
small fix to #6083, the enhancement would take effect immediately upon turning it on rather than on scene change as it was intended so it could work seamlessly with disabling prerenders. also it wouldnt properly deactivate all the way when its turned off in gameplay, this fixes that too. my bad guys lol

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5030959733.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5031004138.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5031270917.zip)
<!--- section:artifacts:end -->