### PR TITLE
Surround sound enhancements.

### DIFF
--- a/soh/include/z64audio.h
+++ b/soh/include/z64audio.h
@@ -496,7 +496,7 @@ typedef struct {
     /* 0x16 */ u16 unk_16;
     /* 0x18 */ u16 unk_18;
     /* 0x1A */ u8 unk_1A;
-    /* 0x1C */ u16 unk_1C;
+    /* 0x1C */ u16 surroundEffectGain;
     /* 0x1E */ u16 unk_1E;
     struct OggOpusFile* opusFile; // Only for streamed opus audio
 } NoteSynthesisState; // size = 0x20

--- a/soh/include/z64audio.h
+++ b/soh/include/z64audio.h
@@ -46,6 +46,14 @@ typedef enum {
 } AdsrStatus;
 
 typedef enum {
+    /* 0 */ SOUNDMODE_STEREO,
+    /* 1 */ SOUNDMODE_HEADSET,
+    /* 2 */ SOUNDMODE_SURROUND_EXTERNAL,
+    /* 3 */ SOUNDMODE_MONO,
+    /* 4 */ SOUNDMODE_SURROUND
+} SoundMode;
+
+typedef enum {
     /* 0 */ MEDIUM_RAM,
     /* 1 */ MEDIUM_UNK,
     /* 2 */ MEDIUM_CART,
@@ -545,7 +553,7 @@ typedef struct {
     /* 0x03 */ u8 headsetPanRight;
     /* 0x04 */ u8 headsetPanLeft;
     /* 0x05 */ u8 reverbVol;
-    /* 0x06 */ u8 unk_06;
+    /* 0x06 */ u8 surroundEffectIndex;
     /* 0x07 */ u8 unk_07;
     /* 0x08 */ u16 targetVolLeft;
     /* 0x0A */ u16 targetVolRight;

--- a/soh/include/z64audio.h
+++ b/soh/include/z64audio.h
@@ -46,14 +46,6 @@ typedef enum {
 } AdsrStatus;
 
 typedef enum {
-    /* 0 */ SOUNDMODE_STEREO,
-    /* 1 */ SOUNDMODE_HEADSET,
-    /* 2 */ SOUNDMODE_SURROUND_EXTERNAL,
-    /* 3 */ SOUNDMODE_MONO,
-    /* 4 */ SOUNDMODE_SURROUND
-} SoundMode;
-
-typedef enum {
     /* 0 */ MEDIUM_RAM,
     /* 1 */ MEDIUM_UNK,
     /* 2 */ MEDIUM_CART,

--- a/soh/src/code/audio_playback.c
+++ b/soh/src/code/audio_playback.c
@@ -24,7 +24,7 @@ void Audio_InitNoteSub(Note* note, NoteSubEu* sub, NoteSubAttributes* attrs) {
     sub->bitField0 = note->noteSubEu.bitField0;
     sub->bitField1 = note->noteSubEu.bitField1;
     sub->sound.samples = note->noteSubEu.sound.samples;
-    sub->unk_06 = note->noteSubEu.unk_06;
+    sub->surroundEffectIndex = note->noteSubEu.surroundEffectIndex;
 
     Audio_NoteSetResamplingRate(sub, attrs->frequency);
 
@@ -586,7 +586,7 @@ void Audio_InitSyntheticWave(Note* note, SequenceLayer* layer) {
     waveSampleCountIndex = Audio_BuildSyntheticWave(note, layer, waveId);
 
     if (waveSampleCountIndex != sampleCountIndex) {
-        note->noteSubEu.unk_06 = waveSampleCountIndex * 4 + sampleCountIndex;
+        note->noteSubEu.surroundEffectIndex = waveSampleCountIndex * 4 + sampleCountIndex;
     }
 }
 

--- a/soh/src/code/audio_synthesis.c
+++ b/soh/src/code/audio_synthesis.c
@@ -31,8 +31,8 @@ Acmd* AudioSynth_ProcessEnvelope(Acmd* cmd, NoteSubEu* noteSubEu, NoteSynthesisS
                                  u16 inBuf, s32 headsetPanSettings, s32 flags);
 Acmd* AudioSynth_FinalResample(Acmd* cmd, NoteSynthesisState* synthState, s32 count, u16 pitch, u16 inpDmem,
                                s32 resampleFlags);
-Acmd* AudioSynth_ApplySurroundEffect(Acmd* cmd, NoteSubEu* noteSubEu, NoteSynthesisState* synthState,
-                                     s32 aiBufLen, s32 inputDmem, s32 flags);
+Acmd* AudioSynth_ApplySurroundEffect(Acmd* cmd, NoteSubEu* noteSubEu, NoteSynthesisState* synthState, s32 aiBufLen,
+                                     s32 inputDmem, s32 flags);
 
 u32 D_801304A0 = 0x13000000;
 u32 D_801304A4 = 0x5CAEC8E2;
@@ -863,8 +863,8 @@ Acmd* AudioSynth_ProcessNote(s32 noteIndex, NoteSubEu* noteSubEu, NoteSynthesisS
                         size_t bytesToRead;
                         nSamplesProcessed += samplesLenAdjusted;
 
-                        if (((synthState->samplePosInt * 2) + (samplesLenAdjusted)*2) < audioFontSample->size) {
-                            bytesToRead = (samplesLenAdjusted)*2;
+                        if (((synthState->samplePosInt * 2) + (samplesLenAdjusted) * 2) < audioFontSample->size) {
+                            bytesToRead = (samplesLenAdjusted) * 2;
                         } else {
                             bytesToRead = audioFontSample->size - (synthState->samplePosInt * 2);
                         }
@@ -1265,8 +1265,8 @@ Acmd* AudioSynth_NoteApplyHeadsetPanEffects(Acmd* cmd, NoteSubEu* noteSubEu, Not
     return cmd;
 }
 
-Acmd* AudioSynth_ApplySurroundEffect(Acmd* cmd, NoteSubEu* noteSubEu, NoteSynthesisState* synthState,
-                                     s32 aiBufLen, s32 inputDmem, s32 flags) {
+Acmd* AudioSynth_ApplySurroundEffect(Acmd* cmd, NoteSubEu* noteSubEu, NoteSynthesisState* synthState, s32 aiBufLen,
+                                     s32 inputDmem, s32 flags) {
     s32 wetGain;
     u16 dryGain;
     s64 dmem = DMEM_SURROUND_TEMP;
@@ -1309,8 +1309,7 @@ Acmd* AudioSynth_ApplySurroundEffect(Acmd* cmd, NoteSubEu* noteSubEu, NoteSynthe
         // === End matrix surround encoding ===
     }
 
-    aSaveBuffer(cmd++, DMEM_SURROUND_TEMP + (aiBufLen * 2),
-                synthState->synthesisBuffers->panSamplesBuffer,
+    aSaveBuffer(cmd++, DMEM_SURROUND_TEMP + (aiBufLen * 2), synthState->synthesisBuffers->panSamplesBuffer,
                 sizeof(synthState->synthesisBuffers->panSamplesBuffer));
 
     decayGain = (noteSubEu->targetVolLeft + noteSubEu->targetVolRight) * (1.0f / 0x2000);

--- a/soh/src/code/audio_synthesis.c
+++ b/soh/src/code/audio_synthesis.c
@@ -1273,11 +1273,11 @@ Acmd* AudioSynth_ApplySurroundEffect(Acmd* cmd, NoteSubEu* noteSubEu, NoteSynthe
     f32 decayGain;
 
     AudioSynth_DMemMove(cmd++, inputDmem, DMEM_NOTE_PAN_TEMP, aiBufLen * 2);
-    dryGain = synthState->unk_1C; // surroundEffectGain equivalent
+    dryGain = synthState->surroundEffectGain;
 
     if (flags == A_INIT) {
         aClearBuffer(cmd++, dmem, sizeof(synthState->synthesisBuffers->panSamplesBuffer));
-        synthState->unk_1C = 0;
+        synthState->surroundEffectGain = 0;
     } else {
         aLoadBuffer(cmd++, synthState->synthesisBuffers->panSamplesBuffer, dmem,
                     sizeof(synthState->synthesisBuffers->panSamplesBuffer));
@@ -1322,7 +1322,7 @@ Acmd* AudioSynth_ApplySurroundEffect(Acmd* cmd, NoteSubEu* noteSubEu, NoteSynthe
     // Use a default pan volume table or create a simple calculation
     f32 surroundIndex = noteSubEu->surroundEffectIndex;
     decayGain = decayGain * (1.0f - (surroundIndex / 127.0f));
-    synthState->unk_1C = ((decayGain * 0x7FFF) + synthState->unk_1C) / 2;
+    synthState->surroundEffectGain = ((decayGain * 0x7FFF) + synthState->surroundEffectGain) / 2;
 
     AudioSynth_DMemMove(cmd++, DMEM_NOTE_PAN_TEMP, inputDmem, aiBufLen * 2);
 

--- a/soh/src/code/audio_synthesis.c
+++ b/soh/src/code/audio_synthesis.c
@@ -862,9 +862,9 @@ Acmd* AudioSynth_ProcessNote(s32 noteIndex, NoteSubEu* noteSubEu, NoteSynthesisS
                         skipBytes = 0;
                         size_t bytesToRead;
                         nSamplesProcessed += samplesLenAdjusted;
-
-                        if (((synthState->samplePosInt * 2) + (samplesLenAdjusted) * 2) < audioFontSample->size) {
-                            bytesToRead = (samplesLenAdjusted) * 2;
+                        
+                        if (((synthState->samplePosInt * 2) + (samplesLenAdjusted)*2) < audioFontSample->size) {
+                            bytesToRead = (samplesLenAdjusted)*2;
                         } else {
                             bytesToRead = audioFontSample->size - (synthState->samplePosInt * 2);
                         }

--- a/soh/src/code/audio_synthesis.c
+++ b/soh/src/code/audio_synthesis.c
@@ -16,6 +16,7 @@
 #define DMEM_WET_SCRATCH 0x720 // = DMEM_WET_TEMP + DEFAULT_LEN_2CH
 #define DMEM_WET_LEFT_CH 0xC80
 #define DMEM_WET_RIGHT_CH 0xE20 // = DMEM_WET_LEFT_CH + DEFAULT_LEN_1CH
+#define DMEM_SURROUND_TEMP 0x4B0
 
 Acmd* AudioSynth_LoadRingBufferPart(Acmd* cmd, u16 dmem, u16 startPos, s32 length, SynthesisReverb* reverb);
 Acmd* AudioSynth_SaveBufferOffset(Acmd* cmd, u16 dmem, u16 offset, s32 length, s16* buf);
@@ -30,6 +31,8 @@ Acmd* AudioSynth_ProcessEnvelope(Acmd* cmd, NoteSubEu* noteSubEu, NoteSynthesisS
                                  u16 inBuf, s32 headsetPanSettings, s32 flags);
 Acmd* AudioSynth_FinalResample(Acmd* cmd, NoteSynthesisState* synthState, s32 count, u16 pitch, u16 inpDmem,
                                s32 resampleFlags);
+Acmd* AudioSynth_ApplySurroundEffect(Acmd* cmd, NoteSubEu* noteSubEu, NoteSynthesisState* synthState,
+                                     s32 aiBufLen, s32 inputDmem, s32 flags);
 
 u32 D_801304A0 = 0x13000000;
 u32 D_801304A4 = 0x5CAEC8E2;
@@ -127,7 +130,7 @@ void func_800DB03C(s32 arg0) {
             subEu2->bitField0.enabled = false;
         }
 
-        subEu->unk_06 = 0;
+        subEu->surroundEffectIndex = 0;
     }
 }
 
@@ -1070,6 +1073,16 @@ Acmd* AudioSynth_ProcessNote(s32 noteIndex, NoteSubEu* noteSubEu, NoteSynthesisS
     } else {
         side = 0;
     }
+
+    // Apply surround effect for rear speakers when in surround mode
+    if (gAudioContext.soundMode == SOUNDMODE_SURROUND) {
+        noteSubEu->targetVolLeft = noteSubEu->targetVolLeft >> 1;
+        noteSubEu->targetVolRight = noteSubEu->targetVolRight >> 1;
+        if (noteSubEu->surroundEffectIndex != 0xFF) {
+            cmd = AudioSynth_ApplySurroundEffect(cmd, noteSubEu, synthState, aiBufLen, DMEM_TEMP, flags);
+        }
+    }
+
     cmd = AudioSynth_ProcessEnvelope(cmd, noteSubEu, synthState, aiBufLen, DMEM_TEMP, side, flags);
     if (noteSubEu->bitField1.usesHeadsetPanEffects2) {
         if (!(flags & A_INIT)) {
@@ -1167,7 +1180,7 @@ Acmd* AudioSynth_ProcessEnvelope(Acmd* cmd, NoteSubEu* noteSubEu, NoteSynthesisS
 
 Acmd* AudioSynth_LoadWaveSamples(Acmd* cmd, NoteSubEu* noteSubEu, NoteSynthesisState* synthState, s32 nSamplesToLoad) {
     s32 temp_v0;
-    s32 unk6 = noteSubEu->unk_06;
+    s32 unk6 = noteSubEu->surroundEffectIndex;
     s32 samplePosInt = synthState->samplePosInt;
     s32 repeats;
 
@@ -1249,5 +1262,69 @@ Acmd* AudioSynth_NoteApplyHeadsetPanEffects(Acmd* cmd, NoteSubEu* noteSubEu, Not
                     ALIGN16(panShift));
     }
     aAddMixer(cmd++, ALIGN64(bufLen), DMEM_NOTE_PAN_TEMP, dest);
+    return cmd;
+}
+
+Acmd* AudioSynth_ApplySurroundEffect(Acmd* cmd, NoteSubEu* noteSubEu, NoteSynthesisState* synthState,
+                                     s32 aiBufLen, s32 inputDmem, s32 flags) {
+    s32 wetGain;
+    u16 dryGain;
+    s64 dmem = DMEM_SURROUND_TEMP;
+    f32 decayGain;
+
+    AudioSynth_DMemMove(cmd++, inputDmem, DMEM_NOTE_PAN_TEMP, aiBufLen * 2);
+    dryGain = synthState->unk_1C; // surroundEffectGain equivalent
+
+    if (flags == A_INIT) {
+        aClearBuffer(cmd++, dmem, sizeof(synthState->synthesisBuffers->panSamplesBuffer));
+        synthState->unk_1C = 0;
+    } else {
+        aLoadBuffer(cmd++, synthState->synthesisBuffers->panSamplesBuffer, dmem,
+                    sizeof(synthState->synthesisBuffers->panSamplesBuffer));
+
+        // === Pro Logic II encoding: steer surround to RL or RR based on pan ===
+        // Calculate pan position: 0.0 = full left, 0.5 = center, 1.0 = full right
+        f32 sumVol = noteSubEu->targetVolLeft + noteSubEu->targetVolRight;
+        f32 panPosition = 0.5f; // default: center (mono surround)
+        if (sumVol > 0.0f) {
+            panPosition = (f32)noteSubEu->targetVolRight / sumVol;
+        }
+
+        // For PLII decoding, the L/R balance determines RL vs RR steering:
+        // - L dominant (leftGain > rightGain): surround goes more to Rear Left
+        // - R dominant (rightGain > leftGain): surround goes more to Rear Right
+        // - Equal: mono surround to both (like Pro Logic I)
+        s16 leftGain = (s16)(dryGain * (1.0f - panPosition));
+        s16 rightGain = (s16)(dryGain * panPosition);
+
+        aMix(cmd++, (aiBufLen * 2) >> 4, leftGain, dmem, DMEM_LEFT_CH);
+        aMix(cmd++, (aiBufLen * 2) >> 4, (rightGain ^ 0xFFFF), dmem, DMEM_RIGHT_CH);
+
+        wetGain = (dryGain * synthState->reverbVol) >> 7;
+        s16 wetLeftGain = (s16)(wetGain * (1.0f - panPosition));
+        s16 wetRightGain = (s16)(wetGain * panPosition);
+
+        aMix(cmd++, (aiBufLen * 2) >> 4, wetLeftGain, dmem, DMEM_WET_LEFT_CH);
+        aMix(cmd++, (aiBufLen * 2) >> 4, (wetRightGain ^ 0xFFFF), dmem, DMEM_WET_RIGHT_CH);
+        // === End Pro Logic II encoding ===
+    }
+
+    aSaveBuffer(cmd++, DMEM_SURROUND_TEMP + (aiBufLen * 2),
+                synthState->synthesisBuffers->panSamplesBuffer,
+                sizeof(synthState->synthesisBuffers->panSamplesBuffer));
+
+    decayGain = (noteSubEu->targetVolLeft + noteSubEu->targetVolRight) * (1.0f / 0x2000);
+
+    if (decayGain > 1.0f) {
+        decayGain = 1.0f;
+    }
+
+    // Use a default pan volume table or create a simple calculation
+    f32 surroundIndex = noteSubEu->surroundEffectIndex;
+    decayGain = decayGain * (1.0f - (surroundIndex / 127.0f));
+    synthState->unk_1C = ((decayGain * 0x7FFF) + synthState->unk_1C) / 2;
+
+    AudioSynth_DMemMove(cmd++, DMEM_NOTE_PAN_TEMP, inputDmem, aiBufLen * 2);
+
     return cmd;
 }

--- a/soh/src/code/audio_synthesis.c
+++ b/soh/src/code/audio_synthesis.c
@@ -1282,7 +1282,7 @@ Acmd* AudioSynth_ApplySurroundEffect(Acmd* cmd, NoteSubEu* noteSubEu, NoteSynthe
         aLoadBuffer(cmd++, synthState->synthesisBuffers->panSamplesBuffer, dmem,
                     sizeof(synthState->synthesisBuffers->panSamplesBuffer));
 
-        // === Pro Logic II encoding: steer surround to RL or RR based on pan ===
+        // === Matrix surround encoding: steer surround to RL or RR based on pan ===
         // Calculate pan position: 0.0 = full left, 0.5 = center, 1.0 = full right
         f32 sumVol = noteSubEu->targetVolLeft + noteSubEu->targetVolRight;
         f32 panPosition = 0.5f; // default: center (mono surround)
@@ -1290,10 +1290,10 @@ Acmd* AudioSynth_ApplySurroundEffect(Acmd* cmd, NoteSubEu* noteSubEu, NoteSynthe
             panPosition = (f32)noteSubEu->targetVolRight / sumVol;
         }
 
-        // For PLII decoding, the L/R balance determines RL vs RR steering:
+        // The L/R balance determines RL vs RR steering:
         // - L dominant (leftGain > rightGain): surround goes more to Rear Left
         // - R dominant (rightGain > leftGain): surround goes more to Rear Right
-        // - Equal: mono surround to both (like Pro Logic I)
+        // - Equal: mono surround to both
         s16 leftGain = (s16)(dryGain * (1.0f - panPosition));
         s16 rightGain = (s16)(dryGain * panPosition);
 
@@ -1306,7 +1306,7 @@ Acmd* AudioSynth_ApplySurroundEffect(Acmd* cmd, NoteSubEu* noteSubEu, NoteSynthe
 
         aMix(cmd++, (aiBufLen * 2) >> 4, wetLeftGain, dmem, DMEM_WET_LEFT_CH);
         aMix(cmd++, (aiBufLen * 2) >> 4, (wetRightGain ^ 0xFFFF), dmem, DMEM_WET_RIGHT_CH);
-        // === End Pro Logic II encoding ===
+        // === End matrix surround encoding ===
     }
 
     aSaveBuffer(cmd++, DMEM_SURROUND_TEMP + (aiBufLen * 2),

--- a/soh/src/code/audio_synthesis.c
+++ b/soh/src/code/audio_synthesis.c
@@ -1075,7 +1075,7 @@ Acmd* AudioSynth_ProcessNote(s32 noteIndex, NoteSubEu* noteSubEu, NoteSynthesisS
     }
 
     // Apply surround effect for rear speakers when in surround mode
-    if (gAudioContext.soundMode == SOUNDMODE_SURROUND) {
+    if (gAudioContext.soundMode == 4) {
         noteSubEu->targetVolLeft = noteSubEu->targetVolLeft >> 1;
         noteSubEu->targetVolRight = noteSubEu->targetVolRight >> 1;
         if (noteSubEu->surroundEffectIndex != 0xFF) {

--- a/soh/src/code/audio_synthesis.c
+++ b/soh/src/code/audio_synthesis.c
@@ -862,7 +862,7 @@ Acmd* AudioSynth_ProcessNote(s32 noteIndex, NoteSubEu* noteSubEu, NoteSynthesisS
                         skipBytes = 0;
                         size_t bytesToRead;
                         nSamplesProcessed += samplesLenAdjusted;
-                        
+
                         if (((synthState->samplePosInt * 2) + (samplesLenAdjusted)*2) < audioFontSample->size) {
                             bytesToRead = (samplesLenAdjusted)*2;
                         } else {

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -3857,17 +3857,33 @@ u8 func_800F37B8(f32 behindScreenZ, SoundBankEntry* arg1, s8 arg2) {
     return (phi_v1 * 0x10) + (u8)((phi_f0 * phi_f12) / (10000.0f / 5.2f));
 }
 
-s8 func_800F3990(f32 arg0, u16 sfxParams) {
+s8 AudioSfx_ComputeSurroundEffectIndex(f32 arg0, u16 sfxParams) {
     s8 ret = 0;
 
-    if (arg0 >= 0.0f) {
-        if (arg0 > 625.0f) {
+    // Enhanced surround effect calculation for better RL/RR separation
+    // Similar to 2ship2harkinian's Audio_SetSequenceProperties logic
+    if (arg0 > 0.0f) {
+        // Front of screen: map 0-100 range to 0-64 for rear left bias
+        if (arg0 > 100.0f) {
+            ret = 0;
+        } else {
+            ret = (s8)(((100.0f - arg0) / 100.0f) * 64.0f);
+        }
+    } else {
+        // Behind screen: map -100-0 range to 63-127 for rear right bias
+        if (arg0 < -100.0f) {
             ret = 127;
         } else {
-            ret = (arg0 / 625.0f) * 126.0f;
+            ret = (s8)((-arg0 / 100.0f) * 64.0f) + 63;
         }
     }
-    return ret | 1;
+    
+    // Ensure we don't return 0 (which disables the effect)
+    if (ret == 0) {
+        ret = 1;
+    }
+    
+    return ret;
 }
 
 void Audio_SetSoundProperties(u8 bankId, u8 entryIdx, u8 channelIdx) {
@@ -3890,7 +3906,9 @@ void Audio_SetSoundProperties(u8 bankId, u8 entryIdx, u8 channelIdx) {
         case BANK_ENEMY:
         case BANK_VOICE:
             if (D_80130604 == 2) {
-                sp38 = func_800F3990(*entry->posY, entry->sfxParams);
+                // Use Z position for depth-based surround effect (front/back)
+                // This provides better RL/RR separation
+                sp38 = AudioSfx_ComputeSurroundEffectIndex(*entry->posZ, entry->sfxParams);
             }
             // fallthrough
         case BANK_OCARINA:

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -3876,7 +3876,7 @@ s8 AudioSfx_ComputeSurroundEffectIndex(f32 projectedPosZ, u16 sfxParams) {
             ret = (s8)((-projectedPosZ / 100.0f) * 64.0f) + 63;
         }
     }
-    
+
     return ret;
 }
 

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -4995,7 +4995,7 @@ void func_800F6700(s8 arg0) {
             break;
     }
 
-    SetAudioChannelsSetting(channelsSetting);
+    SetAudioChannels(channelsSetting);
 
     Audio_SeqCmdE0(SEQ_PLAYER_BGM_MAIN, sp1F);
 }

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -4966,6 +4966,7 @@ void Audio_SetCodeReverb(s8 reverb) {
 
 void func_800F6700(s8 arg0) {
     s8 sp1F = 0;
+    AudioChannelsSetting channelsSetting = audioStereo;
 
     switch (arg0) {
         case 0:
@@ -4993,6 +4994,8 @@ void func_800F6700(s8 arg0) {
             SetAudioChannels(audioMatrix51);
             break;
     }
+
+    SetAudioChannelsSetting(channelsSetting);
 
     Audio_SeqCmdE0(SEQ_PLAYER_BGM_MAIN, sp1F);
 }

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -3857,23 +3857,23 @@ u8 func_800F37B8(f32 behindScreenZ, SoundBankEntry* arg1, s8 arg2) {
     return (phi_v1 * 0x10) + (u8)((phi_f0 * phi_f12) / (10000.0f / 5.2f));
 }
 
-s8 AudioSfx_ComputeSurroundEffectIndex(f32 arg0, u16 sfxParams) {
+s8 AudioSfx_ComputeSurroundEffectIndex(f32 projectedPosZ, u16 sfxParams) {
     s8 ret = 0;
 
     // Enhanced surround effect calculation for better RL/RR separation
-    if (arg0 > 0.0f) {
+    if (projectedPosZ > 0.0f) {
         // Front of screen: map 0-100 range to 0-64 for rear left bias
-        if (arg0 > 100.0f) {
+        if (projectedPosZ > 100.0f) {
             ret = 0;
         } else {
-            ret = (s8)(((100.0f - arg0) / 100.0f) * 64.0f);
+            ret = (s8)(((100.0f - projectedPosZ) / 100.0f) * 64.0f);
         }
     } else {
         // Behind screen: map -100-0 range to 63-127 for rear right bias
-        if (arg0 < -100.0f) {
+        if (projectedPosZ < -100.0f) {
             ret = 127;
         } else {
-            ret = (s8)((-arg0 / 100.0f) * 64.0f) + 63;
+            ret = (s8)((-projectedPosZ / 100.0f) * 64.0f) + 63;
         }
     }
     

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -3861,7 +3861,6 @@ s8 AudioSfx_ComputeSurroundEffectIndex(f32 arg0, u16 sfxParams) {
     s8 ret = 0;
 
     // Enhanced surround effect calculation for better RL/RR separation
-    // Similar to 2ship2harkinian's Audio_SetSequenceProperties logic
     if (arg0 > 0.0f) {
         // Front of screen: map 0-100 range to 0-64 for rear left bias
         if (arg0 > 100.0f) {

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -4978,7 +4978,6 @@ void Audio_SetCodeReverb(s8 reverb) {
 
 void func_800F6700(s8 arg0) {
     s8 sp1F = 0;
-    AudioChannelsSetting channelsSetting = audioStereo;
 
     switch (arg0) {
         case 0:
@@ -5006,8 +5005,6 @@ void func_800F6700(s8 arg0) {
             SetAudioChannels(audioMatrix51);
             break;
     }
-
-    SetAudioChannels(channelsSetting);
 
     Audio_SeqCmdE0(SEQ_PLAYER_BGM_MAIN, sp1F);
 }

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -3877,11 +3877,6 @@ s8 AudioSfx_ComputeSurroundEffectIndex(f32 arg0, u16 sfxParams) {
         }
     }
     
-    // Ensure we don't return 0 (which disables the effect)
-    if (ret == 0) {
-        ret = 1;
-    }
-    
     return ret;
 }
 

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -3810,7 +3810,7 @@ f32 Audio_ComputeSoundFreqScale(u8 bankId, u8 entryIdx) {
     return freq;
 }
 
-u8 func_800F37B8(f32 behindScreenZ, SoundBankEntry* arg1, s8 arg2) {
+u8 AudioSfx_ComputeSurroundSoundFilter(f32 behindScreenZ, SoundBankEntry* arg1, s8 arg2) {
     s8 phi_v0;
     u8 phi_v1;
     f32 phi_f0;
@@ -3938,7 +3938,7 @@ void Audio_SetSoundProperties(u8 bankId, u8 entryIdx, u8 channelIdx) {
             if ((baseFilter | sAudioExtraFilter) != 0) {
                 filter = (baseFilter | sAudioExtraFilter);
             } else if (D_80130604 == 2 && (entry->sfxParams & 0x2000) == 0) {
-                filter = func_800F37B8(behindScreenZ, entry, panSigned);
+                filter = AudioSfx_ComputeSurroundSoundFilter(behindScreenZ, entry, panSigned);
             }
             break;
         case BANK_SYSTEM:


### PR DESCRIPTION
This PR does the following:

- It renames a few variables and functions that are involved with surround sound.
- Fixes the surround fn now named AudioSfx_ComputeSurroundEffectIndex. Previously it used posY to calculate the surround effect, which was wrong. I updated it using the same logic for this fn as 2s2h.
- Adds AudioSynth_ApplySurroundEffect, which is an enhancement introduced by MM. I have further improved that fn to support separate RL/RR encoding, which the surround matrix decoder supports.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5307883257.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5307944758.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5308743458.zip)
<!--- section:artifacts:end -->