### PR TITLE
Can always bribe the Hyrule Castle guard in randomiser.

### DIFF
--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -267,7 +267,7 @@ typedef enum {
     // true
     // ```
     // #### `args`
-    // - ``
+    // - `*EnHeishi2`
     VB_CAN_BRIBE_HEISHI2,
 
     // #### `result`

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -267,6 +267,14 @@ typedef enum {
     // true
     // ```
     // #### `args`
+    // - ``
+    VB_CAN_BRIBE_HEISHI2,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
     // - `int32_t` (item)
     VB_CHANGE_HELD_ITEM_AND_USE_ITEM,
 

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -57,6 +57,7 @@ extern "C" {
 #include "src/overlays/actors/ovl_Fishing/z_fishing.h"
 #include "src/overlays/actors/ovl_En_Mk/z_en_mk.h"
 #include "src/overlays/actors/ovl_Obj_Bean/z_obj_bean.h"
+#include "src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.h"
 #include "draw.h"
 
 static ObjectExtension::Register<DnsItemEntry> RegisterDnsItemEntryOverride;
@@ -842,6 +843,8 @@ void RandomizerOnDialogMessageHandler() {
     }
 }
 
+extern "C" void func_80A5475C(EnHeishi2* CastleGuard, PlayState* play);
+
 void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_list originalArgs) {
     va_list args;
     va_copy(args, originalArgs);
@@ -946,6 +949,15 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
             } else if (RAND_GET_OPTION(RSK_SKIP_PLANTING_BEANS)) {
                 *should = gSaveContext.rupees >= 60;
             }
+            break;
+        }
+        case VB_CAN_BRIBE_HEISHI2: {
+            EnHeishi2* guard = va_arg(args, EnHeishi2*);
+            guard->actor.textId = 0x7072;
+            guard->unk_300 = TEXT_STATE_CHOICE;
+            guard->unk_30E = 1;
+            guard->actionFunc = func_80A5475C;
+            *should = false;
             break;
         }
         case VB_GIVE_ITEM_MASTER_SWORD:

