### PR TITLE
Add action shuffle icons to the item tracker

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -141,6 +141,26 @@ std::vector<ItemTrackerItem> rocsFeather = {
     ITEM_TRACKER_ITEM(RG_ROCS_FEATHER, 0, DrawItem),
 };
 
+std::vector<ItemTrackerItem> swimItems = {
+    ITEM_TRACKER_ITEM_CUSTOM(RG_BRONZE_SCALE, ITEM_SCALE_SILVER, ITEM_SCALE_SILVER, 0, DrawItem),
+};
+
+std::vector<ItemTrackerItem> crawlItems = {
+    ITEM_TRACKER_ITEM(RG_CRAWL, 0, DrawItem),
+};
+
+std::vector<ItemTrackerItem> climbItems = {
+    ITEM_TRACKER_ITEM(RG_CLIMB, 0, DrawItem),
+};
+
+std::vector<ItemTrackerItem> grabItems = {
+    ITEM_TRACKER_ITEM(RG_POWER_BRACELET, 0, DrawItem),
+};
+
+std::vector<ItemTrackerItem> openChestItems = {
+    ITEM_TRACKER_ITEM(RG_OPEN_CHEST, 0, DrawItem),
+};
+
 std::vector<ItemTrackerItem> beanSoulItems = {
     ITEM_TRACKER_ITEM_CUSTOM(RG_DEATH_MOUNTAIN_CRATER_BEAN_SOUL, ITEM_BEAN, ITEM_BEAN, 0, DrawItem),
     ITEM_TRACKER_ITEM_CUSTOM(RG_DEATH_MOUNTAIN_TRAIL_BEAN_SOUL, ITEM_BEAN, ITEM_BEAN, 0, DrawItem),
@@ -1107,6 +1127,31 @@ void DrawItem(ItemTrackerItem item) {
             hasItem = Flags_GetRandomizerInf(RAND_INF_FISHING_HOLE_KEY_OBTAINED);
             itemName = "Fishing Hole Key";
             break;
+        case RG_BRONZE_SCALE:
+            actualItemId = item.id;
+            hasItem = Flags_GetRandomizerInf(RAND_INF_CAN_SWIM);
+            itemName = "Swim";
+            break;
+        case RG_CRAWL:
+            actualItemId = item.id;
+            hasItem = Flags_GetRandomizerInf(RAND_INF_CAN_CRAWL);
+            itemName = "Crawl";
+            break;
+        case RG_CLIMB:
+            actualItemId = item.id;
+            hasItem = Flags_GetRandomizerInf(RAND_INF_CAN_CLIMB);
+            itemName = "Climb";
+            break;
+        case RG_POWER_BRACELET:
+            actualItemId = item.id;
+            hasItem = Flags_GetRandomizerInf(RAND_INF_CAN_GRAB);
+            itemName = "Grab";
+            break;
+        case RG_OPEN_CHEST:
+            actualItemId = item.id;
+            hasItem = Flags_GetRandomizerInf(RAND_INF_CAN_OPEN_CHEST);
+            itemName = "Open";
+            break;
     }
 
     if (GameInteractor::IsSaveLoaded() &&
@@ -1160,6 +1205,15 @@ void DrawItem(ItemTrackerItem item) {
                                          p.y - (iconSize + 13)));
         ImGui::PushStyleColor(ImGuiCol_Text, IM_COL_WHITE);
         ImGui::Text("%s", overworldKeyName.c_str());
+        ImGui::PopStyleColor();
+    }
+
+    if (item.id >= RG_BRONZE_SCALE && item.id <= RG_OPEN_CHEST) {
+        ImVec2 p = ImGui::GetCursorScreenPos();
+        ImGui::SetCursorScreenPos(
+            ImVec2(p.x + (iconSize / 2) - (ImGui::CalcTextSize(itemName.c_str()).x / 2), p.y - (iconSize + 2)));
+        ImGui::PushStyleColor(ImGuiCol_Text, IM_COL_WHITE);
+        ImGui::Text("%s", itemName.c_str());
         ImGui::PopStyleColor();
     }
 
