### PR TITLE
Add an option to include Dogs in the Enemy Randomizer

### DIFF
--- a/soh/soh/Enhancements/enemyrandomizer.cpp
+++ b/soh/soh/Enhancements/enemyrandomizer.cpp
@@ -18,8 +18,10 @@ extern PlayState* gPlayState;
 }
 
 #define CVAR_ENEMY_RANDOMIZER_NAME CVAR_ENHANCEMENT("RandomizedEnemies")
+#define CVAR_RANDOMIZE_DOGS_NAME CVAR_ENHANCEMENT("RandomizeDogs")
 #define CVAR_ENEMY_RANDOMIZER_DEFAULT ENEMY_RANDOMIZER_OFF
 #define CVAR_ENEMY_RANDOMIZER_VALUE CVarGetInteger(CVAR_ENEMY_RANDOMIZER_NAME, CVAR_ENEMY_RANDOMIZER_DEFAULT)
+#define CVAR_RANDOMIZE_DOGS_VALUE CVarGetInteger(CVAR_RANDOMIZE_DOGS_NAME, 0)
 
 typedef struct EnemyEntry {
     int16_t id;
@@ -241,6 +243,7 @@ static int enemiesToRandomize[] = {
     ACTOR_EN_OKUTA,       // Octorok
     ACTOR_EN_WALLMAS,     // Wallmaster
     ACTOR_EN_DODONGO,     // Dodongo
+    ACTOR_EN_DOG,         // Dog
     // ACTOR_EN_REEBA,       // Leever (reliant on spawner (z_en_encount1.c))
     ACTOR_EN_PEEHAT,    // Flying Peahat, big one spawning larva, larva
     ACTOR_EN_ZF,        // Lizalfos, Dinolfos
@@ -381,6 +384,15 @@ extern "C" uint8_t GetRandomizedEnemy(PlayState* play, int16_t* actorId, f32* po
             case ACTOR_EN_CROW:
                 *posY = *posY + 75;
                 break;
+            // Spawn dog with an ID different than the one following, if there is one, and randomize color
+            // Dog Actors will destroy themselves if the following dog has the same ID as the one trying to spawn
+            case ACTOR_EN_DOG:
+                if ((gSaveContext.dogParams & 0x0F00)) {
+                    *params = ((gSaveContext.dogParams & 0x0F00) ^ 0x0F00);
+                } else {
+                    *params = 0x0100;
+                }
+                *params |= Random(0, 2); // Random color 0 = white | 1 = brown
             default:
                 break;
         }
@@ -401,6 +413,9 @@ void GetSelectedEnemies() {
             selectedEnemyList.push_back(randomizedEnemySpawnTable[i]);
         }
     }
+    if (CVAR_RANDOMIZE_DOGS_VALUE) {
+        selectedEnemyList.push_back({ ACTOR_EN_DOG, 0 });
+    }
     if (selectedEnemyList.size() == 0) {
         selectedEnemyList.push_back(randomizedEnemySpawnTable[0]);
     }
@@ -417,7 +432,12 @@ EnemyEntry GetRandomizedEnemyEntry(uint32_t seed, PlayState* play) {
         }
     }
     if (filteredEnemyList.size() == 0) {
-        filteredEnemyList = selectedEnemyList;
+        // Fail-safe for soft-locks if only selected "enemy" is dogs -- replace with Withered Deku Baba
+        if (selectedEnemyList.size() == 1 && selectedEnemyList[0].id == ACTOR_EN_DOG) {
+            filteredEnemyList.push_back({ ACTOR_EN_KAREBABA, 0 });
+        } else {
+            filteredEnemyList = selectedEnemyList;
+        }
     }
     if (CVAR_ENEMY_RANDOMIZER_VALUE == ENEMY_RANDOMIZER_RANDOM_SEEDED) {
         uint32_t finalSeed =
@@ -491,6 +511,9 @@ bool IsEnemyFoundToRandomize(int16_t sceneNum, int8_t roomNum, int16_t actorId, 
                     return (!(!isMQ && sceneNum == SCENE_WATER_TEMPLE && roomNum == 2));
                 case ACTOR_EN_SKJ:
                     return !(sceneNum == SCENE_LOST_WOODS && LINK_IS_CHILD);
+                // If the dog is Richard or is following the player, we do not want to randomize it
+                case ACTOR_EN_DOG:
+                    return CVAR_RANDOMIZE_DOGS_VALUE && (params & 0x0F00) >> 8 != 0 && (params & 0x8000) == 0;
                 default:
                     return 1;
             }
@@ -514,10 +537,11 @@ bool IsEnemyAllowedToSpawn(int16_t sceneNum, int8_t roomNum, EnemyEntry enemy) {
     bool enemiesToExcludeClearRooms =
         enemy.id == ACTOR_EN_FZ || enemy.id == ACTOR_EN_VM || enemy.id == ACTOR_EN_SB || enemy.id == ACTOR_EN_NY ||
         enemy.id == ACTOR_EN_CLEAR_TAG || enemy.id == ACTOR_EN_WALLMAS || enemy.id == ACTOR_EN_TORCH2 ||
-        (enemy.id == ACTOR_EN_MB && enemy.params == 0) || enemy.id == ACTOR_EN_FD || enemy.id == ACTOR_EN_ANUBICE_TAG;
+        (enemy.id == ACTOR_EN_MB && enemy.params == 0) || enemy.id == ACTOR_EN_FD || enemy.id == ACTOR_EN_ANUBICE_TAG
+        || enemy.id == ACTOR_EN_DOG;
 
     // Bari - Spawns 3 more enemies, potentially extremely difficult in timed rooms.
-    bool enemiesToExcludeTimedRooms = enemiesToExcludeClearRooms || enemy.id == ACTOR_EN_VALI;
+    bool enemiesToExcludeTimedRooms = enemiesToExcludeClearRooms || enemy.id == ACTOR_EN_VALI || enemy.id == ACTOR_EN_DOG;
 
     switch (sceneNum) {
         // Deku Tree

--- a/soh/soh/Enhancements/enemyrandomizer.cpp
+++ b/soh/soh/Enhancements/enemyrandomizer.cpp
@@ -513,7 +513,7 @@ bool IsEnemyFoundToRandomize(int16_t sceneNum, int8_t roomNum, int16_t actorId, 
                     return !(sceneNum == SCENE_LOST_WOODS && LINK_IS_CHILD);
                 // If the dog is Richard or is following the player, we do not want to randomize it
                 case ACTOR_EN_DOG:
-                    return CVAR_RANDOMIZE_DOGS_VALUE && (params & 0x0F00) >> 8 != 0 && (params & 0x8000) == 0;
+                    return CVAR_RANDOMIZE_DOGS_VALUE && (params & 0x0F00) != 0 && (params & 0x8000) == 0;
                 default:
                     return 1;
             }

--- a/soh/soh/Enhancements/enemyrandomizer.cpp
+++ b/soh/soh/Enhancements/enemyrandomizer.cpp
@@ -534,14 +534,15 @@ bool IsEnemyAllowedToSpawn(int16_t sceneNum, int8_t roomNum, EnemyEntry enemy) {
     // Flare dancer, Arwing & Dark Link - Both go out of bounds way too easily, softlocking the player.
     // Wallmaster - Not easily visible, often makes players think they're softlocked and that there's no enemies left.
     // Club Moblin - Many issues with them falling or placing out of bounds. Maybe fixable in the future?
-    bool enemiesToExcludeClearRooms =
-        enemy.id == ACTOR_EN_FZ || enemy.id == ACTOR_EN_VM || enemy.id == ACTOR_EN_SB || enemy.id == ACTOR_EN_NY ||
-        enemy.id == ACTOR_EN_CLEAR_TAG || enemy.id == ACTOR_EN_WALLMAS || enemy.id == ACTOR_EN_TORCH2 ||
-        (enemy.id == ACTOR_EN_MB && enemy.params == 0) || enemy.id == ACTOR_EN_FD || enemy.id == ACTOR_EN_ANUBICE_TAG
-        || enemy.id == ACTOR_EN_DOG;
+    bool enemiesToExcludeClearRooms = enemy.id == ACTOR_EN_FZ || enemy.id == ACTOR_EN_VM || enemy.id == ACTOR_EN_SB ||
+                                      enemy.id == ACTOR_EN_NY || enemy.id == ACTOR_EN_CLEAR_TAG ||
+                                      enemy.id == ACTOR_EN_WALLMAS || enemy.id == ACTOR_EN_TORCH2 ||
+                                      (enemy.id == ACTOR_EN_MB && enemy.params == 0) || enemy.id == ACTOR_EN_FD ||
+                                      enemy.id == ACTOR_EN_ANUBICE_TAG || enemy.id == ACTOR_EN_DOG;
 
     // Bari - Spawns 3 more enemies, potentially extremely difficult in timed rooms.
-    bool enemiesToExcludeTimedRooms = enemiesToExcludeClearRooms || enemy.id == ACTOR_EN_VALI || enemy.id == ACTOR_EN_DOG;
+    bool enemiesToExcludeTimedRooms =
+        enemiesToExcludeClearRooms || enemy.id == ACTOR_EN_VALI || enemy.id == ACTOR_EN_DOG;
 
     switch (sceneNum) {
         // Deku Tree

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1684,17 +1684,20 @@ void SohMenu::AddMenuEnhancements() {
         })
         .Options(CheckboxOptions().Tooltip(
             "Scales normal enemies Health with their randomized size. *This will NOT affect Bosses!*"));
+    AddWidget(path, "Randomizer Settings", WIDGET_SEPARATOR_TEXT).PreFunc([](WidgetInfo& info) {
+        info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0);
+    });
+    AddWidget(path, "Include Dogs in Randomizer", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("RandomizeDogs"))
+        .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0); })
+        .Options(CheckboxOptions().Tooltip("Dogs will be randomized and can replace enemies."))
+        .Callback([](WidgetInfo& info) { GetSelectedEnemies(); });
     AddWidget(path, "Enemy List", WIDGET_SEPARATOR_TEXT).PreFunc([](WidgetInfo& info) {
         info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0);
     });
     AddWidget(path, "Select all Enemies", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("RandomizedEnemyList.All"))
         .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0); })
