### PR TITLE
Owl Travel cutscenes skipped as Story cutscenes

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/SkipCutscene/SkipOwlTravel.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipCutscene/SkipOwlTravel.cpp
@@ -11,7 +11,7 @@ extern SaveContext gSaveContext;
 u8 Randomizer_GetSettingValue(RandomizerSettingKey randoSettingKey);
 }
 
-#define CVAR_NAME CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.Story")
+#define CVAR_NAME CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.OnePoint")
 #define CVAR_VALUE CVarGetInteger(CVAR_NAME, 0)
 
 static s16 GetEntranceIndex(s32 owlType) {

--- a/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipOwlTravel.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipOwlTravel.cpp
@@ -18,16 +18,16 @@ static s16 GetEntranceIndex(s32 owlType) {
     s16 entranceIndex;
 
     switch (owlType) {
-    case 7:
-        entranceIndex = ENTR_HYRULE_FIELD_OWL_DROP;
-        break;
-    case 8:
-    case 9:
-        entranceIndex = ENTR_KAKARIKO_VILLAGE_OWL_DROP;
-        break;
-    default:
-        assert(0);
-        return ENTR_MAX;
+        case 7:
+            entranceIndex = ENTR_HYRULE_FIELD_OWL_DROP;
+            break;
+        case 8:
+        case 9:
+            entranceIndex = ENTR_KAKARIKO_VILLAGE_OWL_DROP;
+            break;
+        default:
+            assert(0);
+            return ENTR_MAX;
     }
 
     if (IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_OWL_DROPS)) {
@@ -46,9 +46,9 @@ static void SkipOwlTravel(s32 owlType) {
 static void RegisterSkipOwlTravel() {
     COND_VB_SHOULD(VB_PLAY_OWL_TRAVEL_CS, CVAR_VALUE || IS_RANDO, {
         s32 owlType = va_arg(args, s32);
-    SkipOwlTravel(owlType);
-    *should = false;
-        });
+        SkipOwlTravel(owlType);
+        *should = false;
+    });
 }
 
 static RegisterShipInitFunc initFunc(RegisterSkipOwlTravel, { CVAR_NAME, "IS_RANDO" });

--- a/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipOwlTravel.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipOwlTravel.cpp
@@ -1,0 +1,54 @@
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/Enhancements/randomizer/randomizer_entrance.h"
+#include "soh/ShipInit.hpp"
+#include <cassert>
+
+extern "C" {
+#include "z64save.h"
+extern PlayState* gPlayState;
+extern SaveContext gSaveContext;
+
+u8 Randomizer_GetSettingValue(RandomizerSettingKey randoSettingKey);
+}
+
+#define CVAR_NAME CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.Story")
+#define CVAR_VALUE CVarGetInteger(CVAR_NAME, 0)
+
+static s16 GetEntranceIndex(s32 owlType) {
+    s16 entranceIndex;
+
+    switch (owlType) {
+    case 7:
+        entranceIndex = ENTR_HYRULE_FIELD_OWL_DROP;
+        break;
+    case 8:
+    case 9:
+        entranceIndex = ENTR_KAKARIKO_VILLAGE_OWL_DROP;
+        break;
+    default:
+        assert(0);
+        return ENTR_MAX;
+    }
+
+    if (IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_OWL_DROPS)) {
+        entranceIndex = Entrance_OverrideNextIndex(entranceIndex);
+    }
+
+    return entranceIndex;
+}
+
+static void SkipOwlTravel(s32 owlType) {
+    gPlayState->nextEntranceIndex = GetEntranceIndex(owlType);
+    gPlayState->transitionTrigger = TRANS_TRIGGER_START;
+    gPlayState->transitionType = TRANS_TYPE_FADE_BLACK;
+}
+
+static void RegisterSkipOwlTravel() {
+    COND_VB_SHOULD(VB_PLAY_OWL_TRAVEL_CS, CVAR_VALUE || IS_RANDO, {
+        s32 owlType = va_arg(args, s32);
+    SkipOwlTravel(owlType);
+    *should = false;
+        });
+}
+
+static RegisterShipInitFunc initFunc(RegisterSkipOwlTravel, { CVAR_NAME, "IS_RANDO" });

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -1708,6 +1708,14 @@ typedef enum {
     // true
     // ```
     // #### `args`
+    // - `int32_t` (owl type)
+    VB_PLAY_OWL_TRAVEL_CS,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
     // - None
     VB_PLAY_PRELUDE_OF_LIGHT_CS,
 

--- a/soh/src/overlays/actors/ovl_En_Owl/z_en_owl.c
+++ b/soh/src/overlays/actors/ovl_En_Owl/z_en_owl.c
@@ -10,7 +10,6 @@
 #include "scenes/overworld/spot16/spot16_scene.h"
 #include "vt.h"
 #include <assert.h>
-#include "soh/OTRGlobals.h"
 #include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
@@ -941,42 +940,24 @@ void func_80ACC00C(EnOwl* this, PlayState* play) {
             osSyncPrintf(VT_FGCOL(CYAN));
             osSyncPrintf("%dのフクロウ\n", owlType); // "%d owl"
             osSyncPrintf(VT_RST);
-            switch (owlType) {
+            if (GameInteractor_Should(VB_PLAY_OWL_TRAVEL_CS, true, owlType)) {
+                switch (owlType) {
                 case 7:
                     osSyncPrintf(VT_FGCOL(CYAN));
                     osSyncPrintf("SPOT 06 の デモがはしった\n"); // "Demo of SPOT 06 has been completed"
                     osSyncPrintf(VT_RST);
-                    if (IS_RANDO) {
-                        if (Randomizer_GetSettingValue(RSK_SHUFFLE_OWL_DROPS)) {
-                            play->nextEntranceIndex = Entrance_OverrideNextIndex(ENTR_HYRULE_FIELD_OWL_DROP);
-                        } else {
-                            play->nextEntranceIndex = ENTR_HYRULE_FIELD_OWL_DROP;
-                        }
-                        play->transitionTrigger = TRANS_TRIGGER_START;
-                        play->transitionType = TRANS_TYPE_FADE_BLACK;
-                        break;
-                    }
                     play->csCtx.segment = SEGMENTED_TO_VIRTUAL(gLakeHyliaOwlCs);
                     this->actor.draw = NULL;
                     break;
                 case 8:
                 case 9:
-                    if (IS_RANDO) {
-                        if (Randomizer_GetSettingValue(RSK_SHUFFLE_OWL_DROPS)) {
-                            play->nextEntranceIndex = Entrance_OverrideNextIndex(ENTR_KAKARIKO_VILLAGE_OWL_DROP);
-                        } else {
-                            play->nextEntranceIndex = ENTR_KAKARIKO_VILLAGE_OWL_DROP;
-                        }
-                        play->transitionTrigger = TRANS_TRIGGER_START;
-                        play->transitionType = TRANS_TYPE_FADE_BLACK;
-                        break;
-                    }
                     play->csCtx.segment = SEGMENTED_TO_VIRTUAL(gDMTOwlCs);
                     this->actor.draw = NULL;
                     break;
                 default:
                     assert(0);
                     break;
+                }
             }
 
             Sfx_PlaySfxCentered(NA_SE_SY_TRE_BOX_APPEAR);

--- a/soh/src/overlays/actors/ovl_En_Owl/z_en_owl.c
+++ b/soh/src/overlays/actors/ovl_En_Owl/z_en_owl.c
@@ -942,21 +942,21 @@ void func_80ACC00C(EnOwl* this, PlayState* play) {
             osSyncPrintf(VT_RST);
             if (GameInteractor_Should(VB_PLAY_OWL_TRAVEL_CS, true, owlType)) {
                 switch (owlType) {
-                case 7:
-                    osSyncPrintf(VT_FGCOL(CYAN));
-                    osSyncPrintf("SPOT 06 の デモがはしった\n"); // "Demo of SPOT 06 has been completed"
-                    osSyncPrintf(VT_RST);
-                    play->csCtx.segment = SEGMENTED_TO_VIRTUAL(gLakeHyliaOwlCs);
-                    this->actor.draw = NULL;
-                    break;
-                case 8:
-                case 9:
-                    play->csCtx.segment = SEGMENTED_TO_VIRTUAL(gDMTOwlCs);
-                    this->actor.draw = NULL;
-                    break;
-                default:
-                    assert(0);
-                    break;
+                    case 7:
+                        osSyncPrintf(VT_FGCOL(CYAN));
+                        osSyncPrintf("SPOT 06 の デモがはしった\n"); // "Demo of SPOT 06 has been completed"
+                        osSyncPrintf(VT_RST);
+                        play->csCtx.segment = SEGMENTED_TO_VIRTUAL(gLakeHyliaOwlCs);
+                        this->actor.draw = NULL;
+                        break;
+                    case 8:
+                    case 9:
+                        play->csCtx.segment = SEGMENTED_TO_VIRTUAL(gDMTOwlCs);
+                        this->actor.draw = NULL;
+                        break;
+                    default:
+                        assert(0);
+                        break;
                 }
             }
 


### PR DESCRIPTION
Closes #6140

Added a VB hook to handle these cutscenes, also unifying them with the rando code, which can now be removed from the vanilla source.

https://github.com/user-attachments/assets/d313d838-a4b6-45a4-baae-2ceb5eb96a5d

https://github.com/user-attachments/assets/a01172f8-c0d1-488e-a87c-d88ba552d516



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5144474450.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5144510146.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5145016005.zip)
<!--- section:artifacts:end -->