### PR TITLE
Add Reset Flag for Vanilla and MQ DC Gossip Stone

### DIFF
--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -2029,6 +2029,11 @@ void RandomizerOnActorInitHandler(void* actorRef) {
                 if (!isVanilla && Flags_GetRandomizerInf(RAND_INF_DODONGOS_CAVERN_MQ_SILVER_RUPEES)) {
                     Flags_SetSwitch(gPlayState, 0x25);
                 }
+                if (isVanilla) { // make gossip stone fairy respawn (temp flag)
+                    Flags_UnsetSwitch(gPlayState, 0x11);
+                } else {
+                    Flags_UnsetSwitch(gPlayState, 0x3E);
+                }
                 break;
             case SCENE_JABU_JABU:
                 if (isVanilla && Flags_GetRandomizerInf(RAND_INF_JABU_JABUS_BELLY_FIRST_SWITCH)) {


### PR DESCRIPTION
Following https://github.com/HarbourMasters/Shipwright/pull/6128 as example.

Havent tested yet so leaving it as a draft until tested

Included MQ as it apparently also uses a perm flag

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5336407601.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5336412769.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5336442321.zip)
<!--- section:artifacts:end -->