### PR TITLE
Don't put unshuffled master sword into spoiler playthrough

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -4,7 +4,6 @@
 #include "../SeedContext.h"
 #include "item_pool.hpp"
 #include "random.hpp"
-#include "spoiler_log.hpp"
 #include "starting_inventory.hpp"
 #include "hints.hpp"
 #include "shops.hpp"
@@ -757,7 +756,7 @@ static void CalculateWotH() {
             // necessary, so add it unless it is in Links Pocket or an isolated place.
             auto itemLoc = ctx->GetItemLocation(ctx->playthroughLocations[i][j]);
             if (itemLoc->IsHintable() && itemLoc->GetFirstArea() > RA_LINKS_POCKET &&
-                !(IsBeatableWithout(ctx->playthroughLocations[i][j], true))) {
+                !IsBeatableWithout(ctx->playthroughLocations[i][j], true)) {
                 itemLoc->SetWothCandidate();
             }
         }

--- a/soh/soh/Enhancements/randomizer/3drando/fill.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.hpp
@@ -5,7 +5,6 @@
 #include "../entrance.h"
 
 #include <vector>
-#include <string>
 
 // RANDOTODO merge into Logic once Logic is a class passed to logic funtions
 struct GetAccessibleLocationsStruct {

--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -6,7 +6,6 @@
 #include "fill.hpp"
 #include "../trial.h"
 #include "../entrance.h"
-#include "z64item.h"
 #include <spdlog/spdlog.h>
 #include "../randomizerTypes.h"
 #include "pool_functions.hpp"
@@ -649,7 +648,7 @@ void CreateStoneHints() {
     if (ctx->GetOption(RSK_SKIP_CHILD_ZELDA)) {
         ctx->GetItemLocation(RC_SONG_FROM_IMPA)->SetHintAccesible();
     }
-    if (ctx->GetOption(RSK_SELECTED_STARTING_AGE).Is(RO_AGE_ADULT)) {
+    if (ctx->GetOption(RSK_SELECTED_STARTING_AGE).Is(RO_AGE_ADULT) || !ctx->GetOption(RSK_SHUFFLE_MASTER_SWORD)) {
         ctx->GetItemLocation(RC_TOT_MASTER_SWORD)->SetHintAccesible();
     }
 
@@ -662,7 +661,7 @@ void CreateStoneHints() {
             auto gregLocations = FilterFromPool(ctx->allLocations, [ctx](const RandomizerCheck loc) {
                 return ((ctx->GetItemLocation(loc)->GetPlacedRandomizerGet() == RG_GREG_RUPEE)) &&
                        ctx->GetItemLocation(loc)->IsHintable() &&
-                       !(ctx->GetOption(RSK_GREG_HINT) && (IsReachableWithout({ RC_GREG_HINT }, loc, true)));
+                       !(ctx->GetOption(RSK_GREG_HINT) && IsReachableWithout({ RC_GREG_HINT }, loc, true));
             });
             if (gregLocations.size() > 0) {
                 alwaysHintLocations.push_back(gregLocations[0]);

--- a/soh/soh/Enhancements/randomizer/3drando/playthrough.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/playthrough.cpp
@@ -6,8 +6,8 @@
 #include "random.hpp"
 #include "spoiler_log.hpp"
 #include "soh/Enhancements/randomizer/randomizerTypes.h"
+#include "soh/Enhancements/randomizer/settings.h"
 #include "variables.h"
-#include "soh/OTRGlobals.h"
 #include "soh/cvar_prefixes.h"
 #include "../option.h"
 #include "soh/Enhancements/debugger/performanceTimer.h"
@@ -16,7 +16,7 @@ namespace Playthrough {
 
 int Playthrough_Init(uint32_t seed, std::set<RandomizerCheck> excludedLocations,
                      std::set<RandomizerTrick> enabledTricks) {
-    // initialize the RNG with just the seed incase any settings need to be
+    // initialize the RNG with just the seed in case any settings need to be
     // resolved to something random
     Random_Init(seed);
 
@@ -73,17 +73,12 @@ int Playthrough_Init(uint32_t seed, std::set<RandomizerCheck> excludedLocations,
     GenerateHash();
 
     if (true) {
-        // TODO: Handle different types of file output (i.e. Spoiler Log, Plando Template, Patch Files, Race Files,
-        // etc.)
-        //  write logs
+        // TODO: Handle different types of file output (Spoiler Log, Plando Template, Patch Files, Race Files, etc.)
         SPDLOG_INFO("Writing Spoiler Log...");
         StartPerformanceTimer(PT_SPOILER_LOG);
-        if (SpoilerLog_Write()) {
-            SPDLOG_INFO("Writing Spoiler Log Done");
-        } else {
-            SPDLOG_ERROR("Writing Spoiler Log Failed");
-        }
+        SpoilerLog_Write();
         StopPerformanceTimer(PT_SPOILER_LOG);
+        SPDLOG_INFO("Writing Spoiler Log Done");
     }
 
     ctx->playthroughLocations.clear();

--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
@@ -4,11 +4,8 @@
 #include "../static_data.h"
 #include "../settings.h"
 #include "../entrance.h"
-#include "random.hpp"
 #include "../trial.h"
-#include "hints.hpp"
 #include "pool_functions.hpp"
-#include "soh/Enhancements/randomizer/randomizer_check_objects.h"
 #include "soh/Enhancements/randomizer/randomizer_entrance_tracker.h"
 #include <nlohmann/json.hpp>
 
@@ -16,10 +13,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <map>
-#include <set>
 #include <string>
 #include <sstream>
-#include <unordered_map>
 #include <vector>
 #include <iostream>
 #include <fstream>
@@ -235,7 +230,9 @@ static void WritePlaythrough() {
             sphereString += "0";
         sphereString += sphereNum;
         for (const RandomizerCheck key : ctx->playthroughLocations[i]) {
-            WriteLocation(sphereString, key, true);
+            if (!ctx->GetItemLocation(key)->IsHidden()) {
+                WriteLocation(sphereString, key, true);
+            }
         }
     }
 }
@@ -337,7 +334,7 @@ static void WriteAllLocations() {
     }
 }
 
-const char* SpoilerLog_Write() {
+void SpoilerLog_Write() {
     auto ctx = Rando::Context::GetInstance();
 
     jsonData.clear();
@@ -393,12 +390,6 @@ const char* SpoilerLog_Write() {
     jsonFile.close();
 
     CVarSetString(CVAR_GENERAL("SpoilerLog"), (std::string("./Randomizer/") + fileName + std::string(".json")).c_str());
-
-    // Note: probably shouldn't return this without making sure this string is stored somewhere, but
-    // this return value is currently only used in playthrough.cpp as a true/false. Even if the pointer
-    // is no longer valid it would still not be nullptr if the spoilerfile was written, so it works but
-    // should probably be changed for correctness later on.
-    return fileName.c_str();
 }
 
 void PlacementLog_Msg(std::string_view msg) {

--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.hpp
@@ -23,4 +23,4 @@ typedef enum {
 
 void GenerateHash();
 
-const char* SpoilerLog_Write();
+void SpoilerLog_Write();

--- a/soh/soh/Enhancements/randomizer/item_location.cpp
+++ b/soh/soh/Enhancements/randomizer/item_location.cpp
@@ -151,7 +151,7 @@ bool ItemLocation::GetIsSkipped() {
 }
 
 bool ItemLocation::IsHintable() const {
-    return isHintable;
+    return isHintable && !hidden;
 }
 
 void ItemLocation::SetAsHintable() {


### PR DESCRIPTION
Includes some cleanup. Main point is:
1. hidden checks are not hintable
2. hidden checks should not be written to spoiler log

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5161255692.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5161279689.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5161304370.zip)
<!--- section:artifacts:end -->