### PR TITLE
Small patch to unequipping items

### DIFF
--- a/soh/soh/Enhancements/ItemUnequip.cpp
+++ b/soh/soh/Enhancements/ItemUnequip.cpp
@@ -65,6 +65,10 @@ void RegisterItemUnequip() {
             shouldUnequip = true;
         } else if (cursorItem == ITEM_ARROW_LIGHT && equippedItem == ITEM_BOW_ARROW_LIGHT) {
             shouldUnequip = true;
+        } else if (cursorItem == ITEM_BOW &&
+                   (equippedItem == ITEM_BOW_ARROW_FIRE || equippedItem == ITEM_BOW_ARROW_ICE ||
+                    equippedItem == ITEM_BOW_ARROW_LIGHT)) {
+            shouldUnequip = true;
         }
 
         if (shouldUnequip) {

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -752,7 +752,7 @@ void SohMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip(
             "Equip items and equipment on the D-pad. If used with \"D-pad on Pause Screen\", you must "
             "hold C-Up to equip instead of navigate."));
-    AddWidget(path, "Unequip C-Items on Re-press", WIDGET_CVAR_CHECKBOX)
+    AddWidget(path, "Allow unequipping Items", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("ItemUnequip"))
         .Options(CheckboxOptions().Tooltip("Allows unequipping items from C-Buttons/D-pad by hovering over an equipped "
                                            "item and pressing the button it's equipped to."));


### PR DESCRIPTION
just a small change to allow unequipping magic arrows from the bow item to match functionality between ports

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5237826826.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5237924305.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5238224935.zip)
<!--- section:artifacts:end -->