### PR TITLE
Fix boss souls on item tracker

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -755,6 +755,14 @@ void DrawQuest(ItemTrackerItem item) {
     Tooltip(SohUtils::GetQuestItemName(item.id).c_str());
 };
 
+bool HasBossSoul(RandomizerInf bossSoul) {
+    uint8_t soulSetting = OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_SHUFFLE_BOSS_SOULS);
+    bool isSoulRandomized = IS_RANDO && (soulSetting == RO_BOSS_SOULS_ON_PLUS_GANON ||
+                                         (soulSetting == RO_BOSS_SOULS_ON && bossSoul != RAND_INF_GANON_SOUL));
+
+    return isSoulRandomized ? Flags_GetRandomizerInf(bossSoul) : true;
+}
+
 void DrawItem(ItemTrackerItem item) {
 
     uint32_t actualItemId = GameInteractor::IsSaveLoaded() ? INV_CONTENT(item.id) : ITEM_NONE;
@@ -811,50 +819,47 @@ void DrawItem(ItemTrackerItem item) {
             break;
         case RG_GOHMA_SOUL:
             actualItemId = item.id;
-            hasItem = Flags_GetRandomizerInf(RAND_INF_GOHMA_SOUL);
+            hasItem = HasBossSoul(RAND_INF_GOHMA_SOUL);
             itemName = "Gohma's Soul";
             break;
         case RG_KING_DODONGO_SOUL:
             actualItemId = item.id;
-            hasItem = Flags_GetRandomizerInf(RAND_INF_KING_DODONGO_SOUL);
+            hasItem = HasBossSoul(RAND_INF_KING_DODONGO_SOUL);
             itemName = "King Dodongo's Soul";
             break;
         case RG_BARINADE_SOUL:
             actualItemId = item.id;
-            hasItem = Flags_GetRandomizerInf(RAND_INF_BARINADE_SOUL);
+            hasItem = HasBossSoul(RAND_INF_BARINADE_SOUL);
             itemName = "Barinade's Soul";
             break;
         case RG_PHANTOM_GANON_SOUL:
             actualItemId = item.id;
-            hasItem = Flags_GetRandomizerInf(RAND_INF_PHANTOM_GANON_SOUL);
+            hasItem = HasBossSoul(RAND_INF_PHANTOM_GANON_SOUL);
             itemName = "Phantom Ganon's Soul";
             break;
         case RG_VOLVAGIA_SOUL:
             actualItemId = item.id;
-            hasItem = Flags_GetRandomizerInf(RAND_INF_VOLVAGIA_SOUL);
+            hasItem = HasBossSoul(RAND_INF_VOLVAGIA_SOUL);
             itemName = "Volvagia's Soul";
             break;
         case RG_MORPHA_SOUL:
             actualItemId = item.id;
-            hasItem = Flags_GetRandomizerInf(RAND_INF_MORPHA_SOUL);
+            hasItem = HasBossSoul(RAND_INF_MORPHA_SOUL);
             itemName = "Morpha's Soul";
             break;
         case RG_BONGO_BONGO_SOUL:
             actualItemId = item.id;
-            hasItem = Flags_GetRandomizerInf(RAND_INF_BONGO_BONGO_SOUL);
+            hasItem = HasBossSoul(RAND_INF_BONGO_BONGO_SOUL);
             itemName = "Bongo Bongo's Soul";
             break;
         case RG_TWINROVA_SOUL:
             actualItemId = item.id;
-            hasItem = Flags_GetRandomizerInf(RAND_INF_TWINROVA_SOUL);
+            hasItem = HasBossSoul(RAND_INF_TWINROVA_SOUL);
             itemName = "Twinrova's Soul";
             break;
         case RG_GANON_SOUL:
             actualItemId = item.id;
-            hasItem = OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_SHUFFLE_BOSS_SOULS) ==
-                              RO_BOSS_SOULS_ON_PLUS_GANON
-                          ? Flags_GetRandomizerInf(RAND_INF_GANON_SOUL)
-                          : true;
+            hasItem = HasBossSoul(RAND_INF_GANON_SOUL);
             itemName = "Ganon's Soul";
             break;
 


### PR DESCRIPTION
It only showed ganon's soul as obtained when it wasn't shuffled. This now correctly reflects the souls being "obtained" when they aren't shuffled.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5138246969.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5138249487.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5138413849.zip)
<!--- section:artifacts:end -->