### PR TITLE
Add Attacking Cuccos to the Randomizer

### DIFF
--- a/soh/soh/Enhancements/enemyrandomizer.cpp
+++ b/soh/soh/Enhancements/enemyrandomizer.cpp
@@ -34,6 +34,7 @@ const char* enemyCVarList[RANDOMIZED_ENEMY_SPAWN_TABLE_SIZE] = {
     CVAR_ENHANCEMENT("RandomizedEnemyList.Anubis"),
     CVAR_ENHANCEMENT("RandomizedEnemyList.Armos"),
     CVAR_ENHANCEMENT("RandomizedEnemyList.Arwing"),
+    CVAR_ENHANCEMENT("RandomizedEnemyList.AttackingCucco"),
     CVAR_ENHANCEMENT("RandomizedEnemyList.BabyDodongo"),
     CVAR_ENHANCEMENT("RandomizedEnemyList.Bari"),
     CVAR_ENHANCEMENT("RandomizedEnemyList.Beamos"),
@@ -98,6 +99,7 @@ const char* enemyNameList[RANDOMIZED_ENEMY_SPAWN_TABLE_SIZE] = {
     "Anubis",
     "Armos",
     "Arwing",
+    "Cucco (Attacking)",
     "Baby Dodongo",
     "Bari",
     "Beamos",
@@ -159,23 +161,24 @@ const char* enemyNameList[RANDOMIZED_ENEMY_SPAWN_TABLE_SIZE] = {
 };
 
 static EnemyEntry randomizedEnemySpawnTable[RANDOMIZED_ENEMY_SPAWN_TABLE_SIZE] = {
-    { ACTOR_EN_ANUBICE_TAG, 1 }, // Anubis
-    { ACTOR_EN_AM, -1 },         // Armos
-    { ACTOR_EN_CLEAR_TAG, 1 },   // Arwing
-    { ACTOR_EN_DODOJR, 0 },      // Baby Dodongo
-    { ACTOR_EN_VALI, -1 },       // Bari (big jellyfish)
-    { ACTOR_EN_VM, 1280 },       // Beamos
-    { ACTOR_EN_ST, 1 },          // Skulltula (big)
-    { ACTOR_EN_SKB, 20 },        // Stalchild (big)
-    { ACTOR_EN_BILI, 0 },        // Biri (jellyfish)
-    { ACTOR_EN_IK, 2 },          // Iron Knuckle (black, standing)
-    { ACTOR_EN_TITE, -2 },       // Tektite (blue)
-    { ACTOR_EN_BB, -1 },         // Bubble (flying skull enemy) (blue)
-    { ACTOR_EN_MB, 0 },          // Club Moblin
-    { ACTOR_EN_TORCH2, 0 },      // Dark Link
-    { ACTOR_EN_ZF, -2 },         // Dinolfos
-    { ACTOR_EN_DODONGO, -1 },    // Dodongo
-    { ACTOR_EN_FIREFLY, 1 },     // Fire Keese
+    { ACTOR_EN_ANUBICE_TAG, 1 },  // Anubis
+    { ACTOR_EN_AM, -1 },          // Armos
+    { ACTOR_EN_CLEAR_TAG, 1 },    // Arwing
+    { ACTOR_EN_ATTACK_NIW, 777 }, // Cucco (Attacking)
+    { ACTOR_EN_DODOJR, 0 },       // Baby Dodongo
+    { ACTOR_EN_VALI, -1 },        // Bari (big jellyfish)
+    { ACTOR_EN_VM, 1280 },        // Beamos
+    { ACTOR_EN_ST, 1 },           // Skulltula (big)
+    { ACTOR_EN_SKB, 20 },         // Stalchild (big)
+    { ACTOR_EN_BILI, 0 },         // Biri (jellyfish)
+    { ACTOR_EN_IK, 2 },           // Iron Knuckle (black, standing)
+    { ACTOR_EN_TITE, -2 },        // Tektite (blue)
+    { ACTOR_EN_BB, -1 },          // Bubble (flying skull enemy) (blue)
+    { ACTOR_EN_MB, 0 },           // Club Moblin
+    { ACTOR_EN_TORCH2, 0 },       // Dark Link
+    { ACTOR_EN_ZF, -2 },          // Dinolfos
+    { ACTOR_EN_DODONGO, -1 },     // Dodongo
+    { ACTOR_EN_FIREFLY, 1 },      // Fire Keese
     // { ACTOR_EN_FD, 0 },          // Flare Dancer (possible cause of crashes because of spawning flame actors on
     // sloped ground)
     { ACTOR_EN_YUKABYUN, 0 },      // Flying Floor Tile
@@ -242,42 +245,43 @@ static int enemiesToRandomize[] = {
     ACTOR_EN_WALLMAS,     // Wallmaster
     ACTOR_EN_DODONGO,     // Dodongo
     // ACTOR_EN_REEBA,       // Leever (reliant on spawner (z_en_encount1.c))
-    ACTOR_EN_PEEHAT,    // Flying Peahat, big one spawning larva, larva
-    ACTOR_EN_ZF,        // Lizalfos, Dinolfos
-    ACTOR_EN_GOMA,      // Gohma Larva (normal, eggs, gohma eggs)
-    ACTOR_EN_BUBBLE,    // Shabom (bubble)
-    ACTOR_EN_DODOJR,    // Baby Dodongo
-    ACTOR_EN_TORCH2,    // Dark Link
-    ACTOR_EN_BILI,      // Biri (small jellyfish)
-    ACTOR_EN_TP,        // Electric Tailpasaran
-    ACTOR_EN_ST,        // Skulltula (normal, big, invisible)
-    ACTOR_EN_BW,        // Torch Slug
-    ACTOR_EN_EIYER,     // Stinger (land)
-    ACTOR_EN_MB,        // Moblins (Club, spear)
-    ACTOR_EN_DEKUBABA,  // Deku Baba (small, large)
-    ACTOR_EN_AM,        // Armos (enemy variant)
-    ACTOR_EN_DEKUNUTS,  // Mad Scrub (single attack, triple attack)
-    ACTOR_EN_VALI,      // Bari (big jellyfish) (spawns very high up)
-    ACTOR_EN_BB,        // Bubble (flying skull enemy) (all colors)
-    ACTOR_EN_YUKABYUN,  // Flying Floor Tile
-    ACTOR_EN_VM,        // Beamos
-    ACTOR_EN_FLOORMAS,  // Floormaster
-    ACTOR_EN_RD,        // Redead, Gibdo
-    ACTOR_EN_SW,        // Skullwalltula
-    ACTOR_EN_FD,        // Flare Dancer
-    ACTOR_EN_SB,        // Shell Blade
-    ACTOR_EN_KAREBABA,  // Withered Deku Baba
-    ACTOR_EN_RR,        // Like-Like
-    ACTOR_EN_NY,        // Spike (rolling enemy)
-    ACTOR_EN_IK,        // Iron Knuckle
-    ACTOR_EN_TUBO_TRAP, // Flying pot
-    ACTOR_EN_FZ,        // Freezard
-    ACTOR_EN_WEIYER,    // Stinger (Water)
-    ACTOR_EN_HINTNUTS,  // Hint Deku Scrubs
-    ACTOR_EN_WF,        // Wolfos
-    ACTOR_EN_SKB,       // Stalchild
-    ACTOR_EN_CROW,      // Guay
-    ACTOR_EN_SKJ,       // Skull Kid
+    ACTOR_EN_PEEHAT,     // Flying Peahat, big one spawning larva, larva
+    ACTOR_EN_ZF,         // Lizalfos, Dinolfos
+    ACTOR_EN_GOMA,       // Gohma Larva (normal, eggs, gohma eggs)
+    ACTOR_EN_BUBBLE,     // Shabom (bubble)
+    ACTOR_EN_DODOJR,     // Baby Dodongo
+    ACTOR_EN_TORCH2,     // Dark Link
+    ACTOR_EN_BILI,       // Biri (small jellyfish)
+    ACTOR_EN_TP,         // Electric Tailpasaran
+    ACTOR_EN_ST,         // Skulltula (normal, big, invisible)
+    ACTOR_EN_BW,         // Torch Slug
+    ACTOR_EN_EIYER,      // Stinger (land)
+    ACTOR_EN_MB,         // Moblins (Club, spear)
+    ACTOR_EN_DEKUBABA,   // Deku Baba (small, large)
+    ACTOR_EN_AM,         // Armos (enemy variant)
+    ACTOR_EN_DEKUNUTS,   // Mad Scrub (single attack, triple attack)
+    ACTOR_EN_VALI,       // Bari (big jellyfish) (spawns very high up)
+    ACTOR_EN_BB,         // Bubble (flying skull enemy) (all colors)
+    ACTOR_EN_YUKABYUN,   // Flying Floor Tile
+    ACTOR_EN_VM,         // Beamos
+    ACTOR_EN_FLOORMAS,   // Floormaster
+    ACTOR_EN_RD,         // Redead, Gibdo
+    ACTOR_EN_SW,         // Skullwalltula
+    ACTOR_EN_FD,         // Flare Dancer
+    ACTOR_EN_SB,         // Shell Blade
+    ACTOR_EN_KAREBABA,   // Withered Deku Baba
+    ACTOR_EN_RR,         // Like-Like
+    ACTOR_EN_NY,         // Spike (rolling enemy)
+    ACTOR_EN_IK,         // Iron Knuckle
+    ACTOR_EN_TUBO_TRAP,  // Flying pot
+    ACTOR_EN_FZ,         // Freezard
+    ACTOR_EN_WEIYER,     // Stinger (Water)
+    ACTOR_EN_HINTNUTS,   // Hint Deku Scrubs
+    ACTOR_EN_WF,         // Wolfos
+    ACTOR_EN_SKB,        // Stalchild
+    ACTOR_EN_CROW,       // Guay
+    ACTOR_EN_SKJ,        // Skull Kid
+    ACTOR_EN_ATTACK_NIW, // Cucco (Attacking)
 };
 
 extern "C" uint8_t GetRandomizedEnemy(PlayState* play, int16_t* actorId, f32* posX, f32* posY, f32* posZ, int16_t* rotX,
@@ -352,6 +356,7 @@ extern "C" uint8_t GetRandomizedEnemy(PlayState* play, int16_t* actorId, f32* po
             play->sceneNum + *actorId + (int)*posX + (int)*posY + (int)*posZ + *rotX + *rotY + *rotZ + *params;
         EnemyEntry randomEnemy = GetRandomizedEnemyEntry(seed, play);
 
+        int16_t prevActorId = *actorId;
         *actorId = randomEnemy.id;
         *params = randomEnemy.params;
 
@@ -380,6 +385,14 @@ extern "C" uint8_t GetRandomizedEnemy(PlayState* play, int16_t* actorId, f32* po
             case ACTOR_EN_CLEAR_TAG:
             case ACTOR_EN_CROW:
                 *posY = *posY + 75;
+                break;
+            // Reset params on a randomized Attacking Cucco if it is replacing one
+            case ACTOR_EN_ATTACK_NIW:
+                if (prevActorId == ACTOR_EN_ATTACK_NIW) {
+                    *params = 0;
+                }
+                *posY = *posY + 75;
+                *rotY = Random(0, 65537) - 32768;
                 break;
             default:
                 break;
@@ -417,7 +430,12 @@ EnemyEntry GetRandomizedEnemyEntry(uint32_t seed, PlayState* play) {
         }
     }
     if (filteredEnemyList.size() == 0) {
-        filteredEnemyList = selectedEnemyList;
+        // Fail-safe for soft-locks if only selected enemy is attacking cuccos -- replace with Withered Deku Baba
+        if (selectedEnemyList.size() == 1 && selectedEnemyList[0].id == ACTOR_EN_ATTACK_NIW) {
+            filteredEnemyList.push_back({ ACTOR_EN_KAREBABA, 0 });
+        } else {
+            filteredEnemyList = selectedEnemyList;
+        }
     }
     if (CVAR_ENEMY_RANDOMIZER_VALUE == ENEMY_RANDOMIZER_RANDOM_SEEDED) {
         uint32_t finalSeed =
@@ -511,13 +529,15 @@ bool IsEnemyAllowedToSpawn(int16_t sceneNum, int8_t roomNum, EnemyEntry enemy) {
     // Flare dancer, Arwing & Dark Link - Both go out of bounds way too easily, softlocking the player.
     // Wallmaster - Not easily visible, often makes players think they're softlocked and that there's no enemies left.
     // Club Moblin - Many issues with them falling or placing out of bounds. Maybe fixable in the future?
-    bool enemiesToExcludeClearRooms =
-        enemy.id == ACTOR_EN_FZ || enemy.id == ACTOR_EN_VM || enemy.id == ACTOR_EN_SB || enemy.id == ACTOR_EN_NY ||
-        enemy.id == ACTOR_EN_CLEAR_TAG || enemy.id == ACTOR_EN_WALLMAS || enemy.id == ACTOR_EN_TORCH2 ||
-        (enemy.id == ACTOR_EN_MB && enemy.params == 0) || enemy.id == ACTOR_EN_FD || enemy.id == ACTOR_EN_ANUBICE_TAG;
+    bool enemiesToExcludeClearRooms = enemy.id == ACTOR_EN_FZ || enemy.id == ACTOR_EN_VM || enemy.id == ACTOR_EN_SB ||
+                                      enemy.id == ACTOR_EN_NY || enemy.id == ACTOR_EN_CLEAR_TAG ||
+                                      enemy.id == ACTOR_EN_WALLMAS || enemy.id == ACTOR_EN_TORCH2 ||
+                                      (enemy.id == ACTOR_EN_MB && enemy.params == 0) || enemy.id == ACTOR_EN_FD ||
+                                      enemy.id == ACTOR_EN_ANUBICE_TAG || enemy.id == ACTOR_EN_ATTACK_NIW;
 
     // Bari - Spawns 3 more enemies, potentially extremely difficult in timed rooms.
-    bool enemiesToExcludeTimedRooms = enemiesToExcludeClearRooms || enemy.id == ACTOR_EN_VALI;
+    bool enemiesToExcludeTimedRooms =
+        enemiesToExcludeClearRooms || enemy.id == ACTOR_EN_VALI || enemy.id == ACTOR_EN_ATTACK_NIW;
 
     switch (sceneNum) {
         // Deku Tree

--- a/soh/soh/Enhancements/enemyrandomizer.cpp
+++ b/soh/soh/Enhancements/enemyrandomizer.cpp
@@ -776,6 +776,14 @@ void RegisterEnemyRandomizer() {
 
     // Handle Cucco updates for randomized Attacking Cuccos
     COND_ID_HOOK(OnActorUpdate, ACTOR_EN_ATTACK_NIW, CVAR_ENEMY_RANDOMIZER_VALUE, HandleAttackCuccoUpdate);
+    // Prevent randomized Attack Cuccos from being culled offscreen
+    COND_VB_SHOULD(VB_DESTROY_OFFSCREEN_EN_ATTACK_NIW, CVAR_ENEMY_RANDOMIZER_VALUE != CVAR_ENEMY_RANDOMIZER_DEFAULT, {
+        Actor* actor = va_arg(args, Actor*);
+
+        if (actor->params == 777) {
+            *should = false;
+        }
+    });
 }
 
 static RegisterShipInitFunc initFunc(RegisterEnemyRandomizer, { CVAR_ENEMY_RANDOMIZER_NAME });

--- a/soh/soh/Enhancements/enemyrandomizer.cpp
+++ b/soh/soh/Enhancements/enemyrandomizer.cpp
@@ -5,6 +5,7 @@
 #include "soh/Enhancements/randomizer/SeedContext.h"
 #include "soh/Enhancements/enhancementTypes.h"
 #include "variables.h"
+#include "overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.h"
 #include "soh/OTRGlobals.h"
 #include "soh/cvar_prefixes.h"
 #include "soh/ResourceManagerHelpers.h"
@@ -386,13 +387,18 @@ extern "C" uint8_t GetRandomizedEnemy(PlayState* play, int16_t* actorId, f32* po
             case ACTOR_EN_CROW:
                 *posY = *posY + 75;
                 break;
-            // Reset params on a randomized Attacking Cucco if it is replacing one
+            // Restore Vanilla Behavior on Attacking Cucco if it is replacing a vanilla one
+            // Otherwise spawn it in the air and rotate randomly
             case ACTOR_EN_ATTACK_NIW:
                 if (prevActorId == ACTOR_EN_ATTACK_NIW) {
                     *params = 0;
+                    // Vanilla spawn height
+                    f32 viewY = play->view.lookAt.y - play->view.eye.y;
+                    *posY = Rand_CenteredFloat(0.3f) + ((play->view.eye.y + 50.0f) + (viewY * 0.5f));
+                } else {
+                    *posY = *posY + 75;
+                    *rotY = Random(0, 65537) - 32768;
                 }
-                *posY = *posY + 75;
-                *rotY = Random(0, 65537) - 32768;
                 break;
             default:
                 break;
@@ -651,6 +657,28 @@ static void OnGerudoFighterDefeat(void* refActor) {
     }
 }
 
+static void HandleAttackCuccoUpdate(void* refActor) {
+    EnAttackNiw* enAttackNiw = reinterpret_cast<EnAttackNiw*>(refActor);
+
+    // params == 777 means this Attacking Cucco was randomized, and we want these to behave differently
+    if (enAttackNiw->actor.params == 777) {
+        // if the cucco is within striking distance, handle the damage here
+        // because vanilla code expects having a normal cucco parent
+        Player* player = GET_PLAYER(gPlayState);
+        if (enAttackNiw->actor.xyzDistToPlayerSq < SQ(20.0f) && player->invincibilityTimer == 0) {
+            func_8002F6D4(gPlayState, &enAttackNiw->actor, 2.0f, enAttackNiw->actor.world.rot.y, 0.0f, 0x10);
+        }
+
+        // keep cucco from flying away
+        enAttackNiw->unk_262 = 0xFF;
+
+        // we want the cucco to face toward the player on random intervals
+        if (Random(0, 20) == 0) {
+            enAttackNiw->unk_2D4 = Rand_CenteredFloat(200.0f) + enAttackNiw->actor.yawTowardsPlayer;
+        }
+    }
+}
+
 void RegisterEnemyRandomizer() {
     COND_ID_HOOK(OnActorInit, ACTOR_EN_MB, CVAR_ENEMY_RANDOMIZER_VALUE, FixClubMoblinScale);
 
@@ -745,6 +773,9 @@ void RegisterEnemyRandomizer() {
     // If Random Gerudo Fighters are defeated, drop some items
     COND_ID_HOOK(OnEnemyDefeat, ACTOR_EN_GELDB, CVAR_ENEMY_RANDOMIZER_VALUE != CVAR_ENEMY_RANDOMIZER_DEFAULT,
                  OnGerudoFighterDefeat);
+
+    // Handle Cucco updates for randomized Attacking Cuccos
+    COND_ID_HOOK(OnActorUpdate, ACTOR_EN_ATTACK_NIW, CVAR_ENEMY_RANDOMIZER_VALUE, HandleAttackCuccoUpdate);
 }
 
 static RegisterShipInitFunc initFunc(RegisterEnemyRandomizer, { CVAR_ENEMY_RANDOMIZER_NAME });

--- a/soh/soh/Enhancements/enemyrandomizer.cpp
+++ b/soh/soh/Enhancements/enemyrandomizer.cpp
@@ -531,6 +531,7 @@ bool IsEnemyAllowedToSpawn(int16_t sceneNum, int8_t roomNum, EnemyEntry enemy) {
     // Freezard - Child Link can only kill this with jump slash Deku Sticks or other equipment like bombs.
     // Beamos - Needs bombs.
     // Anubis - Needs fire.
+    // Cucco (Attacking) - unkillable without water
     // Shell Blade & Spike - Child Link can't kill these with sword or Deku Stick.
     // Flare dancer, Arwing & Dark Link - Both go out of bounds way too easily, softlocking the player.
     // Wallmaster - Not easily visible, often makes players think they're softlocked and that there's no enemies left.
@@ -542,6 +543,7 @@ bool IsEnemyAllowedToSpawn(int16_t sceneNum, int8_t roomNum, EnemyEntry enemy) {
                                       enemy.id == ACTOR_EN_ANUBICE_TAG || enemy.id == ACTOR_EN_ATTACK_NIW;
 
     // Bari - Spawns 3 more enemies, potentially extremely difficult in timed rooms.
+    // Cucco (Attacking) - unkillable without water
     bool enemiesToExcludeTimedRooms =
         enemiesToExcludeClearRooms || enemy.id == ACTOR_EN_VALI || enemy.id == ACTOR_EN_ATTACK_NIW;
 

--- a/soh/soh/Enhancements/enemyrandomizer.h
+++ b/soh/soh/Enhancements/enemyrandomizer.h
@@ -3,7 +3,7 @@
 #include <libultraship/libultra/types.h>
 #include "item-tables/ItemTableTypes.h"
 
-#define RANDOMIZED_ENEMY_SPAWN_TABLE_SIZE 59
+#define RANDOMIZED_ENEMY_SPAWN_TABLE_SIZE 60
 
 extern const char* enemyCVarList[];
 extern const char* enemyNameList[];

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -2597,6 +2597,14 @@ typedef enum {
     // - `s32` commonType
     VB_SET_IDLE_ANIM,
 
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*Actor`
+    VB_DESTROY_OFFSCREEN_EN_ATTACK_NIW,
+
 } GIVanillaBehavior;
 
 #endif

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -1909,8 +1909,7 @@ typedef struct {
     /* 0x4 */ f32 leashScale;
 } TargetRangeParams; // size = 0x8
 
-#define TARGET_RANGE(range, leash) \
-    { SQ(range), (f32)range / leash }
+#define TARGET_RANGE(range, leash) { SQ(range), (f32)range / leash }
 
 TargetRangeParams D_80115FF8[] = {
     TARGET_RANGE(70, 140),   TARGET_RANGE(170, 255),    TARGET_RANGE(280, 5600),      TARGET_RANGE(350, 525),
@@ -3436,8 +3435,12 @@ Actor* Actor_SpawnAsChild(ActorContext* actorCtx, Actor* parent, PlayState* play
     // Gohma (z_boss_goma.c), the Stalchildren spawner (z_en_encount1.c) and the falling platform spawning Stalfos in
     // Forest Temple (z_bg_mori_bigst.c) that normally rely on this behaviour are changed when
     // Enemy Rando is on so they still work properly even without assigning a parent.
+    //
+    // Also, if the parent actor is a Cucco, and it is not spawning an Attacking Cucco, then we don't want the
+    // actor's parent to be this Cucco
     if (CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0) &&
-        (spawnedActor->id == ACTOR_EN_FLOORMAS || spawnedActor->id == ACTOR_EN_PEEHAT)) {
+        ((spawnedActor->id == ACTOR_EN_FLOORMAS || spawnedActor->id == ACTOR_EN_PEEHAT) ||
+         (parent->id == ACTOR_EN_NIW && spawnedActor->id != ACTOR_EN_ATTACK_NIW))) {
         return spawnedActor;
     }
 

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -1909,7 +1909,8 @@ typedef struct {
     /* 0x4 */ f32 leashScale;
 } TargetRangeParams; // size = 0x8
 
-#define TARGET_RANGE(range, leash) { SQ(range), (f32)range / leash }
+#define TARGET_RANGE(range, leash) \
+    { SQ(range), (f32)range / leash }
 
 TargetRangeParams D_80115FF8[] = {
     TARGET_RANGE(70, 140),   TARGET_RANGE(170, 255),    TARGET_RANGE(280, 5600),      TARGET_RANGE(350, 525),

--- a/soh/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
+++ b/soh/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
@@ -8,6 +8,7 @@
 #include "objects/object_niw/object_niw.h"
 #include "overlays/actors/ovl_En_Niw/z_en_niw.h"
 #include "soh/ResourceManagerHelpers.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS ACTOR_FLAG_UPDATE_CULLING_DISABLED
 
@@ -183,8 +184,9 @@ s32 func_809B55EC(EnAttackNiw* this, PlayState* play) {
 
     Actor_SetFocus(&this->actor, this->unk_2E4);
     Actor_GetScreenPos(play, &this->actor, &sp1E, &sp1C);
-    if ((this->actor.projectedPos.z < -20.0f) || (sp1E < 0) || (sp1E > SCREEN_WIDTH) || (sp1C < 0) ||
-        (sp1C > SCREEN_HEIGHT)) {
+    if (GameInteractor_Should(VB_DESTROY_OFFSCREEN_EN_ATTACK_NIW, true, this->actor) &&
+        ((this->actor.projectedPos.z < -20.0f) || (sp1E < 0) || (sp1E > SCREEN_WIDTH) || (sp1C < 0) ||
+         (sp1C > SCREEN_HEIGHT))) {
         return 0;
     } else {
         return 1;
@@ -367,10 +369,11 @@ void EnAttackNiw_Update(Actor* thisx, PlayState* play) {
     }
 
     tmpf1 = 20.0f;
-    if (this->actor.xyzDistToPlayerSq < SQ(tmpf1) && (this->actor.parent != NULL)) {
+    if (this->actor.xyzDistToPlayerSq < SQ(tmpf1)) {
         cucco = (EnNiw*)this->actor.parent;
-        if ((this->actor.parent->update != NULL) && (cucco != NULL) && (cucco->timer9 == 0) &&
-            (player->invincibilityTimer == 0)) {
+        // reordered checks to prevent null pointer dereference
+        if ((this->actor.parent != NULL) && (this->actor.parent->update != NULL) && (cucco != NULL) &&
+            (cucco->timer9 == 0) && (player->invincibilityTimer == 0)) {
             func_8002F6D4(play, &this->actor, 2.0f, this->actor.world.rot.y, 0.0f, 0x10);
             cucco->timer9 = 0x46;
         }

--- a/soh/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
+++ b/soh/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
@@ -260,14 +260,6 @@ void func_809B59B0(EnAttackNiw* this, PlayState* play) {
         return;
     }
 
-    // Params == 777 means that this is a randomized Attacking Cucco, and we want them attacking indefinitely
-    // So here we randomize the targeting timing and continuously have the Cucco face the player
-    if (this->actor.params == 777) {
-        if (Rand_ZeroOne() * 20.0f <= 1) {
-            this->unk_2D4 = Rand_CenteredFloat(200.0f) + this->actor.yawTowardsPlayer;
-        }
-    }
-
     if (this->actor.bgCheckFlags & 1) {
         if (this->unk_25A == 0) {
             this->unk_25A = 3;
@@ -290,9 +282,7 @@ void func_809B59B0(EnAttackNiw* this, PlayState* play) {
     Math_ApproachF(&this->unk_2DC, 10000.0f, 1.0f, 1000.0f);
     Math_ApproachF(&this->actor.speedXZ, this->unk_2E0, 0.9f, 1.0f);
     if ((this->actor.gravity == -2.0f) && (this->unk_262 == 0) &&
-        ((this->actor.bgCheckFlags & 8) || (this->unk_25C == 0)) && (this->actor.params != 777)) {
-        // Handles flying away for attacking Cucco after some time
-        // Not triggered for randomized Cuccos (params == 777)
+        ((this->actor.bgCheckFlags & 8) || (this->unk_25C == 0))) {
         this->unk_2E0 = 0.0f;
         this->actor.gravity = 0.0f;
         this->unk_2DC = 0.0f;
@@ -377,19 +367,12 @@ void EnAttackNiw_Update(Actor* thisx, PlayState* play) {
     }
 
     tmpf1 = 20.0f;
-    if (this->actor.xyzDistToPlayerSq < SQ(tmpf1)) {
-        // Params == 777 means that this is a randomized Attacking Cucco, and they have no parent Cucco
-        if (this->actor.params == 777) {
-            if ((player->invincibilityTimer == 0)) {
-                func_8002F6D4(play, &this->actor, 2.0f, this->actor.world.rot.y, 0.0f, 0x10);
-            }
-        } else {
-            cucco = (EnNiw*)this->actor.parent;
-            if ((this->actor.parent->update != NULL) && (this->actor.parent != NULL) && (cucco != NULL) &&
-                (cucco->timer9 == 0) && (player->invincibilityTimer == 0)) {
-                func_8002F6D4(play, &this->actor, 2.0f, this->actor.world.rot.y, 0.0f, 0x10);
-                cucco->timer9 = 0x46;
-            }
+    if (this->actor.xyzDistToPlayerSq < SQ(tmpf1) && (this->actor.parent != NULL)) {
+        cucco = (EnNiw*)this->actor.parent;
+        if ((this->actor.parent->update != NULL) && (cucco != NULL) && (cucco->timer9 == 0) &&
+            (player->invincibilityTimer == 0)) {
+            func_8002F6D4(play, &this->actor, 2.0f, this->actor.world.rot.y, 0.0f, 0x10);
+            cucco->timer9 = 0x46;
         }
     }
     if (this->unk_25E == 0) {

--- a/soh/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
+++ b/soh/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
@@ -177,11 +177,6 @@ s32 func_809B55EC(EnAttackNiw* this, PlayState* play) {
     s16 sp1E;
     s16 sp1C;
 
-    // Params == 777 means that this is a randomized Attacking Cucco, and we don't despawn them when they go off-screen
-    if (this->actor.params == 777) {
-        return 1;
-    }
-
     Actor_SetFocus(&this->actor, this->unk_2E4);
     Actor_GetScreenPos(play, &this->actor, &sp1E, &sp1C);
     if (GameInteractor_Should(VB_DESTROY_OFFSCREEN_EN_ATTACK_NIW, true, this->actor) &&

--- a/soh/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
+++ b/soh/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
@@ -176,6 +176,11 @@ s32 func_809B55EC(EnAttackNiw* this, PlayState* play) {
     s16 sp1E;
     s16 sp1C;
 
+    // Params == 777 means that this is a randomized Attacking Cucco, and we don't despawn them when they go off-screen
+    if (this->actor.params == 777) {
+        return 1;
+    }
+
     Actor_SetFocus(&this->actor, this->unk_2E4);
     Actor_GetScreenPos(play, &this->actor, &sp1E, &sp1C);
     if ((this->actor.projectedPos.z < -20.0f) || (sp1E < 0) || (sp1E > SCREEN_WIDTH) || (sp1C < 0) ||
@@ -255,6 +260,14 @@ void func_809B59B0(EnAttackNiw* this, PlayState* play) {
         return;
     }
 
+    // Params == 777 means that this is a randomized Attacking Cucco, and we want them attacking indefinitely
+    // So here we randomize the targeting timing and continuously have the Cucco face the player
+    if (this->actor.params == 777) {
+        if (Rand_ZeroOne() * 20.0f <= 1) {
+            this->unk_2D4 = Rand_CenteredFloat(200.0f) + this->actor.yawTowardsPlayer;
+        }
+    }
+
     if (this->actor.bgCheckFlags & 1) {
         if (this->unk_25A == 0) {
             this->unk_25A = 3;
@@ -277,7 +290,9 @@ void func_809B59B0(EnAttackNiw* this, PlayState* play) {
     Math_ApproachF(&this->unk_2DC, 10000.0f, 1.0f, 1000.0f);
     Math_ApproachF(&this->actor.speedXZ, this->unk_2E0, 0.9f, 1.0f);
     if ((this->actor.gravity == -2.0f) && (this->unk_262 == 0) &&
-        ((this->actor.bgCheckFlags & 8) || (this->unk_25C == 0))) {
+        ((this->actor.bgCheckFlags & 8) || (this->unk_25C == 0)) && (this->actor.params != 777)) {
+        // Handles flying away for attacking Cucco after some time
+        // Not triggered for randomized Cuccos (params == 777)
         this->unk_2E0 = 0.0f;
         this->actor.gravity = 0.0f;
         this->unk_2DC = 0.0f;
@@ -363,11 +378,18 @@ void EnAttackNiw_Update(Actor* thisx, PlayState* play) {
 
     tmpf1 = 20.0f;
     if (this->actor.xyzDistToPlayerSq < SQ(tmpf1)) {
-        cucco = (EnNiw*)this->actor.parent;
-        if ((this->actor.parent->update != NULL) && (this->actor.parent != NULL) && (cucco != NULL) &&
-            (cucco->timer9 == 0) && (player->invincibilityTimer == 0)) {
-            func_8002F6D4(play, &this->actor, 2.0f, this->actor.world.rot.y, 0.0f, 0x10);
-            cucco->timer9 = 0x46;
+        // Params == 777 means that this is a randomized Attacking Cucco, and they have no parent Cucco
+        if (this->actor.params == 777) {
+            if ((player->invincibilityTimer == 0)) {
+                func_8002F6D4(play, &this->actor, 2.0f, this->actor.world.rot.y, 0.0f, 0x10);
+            }
+        } else {
+            cucco = (EnNiw*)this->actor.parent;
+            if ((this->actor.parent->update != NULL) && (this->actor.parent != NULL) && (cucco != NULL) &&
+                (cucco->timer9 == 0) && (player->invincibilityTimer == 0)) {
+                func_8002F6D4(play, &this->actor, 2.0f, this->actor.world.rot.y, 0.0f, 0x10);
+                cucco->timer9 = 0x46;
+            }
         }
     }
     if (this->unk_25E == 0) {


### PR DESCRIPTION
Adds Attacking Cuccos to the Enemy Randomizer. Attacking Cuccos are categorized internally as Enemies :slightly_smiling_face: 

- Attacking Cuccos can replace enemies as well as enemies replacing Attacking Cuccos.
- Attacking Cucco behavior was slightly modified so they do not fly away or despawn when they go off screen. This was accomplished using the unused `params` of the Actor. This may be unorthodox.
- Fail safe was added if they are the only selected Enemy when randomizing clear/timed rooms.
- Enemies spawned by attacking a regular Cucco are de-parented from the spawning Cuccos to avoid crashes.

<img width="494" height="472" alt="image" src="https://github.com/user-attachments/assets/cdfadcef-3cee-457c-bf34-fb9b44a6eb9f" />
<img width="1834" height="956" alt="Screenshot_20260201_025057" src="https://github.com/user-attachments/assets/27ed9f66-94e2-4e29-86af-d52b8c2ea707" />
<img width="1834" height="956" alt="Screenshot_20260201_025252" src="https://github.com/user-attachments/assets/43b42f26-c1c4-47c3-8332-4f8ed9f490d7" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5401597566.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5401614162.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5401755662.zip)
<!--- section:artifacts:end -->