### PR TITLE
Basic Surround Sound support.

### DIFF
--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -1,4 +1,5 @@
 #include <libultraship/libultra.h>
+#include <libultraship/bridge/audiobridge.h>
 #include "global.h"
 #include "soh/OTRGlobals.h"
 #include "soh/Enhancements/audio/AudioEditor.h"
@@ -4965,25 +4966,32 @@ void Audio_SetCodeReverb(s8 reverb) {
 
 void func_800F6700(s8 arg0) {
     s8 sp1F = 0;
+    AudioChannelsSetting channelsSetting = audioStereo;
 
     switch (arg0) {
         case 0:
             sp1F = 0;
             D_80130604 = 0;
+            channelsSetting = audioStereo;
             break;
         case 1:
             sp1F = 3;
             D_80130604 = 3;
+            channelsSetting = audioStereo;
             break;
         case 2:
             sp1F = 1;
             D_80130604 = 1;
+            channelsSetting = audioStereo;
             break;
         case 3:
             sp1F = 0;
             D_80130604 = 2;
+            channelsSetting = audioSurround51;
             break;
     }
+
+    SetAudioChannelsSetting(channelsSetting);
 
     Audio_SeqCmdE0(SEQ_PLAYER_BGM_MAIN, sp1F);
 }

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -4966,32 +4966,33 @@ void Audio_SetCodeReverb(s8 reverb) {
 
 void func_800F6700(s8 arg0) {
     s8 sp1F = 0;
-    AudioChannelsSetting channelsSetting = audioStereo;
 
     switch (arg0) {
         case 0:
             sp1F = 0;
             D_80130604 = 0;
-            channelsSetting = audioStereo;
+            // SOH [Port] Inform LUS of audio setting change
+            SetAudioChannels(audioStereo);
             break;
         case 1:
             sp1F = 3;
             D_80130604 = 3;
-            channelsSetting = audioStereo;
+            // SOH [Port] Inform LUS of audio setting change
+            SetAudioChannels(audioStereo);
             break;
         case 2:
             sp1F = 1;
             D_80130604 = 1;
-            channelsSetting = audioStereo;
+            // SOH [Port] Inform LUS of audio setting change
+            SetAudioChannels(audioStereo);
             break;
         case 3:
             sp1F = 0;
             D_80130604 = 2;
-            channelsSetting = audioMatrix51;
+            // SOH [Port] Inform LUS of audio setting change
+            SetAudioChannels(audioMatrix51);
             break;
     }
-
-    SetAudioChannels(channelsSetting);
 
     Audio_SeqCmdE0(SEQ_PLAYER_BGM_MAIN, sp1F);
 }

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -4987,11 +4987,11 @@ void func_800F6700(s8 arg0) {
         case 3:
             sp1F = 0;
             D_80130604 = 2;
-            channelsSetting = audioSurround51;
+            channelsSetting = audioMatrix51;
             break;
     }
 
-    SetAudioChannelsSetting(channelsSetting);
+    SetAudioChannels(channelsSetting);
 
     Audio_SeqCmdE0(SEQ_PLAYER_BGM_MAIN, sp1F);
 }


### PR DESCRIPTION
This PR uses the new Sound Matrix Decoder in LUS whenever Surround Sound is selected.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5281475045.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5281494163.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5281770472.zip)
<!--- section:artifacts:end -->