### PR TITLE
Bug Fix: Reset selected enemies for Enemy Randomizer when choosing "Select All Enemies"

### DIFF
--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1689,7 +1689,8 @@ void SohMenu::AddMenuEnhancements() {
     });
     AddWidget(path, "Select all Enemies", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("RandomizedEnemyList.All"))
-        .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0); });
+        .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0); })
+        .Callback([](WidgetInfo& info) { GetSelectedEnemies(); });
     AddWidget(path, "Enemy List", WIDGET_SEPARATOR).PreFunc([](WidgetInfo& info) {
         info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0);
     });


### PR DESCRIPTION
Noticed that the enemy list wasn't recalculating when selecting "Select all Enemies" box in the Enemy Randomizer settings while working on my [Dog Randomizer](https://github.com/HarbourMasters/Shipwright/pull/6218). It was just simply missing the Callback function.

So if you're playing with only a couple of randomized enemies, and then you click "Select all Enemies", you'll still be stuck with the few until you reset or select another enemy.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5325896601.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5325906899.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5325951292.zip)
<!--- section:artifacts:end -->