### PR TITLE
Fix rando objects not randomizing

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1488,8 +1488,6 @@ extern "C" void InitOTR(int argc, char* argv[]) {
     SohGui::SetupGuiElements();
     SohGui::SetupMenuElements();
 
-    Rando::StaticData::InitHashMaps();
-    OTRGlobals::Instance->gRandoContext->AddExcludedOptions();
     AudioCollection::Instance = new AudioCollection();
     ActorDB::Instance = new ActorDB();
 #ifdef __APPLE__
@@ -1546,6 +1544,8 @@ extern "C" void InitOTR(int argc, char* argv[]) {
         Anchor::Instance->Enable();
     }
     ShipInit::InitAll();
+    Rando::StaticData::InitHashMaps();
+    OTRGlobals::Instance->gRandoContext->AddExcludedOptions();
 }
 
 extern "C" void SaveManager_ThreadPoolWait() {


### PR DESCRIPTION
Recent change in init ordering had param hashmap built before static locations setup by hooks

Rest of PR is cleanup

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5164862021.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5164868229.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5164888194.zip)
<!--- section:artifacts:end -->