### PR TITLE
Add Clear List button to Mod Menu

### DIFF
--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -310,6 +310,16 @@ void ModMenuWindow::DrawElement() {
             UpdateModFiles(false, true);
         }
         ImGui::SameLine();
+        if (UIWidgets::Button("Clear List", UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline))) {
+            SohGui::RegisterPopup("Clear List",
+                                  "Clear the current mod list and force a rebuild on next boot.\nClick Apply & Close "
+                                  "to save this change on exit.",
+                                  "OK", "Cancel", [&]() {
+                                      enabledModFiles.clear();
+                                      AfterModChange();
+                                  });
+        }
+        ImGui::SameLine();
         if (UIWidgets::Button("Apply & Close",
                               UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline).Color(THEME_COLOR))) {
             SohGui::RegisterPopup("Apply & Close",
@@ -325,25 +335,6 @@ void ModMenuWindow::DrawElement() {
                                       Ship::Context::GetInstance()->GetConsoleVariables()->Save();
                                       Ship::Context::GetInstance()->GetWindow()->Close();
                                   });
-        }
-        ImGui::SameLine();
-        float clearButtonWidth =
-            ImGui::CalcTextSize("Clear List & Close").x + (ImGui::GetStyle().FramePadding.x * 2.0f);
-        float rightX = ImGui::GetContentRegionMax().x - clearButtonWidth - ImGui::GetStyle().WindowPadding.x - 4.0f;
-        if (rightX > ImGui::GetCursorPosX()) {
-            ImGui::SetCursorPosX(rightX);
-        }
-        if (UIWidgets::Button("Clear List & Close",
-                              UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline).Color(THEME_COLOR))) {
-            SohGui::RegisterPopup(
-                "Clear List & Close",
-                "Clear the current mod order and rebuilds it on next startup.\nThis action is not reversible.", "Close",
-                "Cancel", [&]() {
-                    enabledModFiles.clear();
-                    SetEnabledModsCVarValue();
-                    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
-                    Ship::Context::GetInstance()->GetWindow()->Close();
-                });
         }
     }
     ImGui::BeginDisabled(!editing);

--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -313,8 +313,8 @@ void ModMenuWindow::DrawElement() {
         if (UIWidgets::Button("Clear List", UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline))) {
             SohGui::RegisterPopup("Clear List",
                                   "Clear the current mod list and force a rebuild on next boot.\nClick Apply & Close "
-                                  "to save this change on exit.",
-                                  "OK", "Cancel", [&]() {
+                                  "to save this change.",
+                                  "OK", "", [&]() {
                                       enabledModFiles.clear();
                                       AfterModChange();
                                   });

--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -326,6 +326,25 @@ void ModMenuWindow::DrawElement() {
                                       Ship::Context::GetInstance()->GetWindow()->Close();
                                   });
         }
+        ImGui::SameLine();
+        float clearButtonWidth =
+            ImGui::CalcTextSize("Clear List & Close").x + (ImGui::GetStyle().FramePadding.x * 2.0f);
+        float rightX = ImGui::GetContentRegionMax().x - clearButtonWidth - ImGui::GetStyle().WindowPadding.x - 4.0f;
+        if (rightX > ImGui::GetCursorPosX()) {
+            ImGui::SetCursorPosX(rightX);
+        }
+        if (UIWidgets::Button("Clear List & Close",
+                              UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline).Color(THEME_COLOR))) {
+            SohGui::RegisterPopup(
+                "Clear List & Close",
+                "Clear the current mod order and rebuilds it on next startup.\nThis action is not reversible.", "Close",
+                "Cancel", [&]() {
+                    enabledModFiles.clear();
+                    SetEnabledModsCVarValue();
+                    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+                    Ship::Context::GetInstance()->GetWindow()->Close();
+                });
+        }
     }
     ImGui::BeginDisabled(!editing);
     if (ImGui::BeginTable("tableMods", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {

--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -314,7 +314,7 @@ void ModMenuWindow::DrawElement() {
             SohGui::RegisterPopup("Clear List",
                                   "Clear the current mod list and force a rebuild on next boot.\nClick Apply & Close "
                                   "to save this change.",
-                                  "OK", "", [&]() {
+                                  "Clear", "Cancel", [&]() {
                                       enabledModFiles.clear();
                                       AfterModChange();
                                   });


### PR DESCRIPTION
A simple pr to add a button to mod menu to clear list and close ship to rebuild modlist to default ordering.

Just something i wanted as i already do my mods in order inside the mods folder and just want an easy way to rebuild the mod list.

I fully understand if this is not of interest.

<img width="1124" height="214" alt="image" src="https://github.com/user-attachments/assets/80b51605-b86c-4138-b735-a230aa78679f" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5130550596.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5130578033.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5130643338.zip)
<!--- section:artifacts:end -->