--- a/soh/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/soh/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -189,52 +189,54 @@ void func_80A531E4(EnHeishi2* this, PlayState* play) {
 void func_80A53278(EnHeishi2* this, PlayState* play) {
     this->unk_30B = 0;
     this->unk_30E = 0;
-    if (Text_GetFaceReaction(play, 5) != 0) {
-        this->actor.textId = Text_GetFaceReaction(play, 5);
-        this->unk_30B = 1;
-        this->unk_300 = TEXT_STATE_DONE;
-        this->actionFunc = func_80A5475C;
-    } else if ((Flags_GetEventChkInf(EVENTCHKINF_USED_DEKU_TREE_BLUE_WARP)) &&
-               (Flags_GetEventChkInf(EVENTCHKINF_USED_DODONGOS_CAVERN_BLUE_WARP)) &&
-               (Flags_GetEventChkInf(EVENTCHKINF_USED_JABU_JABUS_BELLY_BLUE_WARP))) {
-        // "Get all spiritual stones!"
-        osSyncPrintf(VT_FGCOL(GREEN) " ☆☆☆☆☆ 全部の精霊石GET！ ☆☆☆☆☆ \n" VT_RST);
-        this->unk_300 = TEXT_STATE_DONE;
-        this->actor.textId = 0x7006;
-        this->actionFunc = func_80A5475C;
-    } else if (!IS_DAY) {
-        // "Sleep early for children!"
-        osSyncPrintf(VT_FGCOL(YELLOW) " ☆☆☆☆☆ 子供ははやくネロ！ ☆☆☆☆☆ \n" VT_RST);
-        this->unk_300 = TEXT_STATE_DONE;
-        this->actor.textId = 0x7002;
-        this->actionFunc = func_80A5475C;
+    if (GameInteractor_Should(VB_CAN_BRIBE_HEISHI2, true, this)) {
+        if (Text_GetFaceReaction(play, 5) != 0) {
+            this->actor.textId = Text_GetFaceReaction(play, 5);
+            this->unk_30B = 1;
+            this->unk_300 = TEXT_STATE_DONE;
+            this->actionFunc = func_80A5475C;
+        } else if ((Flags_GetEventChkInf(EVENTCHKINF_USED_DEKU_TREE_BLUE_WARP)) &&
+                   (Flags_GetEventChkInf(EVENTCHKINF_USED_DODONGOS_CAVERN_BLUE_WARP)) &&
+                   (Flags_GetEventChkInf(EVENTCHKINF_USED_JABU_JABUS_BELLY_BLUE_WARP))) {
+            // "Get all spiritual stones!"
+            osSyncPrintf(VT_FGCOL(GREEN) " ☆☆☆☆☆ 全部の精霊石GET！ ☆☆☆☆☆ \n" VT_RST);
+            this->unk_300 = TEXT_STATE_DONE;
+            this->actor.textId = 0x7006;
+            this->actionFunc = func_80A5475C;
+        } else if (!IS_DAY) {
+            // "Sleep early for children!"
+            osSyncPrintf(VT_FGCOL(YELLOW) " ☆☆☆☆☆ 子供ははやくネロ！ ☆☆☆☆☆ \n" VT_RST);
+            this->unk_300 = TEXT_STATE_DONE;
+            this->actor.textId = 0x7002;
+            this->actionFunc = func_80A5475C;
 
-    } else if (this->unk_30C != 0) {
-        // "Anything passes"
-        osSyncPrintf(VT_FGCOL(BLUE) " ☆☆☆☆☆ なんでも通るよ ☆☆☆☆☆ \n" VT_RST);
-        this->unk_300 = TEXT_STATE_DONE;
-        this->actor.textId = 0x7099;
-        this->actionFunc = func_80A5475C;
-    } else if (Flags_GetEventChkInf(EVENTCHKINF_OBTAINED_POCKET_EGG)) {
-        if (this->unk_30E == 0) {
-            // "Start under the first sleeve!"
-            osSyncPrintf(VT_FGCOL(PURPLE) " ☆☆☆☆☆ １回目袖の下開始！ ☆☆☆☆☆ \n" VT_RST);
-            this->actor.textId = 0x7071;
-            this->unk_30E = 1;
+        } else if (this->unk_30C != 0) {
+            // "Anything passes"
+            osSyncPrintf(VT_FGCOL(BLUE) " ☆☆☆☆☆ なんでも通るよ ☆☆☆☆☆ \n" VT_RST);
+            this->unk_300 = TEXT_STATE_DONE;
+            this->actor.textId = 0x7099;
+            this->actionFunc = func_80A5475C;
+        } else if (Flags_GetEventChkInf(EVENTCHKINF_OBTAINED_POCKET_EGG)) {
+            if (this->unk_30E == 0) {
+                // "Start under the first sleeve!"
+                osSyncPrintf(VT_FGCOL(PURPLE) " ☆☆☆☆☆ １回目袖の下開始！ ☆☆☆☆☆ \n" VT_RST);
+                this->actor.textId = 0x7071;
+                this->unk_30E = 1;
+            } else {
+                // "Start under the second sleeve!"
+                osSyncPrintf(VT_FGCOL(PURPLE) " ☆☆☆☆☆ ２回目袖の下開始！ ☆☆☆☆☆ \n" VT_RST);
+                this->actor.textId = 0x7072;
+            }
+            this->unk_300 = TEXT_STATE_CHOICE;
+            this->actionFunc = func_80A5475C;
+
         } else {
-            // "Start under the second sleeve!"
-            osSyncPrintf(VT_FGCOL(PURPLE) " ☆☆☆☆☆ ２回目袖の下開始！ ☆☆☆☆☆ \n" VT_RST);
-            this->actor.textId = 0x7072;
+            // "That's okay"
+            osSyncPrintf(VT_FGCOL(CYAN) " ☆☆☆☆☆ それはとおらんよぉ ☆☆☆☆☆ \n" VT_RST);
+            this->unk_300 = TEXT_STATE_DONE;
+            this->actor.textId = 0x7029;
+            this->actionFunc = func_80A5475C;
         }
-        this->unk_300 = TEXT_STATE_CHOICE;
-        this->actionFunc = func_80A5475C;
-
-    } else {
-        // "That's okay"
-        osSyncPrintf(VT_FGCOL(CYAN) " ☆☆☆☆☆ それはとおらんよぉ ☆☆☆☆☆ \n" VT_RST);
-        this->unk_300 = TEXT_STATE_DONE;
-        this->actor.textId = 0x7029;
-        this->actionFunc = func_80A5475C;
     }
 }
 


### PR DESCRIPTION
In preparation for Shuffle Climb, this makes sure that you can always bribe the gate guard near the start of Hyrule Castle Grounds. This is an obscure vanilla feature that is usually open only during the day, and only between obtaining Malon's egg and using all 3 child blue warps. The current implementation removes all requirements, however the Malon requirement may want to be re-added as it is a vanilla requirement to enable bribing normally.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5086884678.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5086885000.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5086969162.zip)
<!--- section:artifacts:end -->