### PR TITLE
Implement toggle for allowing background inputs

### DIFF
--- a/soh/soh/SohGui/SohMenuSettings.cpp
+++ b/soh/soh/SohGui/SohMenuSettings.cpp
@@ -145,6 +145,17 @@ void SohMenu::AddMenuSettings() {
             "Allows controller navigation of the port menu (Settings, Enhancements,...)\nCAUTION: "
             "This will disable game inputs while the menu is visible.\n\nD-pad to move between "
             "items, A to select, B to move up in scope."));
+    AddWidget(path, "Allow background inputs", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ALLOW_BACKGROUND_INPUTS)
+        .RaceDisable(false)
+        .Callback([](WidgetInfo& info) {
+            SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS,
+                        CVarGetInteger(CVAR_ALLOW_BACKGROUND_INPUTS, 1) ? "1" : "0");
+        })
+        .Options(CheckboxOptions()
+                     .Tooltip("Allows controller inputs to be picked up by the game even when the game window isn't "
+                              "the focused window.")
+                     .DefaultValue(1));
     AddWidget(path, "Menu Background Opacity", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar(CVAR_SETTING("Menu.BackgroundOpacity"))
         .RaceDisable(false)


### PR DESCRIPTION
As the title says, allows for the user to toggle wether the game should accept inputs when the game window isn't focused. This was pretty highly requested for archipelago reasons.

Relies on https://github.com/Kenix3/libultraship/pull/994

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5318957648.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5318989867.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5319047703.zip)
<!--- section:artifacts:end -->