### PR TITLE
Recalculate Available Checks from Current Region

### DIFF
--- a/soh/soh/Enhancements/randomizer/entrance.cpp
+++ b/soh/soh/Enhancements/randomizer/entrance.cpp
@@ -1710,6 +1710,11 @@ void EntranceShuffler::ApplyEntranceOverrides() {
         entrance->SetAsShuffled();
     }
 }
+
+const Entrance* EntranceShuffler::GetEntranceByIndex(int16_t index) {
+    auto iter = entranceMap.find(index);
+    return iter != entranceMap.end() ? iter->second : nullptr;
+}
 } // namespace Rando
 
 extern "C" EntranceOverride* Randomizer_GetEntranceOverrides() {

--- a/soh/soh/Enhancements/randomizer/entrance.h
+++ b/soh/soh/Enhancements/randomizer/entrance.h
@@ -133,6 +133,8 @@ class EntranceShuffler {
     void ParseJson(nlohmann::json spoilerFileJson);
     void ApplyEntranceOverrides();
 
+    static const Entrance* GetEntranceByIndex(int16_t index);
+
   private:
     std::vector<Entrance*> AssumeEntrancePool(std::vector<Entrance*>& entrancePool);
     bool ShuffleOneWayPriorityEntrances(std::map<std::string, PriorityEntrance>& oneWayPriorities,

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -271,6 +271,7 @@ std::vector<uint32_t> buttons = { BTN_A, BTN_B, BTN_CUP,   BTN_CDOWN, BTN_CLEFT,
 static ImGuiTextFilter checkSearch;
 static bool recalculateAvailable = false;
 static RandomizerRegion availableChecksStartingRegion = RR_ROOT;
+static int16_t previousEntrance = 0;
 std::array<bool, RCAREA_INVALID> filterAreasHidden = { 0 };
 std::array<bool, RC_MAX> filterChecksHidden = { 0 };
 
@@ -1028,6 +1029,11 @@ void CheckTrackerWindow::DrawElement() {
         ImGui::Text("Waiting for file load..."); // TODO Language
         EndFloatWindows();
         return;
+    }
+
+    if (gPlayState->nextEntranceIndex != previousEntrance) {
+        previousEntrance = gPlayState->nextEntranceIndex;
+        recalculateAvailable = true;
     }
 
     if (recalculateAvailable) {

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -2067,12 +2067,17 @@ void InternalRecalculateAvailableChecks(RandomizerRegion startingRegion) {
     const auto& ctx = Rando::Context::GetInstance();
     logic = ctx->GetLogic();
 
-    if (startingRegion == RR_ROOT) {
-        // debug warping sets gSaveContext.entranceIndex in Select_LoadGame
-        int32_t entranceIndex = gPlayState->nextEntranceIndex;
-        const auto entrance = Rando::EntranceShuffler::GetEntranceByIndex(entranceIndex);
-        if (entrance != nullptr) {
-            startingRegion = entrance->GetOriginalConnectedRegionKey();
+    int16_t entranceIndex = gPlayState->nextEntranceIndex;
+    if (startingRegion == RR_ROOT && entranceIndex >= 0 && entranceIndex < ENTR_MAX) {
+        // Try to find a mapped entrance
+        // e.g. ENTR_DEKU_TREE_0_1 (index 1) is not mapped, but ENTR_DEKU_TREE_ENTRANCE (index 0) is mapped
+        const int8_t scene = gEntranceTable[entranceIndex].scene;
+        for (; entranceIndex >= 0 && gEntranceTable[entranceIndex].scene == scene; entranceIndex--) {
+            const auto entrance = Rando::EntranceShuffler::GetEntranceByIndex(entranceIndex);
+            if (entrance != nullptr) {
+                startingRegion = entrance->GetOriginalConnectedRegionKey();
+                break;
+            }
         }
     }
 

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -612,9 +612,7 @@ void CheckTrackerLoadGame(int32_t fileNum) {
 
     RegionTable_Init();
 
-    if (Rando::Context::GetInstance()->GetOption(RSK_SHUFFLE_ENTRANCES).Get()) {
-        Rando::Context::GetInstance()->GetEntranceShuffler()->ApplyEntranceOverrides();
-    }
+    Rando::Context::GetInstance()->GetEntranceShuffler()->ApplyEntranceOverrides();
 
     recalculateAvailable = true;
 }

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -270,6 +270,7 @@ std::vector<uint32_t> buttons = { BTN_A, BTN_B, BTN_CUP,   BTN_CDOWN, BTN_CLEFT,
                                   BTN_Z, BTN_R, BTN_START, BTN_DUP,   BTN_DDOWN, BTN_DLEFT,  BTN_DRIGHT };
 static ImGuiTextFilter checkSearch;
 static bool recalculateAvailable = false;
+static RandomizerRegion availableChecksStartingRegion = RR_ROOT;
 std::array<bool, RCAREA_INVALID> filterAreasHidden = { 0 };
 std::array<bool, RC_MAX> filterChecksHidden = { 0 };
 
@@ -954,6 +955,8 @@ void SetAreaSpoiled(RandomizerCheckArea rcArea) {
     SaveManager::Instance->SaveSection(gSaveContext.fileNum, sectionId, true);
 }
 
+void InternalRecalculateAvailableChecks(RandomizerRegion startingRegion);
+
 void CheckTrackerWindow::DrawElement() {
     Color_Background = CVarGetColor(CVAR_TRACKER_CHECK("BgColor.Value"), Color_Bg_Default);
     Color_Area_Incomplete_Main = CVarGetColor(CVAR_TRACKER_CHECK("AreaIncomplete.MainColor.Value"), Color_Main_Default);
@@ -1029,7 +1032,8 @@ void CheckTrackerWindow::DrawElement() {
 
     if (recalculateAvailable) {
         recalculateAvailable = false;
-        RecalculateAvailableChecks();
+        InternalRecalculateAvailableChecks(availableChecksStartingRegion);
+        availableChecksStartingRegion = RR_ROOT;
     }
 
     // Quick Options
@@ -2052,7 +2056,7 @@ void ImGuiDrawTwoColorPickerSection(const char* text, const char* cvarMainName, 
     UIWidgets::PopStyleCombobox();
 }
 
-void RecalculateAvailableChecks(RandomizerRegion startingRegion /* = RR_ROOT */) {
+void InternalRecalculateAvailableChecks(RandomizerRegion startingRegion) {
     if (!enableAvailableChecks || !GameInteractor::IsSaveLoaded()) {
         return;
     }
@@ -2062,6 +2066,14 @@ void RecalculateAvailableChecks(RandomizerRegion startingRegion /* = RR_ROOT */)
 
     const auto& ctx = Rando::Context::GetInstance();
     logic = ctx->GetLogic();
+
+    if (startingRegion == RR_ROOT) {
+        const auto entranceIndex = GetLastEntranceOverride();
+        const auto entrance = Rando::EntranceShuffler::GetEntranceByIndex(entranceIndex);
+        if (entrance != nullptr) {
+            startingRegion = entrance->GetConnectedRegionKey();
+        }
+    }
 
     std::vector<RandomizerCheck> targetLocations;
     targetLocations.reserve(RC_MAX);
@@ -2095,6 +2107,11 @@ void RecalculateAvailableChecks(RandomizerRegion startingRegion /* = RR_ROOT */)
     StopPerformanceTimer(PT_RECALCULATE_AVAILABLE_CHECKS);
     SPDLOG_INFO("Recalculate Available Checks Time: {}ms",
                 GetPerformanceTimer(PT_RECALCULATE_AVAILABLE_CHECKS).count());
+}
+
+void RecalculateAvailableChecks(RandomizerRegion startingRegion /* = RR_ROOT */) {
+    recalculateAvailable = true;
+    availableChecksStartingRegion = startingRegion;
 }
 
 void CheckTracker_LoadFromPreset(nlohmann::json info) {

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -2068,10 +2068,11 @@ void InternalRecalculateAvailableChecks(RandomizerRegion startingRegion) {
     logic = ctx->GetLogic();
 
     if (startingRegion == RR_ROOT) {
-        const auto entranceIndex = GetLastEntranceOverride();
+        // debug warping sets gSaveContext.entranceIndex in Select_LoadGame
+        int32_t entranceIndex = gPlayState->nextEntranceIndex;
         const auto entrance = Rando::EntranceShuffler::GetEntranceByIndex(entranceIndex);
         if (entrance != nullptr) {
-            startingRegion = entrance->GetConnectedRegionKey();
+            startingRegion = entrance->GetOriginalConnectedRegionKey();
         }
     }
 

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -292,14 +292,12 @@ s16 Entrance_OverrideNextIndex(s16 nextEntranceIndex) {
 
     Entrance_SetEntranceDiscovered(nextEntranceIndex, false);
     EntranceTracker_SetLastEntranceOverride(nextEntranceIndex);
-    CheckTracker_RecalculateAvailableChecks();
     return Grotto_OverrideSpecialEntrance(Entrance_GetOverride(nextEntranceIndex));
 }
 
 s16 Entrance_OverrideDynamicExit(s16 dynamicExitIndex) {
     Entrance_SetEntranceDiscovered(dynamicExitList[dynamicExitIndex], false);
     EntranceTracker_SetLastEntranceOverride(dynamicExitList[dynamicExitIndex]);
-    CheckTracker_RecalculateAvailableChecks();
     return Grotto_OverrideSpecialEntrance(Entrance_GetOverride(dynamicExitList[dynamicExitIndex]));
 }
 
@@ -822,7 +820,6 @@ void Entrance_SetEntranceDiscovered(u16 entranceIndex, u8 isReversedEntrance) {
     if (idx < SAVEFILE_ENTRANCES_DISCOVERED_IDX_COUNT) {
         u32 entranceBit = 1 << (entranceIndex - (idx * bitsPerIndex));
         gSaveContext.ship.stats.entrancesDiscovered[idx] |= entranceBit;
-        CheckTracker_RecalculateAvailableChecks();
 
         // Set reverse entrance when not decoupled
         if (!Randomizer_GetSettingValue(RSK_DECOUPLED_ENTRANCES) && !isReversedEntrance) {

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -292,12 +292,14 @@ s16 Entrance_OverrideNextIndex(s16 nextEntranceIndex) {
 
     Entrance_SetEntranceDiscovered(nextEntranceIndex, false);
     EntranceTracker_SetLastEntranceOverride(nextEntranceIndex);
+    CheckTracker_RecalculateAvailableChecks();
     return Grotto_OverrideSpecialEntrance(Entrance_GetOverride(nextEntranceIndex));
 }
 
 s16 Entrance_OverrideDynamicExit(s16 dynamicExitIndex) {
     Entrance_SetEntranceDiscovered(dynamicExitList[dynamicExitIndex], false);
     EntranceTracker_SetLastEntranceOverride(dynamicExitList[dynamicExitIndex]);
+    CheckTracker_RecalculateAvailableChecks();
     return Grotto_OverrideSpecialEntrance(Entrance_GetOverride(dynamicExitList[dynamicExitIndex]));
 }
 

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -690,6 +690,9 @@ void Play_Init(GameState* thisx) {
                     GET_PLAYER(play)->actor.world.pos.y + Player_GetHeight(GET_PLAYER(play)) + 5.0f,
                     GET_PLAYER(play)->actor.world.pos.z, 0, 0, 0, 1, true);
     }
+
+    // nextEntranceIndex was not initialized, so the previous value was carried over during soft resets.
+    gPlayState->nextEntranceIndex = gSaveContext.entranceIndex;
 }
 
 void Play_Update(PlayState* play) {


### PR DESCRIPTION
Currently, Available checks is only calculated from `RR_ROOT`, then spawns, etc. Being teleported to an unexpected location may make several checks accessible even though it's via a sequence break. This PR is to recalculate Available Checks from the current Randomizer Region in addition to `RR_ROOT`. It does this by using the `LastEntranceIndex` from the Entrance Tracker and looking up where that entrance led to.

There are few gaps at the moment because they don't use `Entrance_OverrideNextIndex` to lookup the randomized entrance.
- [x] Debug Console
- [x] Debug Warping
- [x] Teleport Traps

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5251193308.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5251203774.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5251214354.zip)
<!--- section:artifacts:end -->