@@ -1514,6 +1568,21 @@ void UpdateVectors() {
     }
     if (IS_RANDO && RAND_GET_OPTION(RSK_ROCS_FEATHER)) {
         mainWindowItems.insert(mainWindowItems.end(), rocsFeather.begin(), rocsFeather.end());
+    }
+    if (IS_RANDO && RAND_GET_OPTION(RSK_SHUFFLE_SWIM)) {
+        mainWindowItems.insert(mainWindowItems.end(), swimItems.begin(), swimItems.end());
+    }
+    if (IS_RANDO && RAND_GET_OPTION(RSK_SHUFFLE_GRAB)) {
+        mainWindowItems.insert(mainWindowItems.end(), grabItems.begin(), grabItems.end());
+    }
+    if (IS_RANDO && RAND_GET_OPTION(RSK_SHUFFLE_CLIMB)) {
+        mainWindowItems.insert(mainWindowItems.end(), climbItems.begin(), climbItems.end());
+    }
+    if (IS_RANDO && RAND_GET_OPTION(RSK_SHUFFLE_CRAWL)) {
+        mainWindowItems.insert(mainWindowItems.end(), crawlItems.begin(), crawlItems.end());
+    }
+    if (IS_RANDO && RAND_GET_OPTION(RSK_SHUFFLE_OPEN_CHEST)) {
+        mainWindowItems.insert(mainWindowItems.end(), openChestItems.begin(), openChestItems.end());
     }
 
     // if we're adding greg to the misc window,

--- a/soh/soh/SohGui/ImGuiUtils.cpp
+++ b/soh/soh/SohGui/ImGuiUtils.cpp
@@ -3,6 +3,7 @@
 #include <ship/window/Window.h>
 #include "assets/soh_assets.h"
 #include "soh/Enhancements/randomizer/rando_hash.h"
+#include "soh/Enhancements/randomizer/randomizerTypes.h"
 
 std::map<uint32_t, ItemMapEntry> itemMapping = {
     ITEM_MAP_ENTRY(ITEM_STICK),
@@ -147,6 +148,13 @@ std::map<uint32_t, ItemMapEntry> customItemsMapping = {
     { RG_BONGO_BONGO_SOUL, { RG_BONGO_BONGO_SOUL, "RG_BONGO_BONGO_SOUL", "RG_BONGO_BONGO_SOUL_Faded", gBossSoulTex } },
     { RG_TWINROVA_SOUL, { RG_TWINROVA_SOUL, "RG_TWINROVA_SOUL", "RG_TWINROVA_SOUL_Faded", gBossSoulTex } },
     { RG_GANON_SOUL, { RG_GANON_SOUL, "RG_GANON_SOUL", "RG_GANON_SOUL_Faded", gBossSoulTex } },
+    { RG_OPEN_CHEST, { RG_OPEN_CHEST, "RG_OPEN_CHEST", "RG_OPEN_CHEST_Faded", gMapChestIconTex } }
+};
+
+std::map<uint32_t, ItemMapEntry> actionShuffleMapping = {
+    { RG_CRAWL, { RG_CRAWL, "RG_CRAWL", "RG_CRAWL_Faded", gButtonBackgroundTex } },
+    { RG_CLIMB, { RG_CLIMB, "RG_CLIMB", "RG_CLIMB_Faded", gButtonBackgroundTex } },
+    { RG_POWER_BRACELET, { RG_POWER_BRACELET, "RG_POWER_BRACELET", "RG_POWER_BRACELET_Faded", gButtonBackgroundTex } },
 };
 
 std::map<uint32_t, QuestMapEntry> questMapping = {
@@ -212,6 +220,16 @@ void RegisterImGuiItemIcons() {
                                                                             gregGreen);
         Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(entry.second.nameFaded,
                                                                             entry.second.texturePath, gregFadedGreen);
+    }
+
+    for (const auto& entry : actionShuffleMapping) {
+        ImVec4 aButtonBlue = ImVec4(90.f / 255.f, 90.f / 250.f, 255.f / 255.f, 255.f / 255.f);
+        ImVec4 aButtonBlueFaded = aButtonBlue;
+        aButtonBlueFaded.w = 0.3f;
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(entry.second.name, entry.second.texturePath,
+                                                                            aButtonBlue);
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(entry.second.nameFaded,
+                                                                            entry.second.texturePath, aButtonBlueFaded);
     }
 
     for (const auto& entry : customItemsMapping) {


### PR DESCRIPTION
Adds icons to the item tracker for the various action shuffles, including swim, which been merged for a while but did not have an icon. I tried to set them up so they look kinda like the A button in the game UI does when these actions are available, with the exception of Open Chests (which uses the chest map mark icon) and Swim (which uses the silver scale icon but is different because the word "Swim" is overlayed on top of it).

Also, I didn't bother giving these their own window options, they are just appended to the main window when their respective shuffles are on.

Screenshot for reference:
<img width="680" height="208" alt="image" src="https://github.com/user-attachments/assets/7b280d1b-d2d0-43af-9f23-f77414f67359" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5213364331.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5213375979.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5213423682.zip)
<!--- section:artifacts:end -->