### PR TITLE
Fix Heart Containers/Pieces Item Pool Calculation

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
@@ -871,9 +871,13 @@ void GenerateItemPool() {
                     break;
                 case RO_ITEM_POOL_BALANCED: {
                     int heartsToPlace = maxHearts - startingHearts;
-                    int halfHearts = maxHearts >> 2;
+                    int halfHearts = heartsToPlace / 2;
                     AddFixedItemToPool(RG_HEART_CONTAINER, heartsToPlace - halfHearts, false);
                     AddFixedItemToPool(RG_PIECE_OF_HEART, halfHearts * 4, false);
+                    if (halfHearts % 2 == 1) {
+                        // If startingHearts was odd, we only have enough for 19 hearts at this point, add 4 extra heart pieces
+                        AddFixedItemToPool(RG_PIECE_OF_HEART, 4, false);
+                    }
                     break;
                 }
                 case RO_ITEM_POOL_SCARCE:

--- a/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
@@ -874,11 +874,6 @@ void GenerateItemPool() {
                     int halfHearts = heartsToPlace / 2;
                     AddFixedItemToPool(RG_HEART_CONTAINER, heartsToPlace - halfHearts, false);
                     AddFixedItemToPool(RG_PIECE_OF_HEART, halfHearts * 4, false);
-                    if (halfHearts % 2 == 1) {
-                        // If startingHearts was odd, we only have enough for 19 hearts at this point, add 4 extra heart pieces
-                        AddFixedItemToPool(RG_PIECE_OF_HEART, 4, false);
-                    }
-                    break;
                 }
                 case RO_ITEM_POOL_SCARCE:
                     AddFixedItemToPool(RG_PIECE_OF_HEART, (maxHearts - startingHearts) * 4, false);

--- a/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/item_pool.cpp
@@ -874,6 +874,7 @@ void GenerateItemPool() {
                     int halfHearts = heartsToPlace / 2;
                     AddFixedItemToPool(RG_HEART_CONTAINER, heartsToPlace - halfHearts, false);
                     AddFixedItemToPool(RG_PIECE_OF_HEART, halfHearts * 4, false);
+                    break;
                 }
                 case RO_ITEM_POOL_SCARCE:
                     AddFixedItemToPool(RG_PIECE_OF_HEART, (maxHearts - startingHearts) * 4, false);


### PR DESCRIPTION
This calc ends up with 8 heart containers in the pool with the default 3 starting hearts, just like the 8 heart containers in the vanilla game. Changing starting hearts results in half of the remaining hearts being filled by heart containers and half of the remaining hearts being filled by heart pieces.

The previous calculation was resulting in 11 Heart containers being put into the pool for balanced item pool with 3 starting hearts.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5357140425.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5357177629.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5357235629.zip)
<!--- section:artifacts:end -->