### PR TITLE
Fix Slingshotstrin DL in code

### DIFF
--- a/soh/assets/objects/object_link_child/object_link_child.h
+++ b/soh/assets/objects/object_link_child/object_link_child.h
@@ -219,8 +219,8 @@ static const ALIGN_ASSET(2) char gLinkChildDL_18580[] = dgLinkChildDL_18580;
 #define dgLinkChildBottle2DL "__OTR__objects/object_link_child/gLinkChildBottle2DL"
 static const ALIGN_ASSET(2) char gLinkChildBottle2DL[] = dgLinkChildBottle2DL;
 
-#define dgLinkChildSlinghotStringDL "__OTR__objects/object_link_child/gLinkChildSlinghotStringDL"
-static const ALIGN_ASSET(2) char gLinkChildSlingshotStringDL[] = dgLinkChildSlinghotStringDL;
+#define dgLinkChildSlingshotStringDL "__OTR__objects/object_link_child/gLinkChildSlingshotStringDL"
+static const ALIGN_ASSET(2) char gLinkChildSlingshotStringDL[] = dgLinkChildSlingshotStringDL;
 
 #define dgLinkChildDekuShieldDL "__OTR__objects/object_link_child/gLinkChildDekuShieldDL"
 static const ALIGN_ASSET(2) char gLinkChildDekuShieldDL[] = dgLinkChildDekuShieldDL;


### PR DESCRIPTION
It became apparent that the slingshot dl was misspelled inside the header for defining the `gLinkChildSlingshotStringDL` in the code.

Code wise it was spelled correctly but for the file itself it was named `gLinkChildSlinghotStringDL`

This fixes that