### PR TITLE
Dev: Mac/Linux compat for VS Code tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,14 +9,24 @@
                 "-S",
                 ".",
                 "-B",
-                "build/x64",
+                "build-cmake",
                 "-G",
-                "Visual Studio 17 2022",
-                "-T",
-                "v143",
-                "-A",
-                "x64"
+                "Ninja"
             ],
+            "windows": {
+                "args": [
+                    "-S",
+                    ".",
+                    "-B",
+                    "build/x64",
+                    "-G",
+                    "Visual Studio 17 2022",
+                    "-T",
+                    "v143",
+                    "-A",
+                    "x64"
+                ]
+            },
             "group": "build",
             "problemMatcher": []
         },
@@ -26,10 +36,18 @@
             "command": "cmake",
             "args": [
                 "--build",
-                "./build/x64",
+                "build-cmake",
                 "--target",
                 "GenerateSohOtr"
             ],
+            "windows": {
+                "args": [
+                    "--build",
+                    "./build/x64",
+                    "--target",
+                    "GenerateSohOtr"
+                ]
+            },
             "group": "build",
             "problemMatcher": []
         },
@@ -39,8 +57,14 @@
             "command": "cmake",
             "args": [
                 "--build",
-                "./build/x64"
+                "build-cmake"
             ],
+            "windows": {
+                "args": [
+                    "--build",
+                    "./build/x64"
+                ]
+            },
             "group": {
                 "kind": "build",
                 "isDefault": true


### PR DESCRIPTION
This pull request updates .vscode/tasks.json to also work on Mac/Linux.

- **Before:** the `.args` for each task would only work on Windows
- **After:** the default `.args` are for both Mac/Linux and then they are overridden by `.windows.args`

When looking at the diff, perhaps turn on “ignore whitespace.”

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5311305558.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5311336796.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5311524054.zip)
<!--- section:artifacts:end -->