### PR TITLE
Fix boot crash when v8 saves are present

### DIFF
--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -548,7 +548,7 @@ void SaveManager::StartupCheckAndInitMeta(int fileNum) {
     fileMetaInfo[fileNum].gsTokens = baseBlock["inventory"]["gsTokens"];
     fileMetaInfo[fileNum].isDoubleDefenseAcquired = baseBlock["isDoubleDefenseAcquired"];
     fileMetaInfo[fileNum].gregFound = false;
-    fileMetaInfo[fileNum].filenameLanguage = baseBlock["filenameLanguage"];
+    fileMetaInfo[fileNum].filenameLanguage = baseBlock.value("filenameLanguage", 0);
     fileMetaInfo[fileNum].hasWallet = !isRando;
     fileMetaInfo[fileNum].defense = baseBlock["inventory"]["defenseHearts"];
     fileMetaInfo[fileNum].health = baseBlock["health"];


### PR DESCRIPTION
This pull request fixes a crash in `StartupCheckAndInitMeta` when processing save files that lacked a `filenameLanguage` property (i.e. saves from before v9). The crash was happening when _booting_ Ship.

Prior to #5817, these files were able to load fine, as `SaveManager::LoadData` was defaulting to `0` for this property. So, to mimic that behavior, I’ve changed the new code to _also_ default to `0`.

(For some reason, one of my save files was from v8.0.6. But this fix may help others with a lingering old save.)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5167662254.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5167665215.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5167681873.zip)
<!--- section:artifacts:end -->