### PR TITLE
Fix memory leaks in MessageViewer and audio_load

### DIFF
--- a/soh/soh/Enhancements/debugger/MessageViewer.cpp
+++ b/soh/soh/Enhancements/debugger/MessageViewer.cpp
@@ -26,6 +26,12 @@ void MessageViewer::InitElement() {
     mCustomMessageBuf = static_cast<char*>(calloc(MAX_STRING_SIZE, sizeof(char)));
 }
 
+MessageViewer::~MessageViewer() {
+    free(mTableIdBuf);
+    free(mTextIdBuf);
+    free(mCustomMessageBuf);
+}
+
 void MessageViewer::DrawElement() {
     ImGui::BeginDisabled(CVarGetInteger(CVAR_SETTING("DisableChanges"), 0));
     ImGui::Text("Table ID");

--- a/soh/soh/Enhancements/debugger/MessageViewer.h
+++ b/soh/soh/Enhancements/debugger/MessageViewer.h
@@ -34,7 +34,7 @@ class MessageViewer final : public Ship::GuiWindow {
     void DrawElement() override;
     void UpdateElement() override;
 
-    virtual ~MessageViewer() = default;
+    ~MessageViewer() override;
 
   private:
     void DisplayExistingMessage() const;

--- a/soh/soh/ResourceManagerHelpers.cpp
+++ b/soh/soh/ResourceManagerHelpers.cpp
@@ -143,7 +143,7 @@ extern "C" void ResourceMgr_UnloadResource(const char* resName) {
 }
 
 // OTRTODO: There is probably a more elegant way to go about this...
-// Kenix: This is definitely leaking memory when it's called.
+// Caller must free each string and the array itself when done.
 extern "C" char** ResourceMgr_ListFiles(const char* searchMask, int* resultSize) {
     auto lst = Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->ListFiles(searchMask);
     char** result = (char**)malloc(lst->size() * sizeof(char*));

--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -1352,6 +1352,9 @@ void AudioLoad_Init(void* heap, size_t heapSize) {
         seqCachePolicyMap[sDat.seqNumber] = sDat.cachePolicy;
     }
 
+    for (int i = 0; i < seqListSize; i++) {
+        free(seqList[i]);
+    }
     free(seqList);
 
     // 2S2H [Streamed Audio] We need to load the custom songs after the fonts because streamed songs will use a hash to
@@ -1369,6 +1372,9 @@ void AudioLoad_Init(void* heap, size_t heapSize) {
         fontMap[sf->fntIndex] = strdup(fntList[i]);
     }
 
+    for (int i = 0; i < fntListSize; i++) {
+        free(fntList[i]);
+    }
     free(fntList);
 
     int customFontStart = fntListSize;
@@ -1376,6 +1382,9 @@ void AudioLoad_Init(void* heap, size_t heapSize) {
         SoundFont* sf = ResourceMgr_LoadAudioSoundFontByName(customFntList[i - customFontStart]);
         sf->fntIndex = i;
         fontMap[i] = strdup(customFntList[i - customFontStart]);
+    }
+    for (int i = 0; i < customFntListSize; i++) {
+        free(customFntList[i]);
     }
     free(customFntList);
 
@@ -1432,6 +1441,9 @@ void AudioLoad_Init(void* heap, size_t heapSize) {
         seqNum++;
     }
 
+    for (int i = 0; i < customSeqListSize; i++) {
+        free(customSeqList[i]);
+    }
     free(customSeqList);
 
     numFonts = fntListSize;


### PR DESCRIPTION
- Add destructor to MessageViewer to free allocated buffers
- Free individual strings from ResourceMgr_ListFiles before freeing the array in audio_load.c
- Update ResourceMgr_ListFiles comment to document caller responsibility

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5085031029.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5085035755.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5085051594.zip)
<!--- section:artifacts:end -->