### PR TITLE
Fix Linux appimage ROM behavior

### DIFF
--- a/soh/soh/Extractor/Extract.cpp
+++ b/soh/soh/Extractor/Extract.cpp
@@ -229,7 +229,8 @@ void Extractor::FilterRoms(std::vector<std::string>& roms, RomSearchMode searchM
 void Extractor::GetRoms(std::vector<std::string>& roms) {
 #ifdef _WIN32
     WIN32_FIND_DATAA ffd;
-    HANDLE h = FindFirstFileA(".\\*", &ffd);
+    std::string search = std::string(mSearchPath + "\\*");
+    HANDLE h = FindFirstFileA(search.c_str(), &ffd);
 
     do {
         if (!(ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -415,6 +415,7 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
     std::atomic<size_t> extractCount = 0, totalExtract = 0;
 
     std::string installPath = Ship::Context::GetAppBundlePath();
+    std::string dataPath = Ship::Context::GetAppDirectoryPath(appShortName);
     std::string file;
 
 #if defined(__SWITCH__)
@@ -631,6 +632,8 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
                     case PS_LOCAL: {
                         extract = Extractor();
                         extract.SetSearchPath(installPath);
+                        extract.GetRoms(args);
+                        extract.SetSearchPath(dataPath);
                         extract.GetRoms(args);
                         if (!args.empty()) {
                             promptStep = PS_WAIT;


### PR DESCRIPTION
Adds the app directory folder to the ROM search for automatically finding ROMs to fix the Linux appimage ROM search behavior.
Also makes Windows ROM search react to the set search path.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5322549193.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5322574568.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5322646291.zip)
<!--- section:artifacts:end -->