### PR TITLE
Fix segfault on quit

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1556,6 +1556,7 @@ extern "C" void DeinitOTR() {
     // Destroying gui here because we have shared ptrs to LUS objects which output to SPDLOG which is destroyed before
     // these shared ptrs.
     SohGui::Destroy();
+    sohFast3dWindow = nullptr;
 
     OTRGlobals::Instance->context = nullptr;
 }


### PR DESCRIPTION
This pull request fixes #6159.

It turned out that `OTRGlobals.cpp` had a lingering reference to the Fast3DWindow which meant that [ship/Context.cpp#L39](https://github.com/koplas/libultraship/blob/41eeeb247ed3f83baaf1ea73b364a57719c14d99/src/ship/Context.cpp#L39) did not destruct the window as (what looks to be) intended.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5312321803.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5312392175.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5312601685.zip)
<!--- section:artifacts:end -->