### PR TITLE
Fixes missing flag filter theme color

### DIFF
--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1120,7 +1120,9 @@ void DrawFlagsTab() {
             ImGui::PushID(flagTable.name);
             ImGuiTextFilter& flagFilter = flagTableFilters[flagTable.name];
             ImGui::SetNextItemWidth(ImGui::GetFontSize() * 16);
+            PushStyleInput(THEME_COLOR);
             flagFilter.Draw();
+            PopStyleInput();
             ImGui::Spacing();
 
             if (!flagFilter.IsActive()) {


### PR DESCRIPTION
Fixes a missing theme color style push for the flag filter text input in the save editor window. Image below
<img width="521" height="277" alt="image" src="https://github.com/user-attachments/assets/1dfe86e7-9bdd-4cc3-b8f8-daa546fa3224" />

If anyone seeing this is aware of any random UI elements that are missing theme colors, please let me know and I can add them to this PR.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5213496157.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5213511287.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5213553759.zip)
<!--- section:artifacts:end -->