### PR TITLE
Add GFX Stack to crash handler ext

### DIFF
--- a/soh/soh/CrashHandlerExt.cpp
+++ b/soh/soh/CrashHandlerExt.cpp
@@ -5,6 +5,8 @@
 #include <string.h>
 #include <stdio.h>
 #include <array>
+#include "soh/ActorDB.h"
+#include <fast/interpreter.h>
 
 #define WRITE_VAR_LINE(buff, len, varName, varValue) \
     append_str(buff, len, varName);                  \
@@ -40,7 +42,6 @@ static void append_line(char* buf, size_t* len, const char* str) {
 
 static void CrashHandler_WriteActorData(char* buffer, size_t* pos) {
     char intCharBuffer[16];
-    append_line(buffer, pos, "Actor Id      Params");
     for (unsigned int i = 0; i < ACTORCAT_MAX; i++) {
 
         ActorListEntry* entry = &gPlayState->actorCtx.actorLists[i];
@@ -49,16 +50,15 @@ static void CrashHandler_WriteActorData(char* buffer, size_t* pos) {
         if (entry->length == 0) {
             continue;
         }
-        WRITE_VAR_LINE(buffer, pos, "Actor Cat: ", sCatToStrArray[i]);
+        WRITE_VAR_LINE(buffer, pos, "  Category: ", sCatToStrArray[i]);
         cur = entry->head;
         while (cur != nullptr) {
-            // Actor ID
-            snprintf(intCharBuffer, sizeof(intCharBuffer), "0x%03X       ", cur->id);
-            append_str(buffer, pos, intCharBuffer);
-
-            // Actor Params
-            snprintf(intCharBuffer, sizeof(intCharBuffer), "0x%04X", cur->params);
-            append_line(buffer, pos, intCharBuffer);
+            std::string actorLine = "    ";
+            actorLine += ActorDB::Instance->RetrieveEntry(cur->id).entry.valid
+                             ? ActorDB::Instance->RetrieveEntry(cur->id).entry.desc
+                             : "???";
+            actorLine += " (" + std::to_string(cur->params) + ")";
+            append_line(buffer, pos, actorLine.c_str());
 
             cur = cur->next;
         }
@@ -68,18 +68,27 @@ static void CrashHandler_WriteActorData(char* buffer, size_t* pos) {
 extern "C" void CrashHandler_PrintSohData(char* buffer, size_t* pos) {
     char intCharBuffer[16];
     append_line(buffer, pos, "Build Information:");
-    WRITE_VAR_LINE(buffer, pos, "Game Version: ", (const char*)gBuildVersion);
-    WRITE_VAR_LINE(buffer, pos, "Git Branch: ", (const char*)gGitBranch);
-    WRITE_VAR_LINE(buffer, pos, "Git Commit: ", (const char*)gGitCommitHash);
-    WRITE_VAR_LINE(buffer, pos, "Build Date: ", (const char*)gBuildDate);
+    WRITE_VAR_LINE(buffer, pos, "  Game Version: ", (const char*)gBuildVersion);
+    WRITE_VAR_LINE(buffer, pos, "  Git Branch: ", (const char*)gGitBranch);
+    WRITE_VAR_LINE(buffer, pos, "  Git Commit: ", (const char*)gGitCommitHash);
+    WRITE_VAR_LINE(buffer, pos, "  Build Date: ", (const char*)gBuildDate);
 
     if (gPlayState != nullptr) {
-        append_line(buffer, pos, "Actors:");
-        CrashHandler_WriteActorData(buffer, pos);
-
         WRITE_VAR_LINE(buffer, pos, "Scene: ", sSceneIdToStrArray[gPlayState->sceneNum]);
 
         snprintf(intCharBuffer, sizeof(intCharBuffer), "%i", gPlayState->roomCtx.curRoom.num);
         WRITE_VAR_LINE(buffer, pos, "Room: ", intCharBuffer);
+
+        append_line(buffer, pos, "Actors:");
+        CrashHandler_WriteActorData(buffer, pos);
+
+        append_line(buffer, pos, "GFX Stack:");
+        for (auto& disp : Fast::g_exec_stack.disp_stack) {
+            std::string line = "  ";
+            line += disp.file;
+            line += ":";
+            line += std::to_string(disp.line);
+            append_line(buffer, pos, line.c_str());
+        }
     }
 }


### PR DESCRIPTION
Not sure if there's an easy way to test this right now on SoH, but GFX stack traces have always been rather useless, printing out the current GFX stack should be much more helpful in narrowing down where the crash came from.

Example useless Stack trace from 2ship:
```
Traceback:
    Fast::gfx_modify_vtx_handler_f3dex2 in D:\a\2ship2harkinian\2ship2harkinian\libultraship\src\fast\interpreter.cpp Line: 3074
    Fast::gfx_step in D:\a\2ship2harkinian\2ship2harkinian\libultraship\src\fast\interpreter.cpp Line: 4149
    Fast::Interpreter::Run in D:\a\2ship2harkinian\2ship2harkinian\libultraship\src\fast\interpreter.cpp Line: 4363
    Fast::Fast3dWindow::DrawAndRunGraphicsCommands in D:\a\2ship2harkinian\2ship2harkinian\libultraship\src\fast\Fast3dWindow.cpp Line: 201
    Graph_ProcessGfxCommands in D:\a\2ship2harkinian\2ship2harkinian\mm\2s2h\BenPort.cpp Line: 968
    Graph_ExecuteAndDraw in D:\a\2ship2harkinian\2ship2harkinian\mm\src\code\graph.c Line: 335
```

With new GFX stack added:
```
GFX Stack:
  D:\a\2ship2harkinian\2ship2harkinian\mm\src\code\z_play.c:1226
  D:\a\2ship2harkinian\2ship2harkinian\mm\src\code\z_actor.c:3383
  D:\a\2ship2harkinian\2ship2harkinian\mm\src\code\z_actor.c:2923
  D:\a\2ship2harkinian\2ship2harkinian\mm\2s2h\Rando\DrawFuncs.cpp:363
  D:\a\2ship2harkinian\2ship2harkinian\mm\src\code\z_skelanime.c:325
  D:\a\2ship2harkinian\2ship2harkinian\mm\src\code\z_skelanime.c:270
```

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5087593843.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5087598872.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5087616479.zip)
<!--- section:artifacts:end -->