### PR TITLE
mod_menu: fix overflow error

### DIFF
--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -213,7 +213,7 @@ void DrawMods(bool enabled) {
     int switchToIndex = -1;
     uint32_t index = 0;
 
-    for (size_t i = selectedModFiles.size() - 1; i >= 0; i--) {
+    for (size_t i = selectedModFiles.size() - 1; i != SIZE_MAX; i--) {
         std::string file = selectedModFiles[i];
         if (enabled) {
             ImGui::BeginGroup();


### PR DESCRIPTION
size_t is unsigned, `>= 0` is always true