-        .Callback([](WidgetInfo& info) { GetSelectedEnemies(); });
-    AddWidget(path, "Include Dogs in Randomizer", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_ENHANCEMENT("RandomizeDogs"))
-        .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0); })
-        .Options(CheckboxOptions().Tooltip("Dogs will be randomized and can replace enemies."))
         .Callback([](WidgetInfo& info) { GetSelectedEnemies(); });
     AddWidget(path, "Enemy List", WIDGET_SEPARATOR).PreFunc([](WidgetInfo& info) {
         info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0);

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1697,7 +1697,7 @@ void SohMenu::AddMenuEnhancements() {
             info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0);
         })
         .Options(CheckboxOptions().Tooltip("Dogs will be randomized and can replace enemies."))
-        .Callback([](WidgetInfo& info) { GetSelectedEnemies();});
+        .Callback([](WidgetInfo& info) { GetSelectedEnemies(); });
     AddWidget(path, "Enemy List", WIDGET_SEPARATOR).PreFunc([](WidgetInfo& info) {
         info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0);
     });

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1693,9 +1693,7 @@ void SohMenu::AddMenuEnhancements() {
         .Callback([](WidgetInfo& info) { GetSelectedEnemies(); });
     AddWidget(path, "Include Dogs in Randomizer", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("RandomizeDogs"))
-        .PreFunc([](WidgetInfo& info) {
-            info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0);
-        })
+        .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0); })
         .Options(CheckboxOptions().Tooltip("Dogs will be randomized and can replace enemies."))
         .Callback([](WidgetInfo& info) { GetSelectedEnemies(); });
     AddWidget(path, "Enemy List", WIDGET_SEPARATOR).PreFunc([](WidgetInfo& info) {

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1691,6 +1691,13 @@ void SohMenu::AddMenuEnhancements() {
         .CVar(CVAR_ENHANCEMENT("RandomizedEnemyList.All"))
         .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0); })
         .Callback([](WidgetInfo& info) { GetSelectedEnemies(); });
+    AddWidget(path, "Include Dogs in Randomizer", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("RandomizeDogs"))
+        .PreFunc([](WidgetInfo& info) {
+            info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0);
+        })
+        .Options(CheckboxOptions().Tooltip("Dogs will be randomized and can replace enemies."))
+        .Callback([](WidgetInfo& info) { GetSelectedEnemies();});
     AddWidget(path, "Enemy List", WIDGET_SEPARATOR).PreFunc([](WidgetInfo& info) {
         info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0);
     });


### PR DESCRIPTION
When activated, all dogs will be randomized and can be replaced with enemies, or replace other enemies.

Workarounds added for not replacing Richard and for clear and timed rooms which would soft lock the game if all enemies were randomized to dogs.

<img width="486" height="389" alt="image" src="https://github.com/user-attachments/assets/dbd747ce-069a-4b60-9b75-bfaccf2d9e15" />
<img width="1243" height="649" alt="image" src="https://github.com/user-attachments/assets/4fe5250f-c3be-4eb1-9bc1-86ca2d11f30d" />
<img width="1243" height="649" alt="image" src="https://github.com/user-attachments/assets/5a0a69a1-5b85-4e1b-9865-4c972811d189" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5332206413.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5332235756.zip)
<!--- section:artifacts:end -->