### PR TITLE
Make Deku Tree's falling platform respawn in rando

### DIFF
--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -2018,6 +2018,9 @@ void RandomizerOnActorInitHandler(void* actorRef) {
                 if (!isVanilla && Flags_GetRandomizerInf(RAND_INF_DEKU_TREE_MQ_TORCH_SWITCH)) {
                     Flags_SetSwitch(gPlayState, 0x27);
                 }
+                if (isVanilla) { // make falling platform respawn
+                    Flags_UnsetSwitch(gPlayState, 0x14);
+                }
                 break;
             case SCENE_DODONGOS_CAVERN:
                 if (!isVanilla && Flags_GetRandomizerInf(RAND_INF_DODONGOS_CAVERN_MQ_SILVER_RUPEES)) {


### PR DESCRIPTION
Relevant in Shuffle Climb, where getting to chest would not be able to logically use platform

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5086586408.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5086591175.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5086610128.zip)
<!--- section:artifacts:end -->