### PR TITLE
Bug Fix: MQ Dungeon setting not updating locations in Locations tab

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_objects.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_objects.cpp
@@ -117,7 +117,9 @@ void RandomizerCheckObjects::UpdateImGuiVisibility() {
                            RO_MQ_DUNGEONS_SET_NUMBER &&
                        (CVarGetInteger(CVAR_RANDOMIZER_SETTING("MQDungeonCount"), 12) > 0) || // at least one MQ dungeon
                    CVarGetInteger(CVAR_RANDOMIZER_SETTING("MQDungeons"), RO_MQ_DUNGEONS_NONE) ==
-                       RO_MQ_DUNGEONS_RANDOM_NUMBER)) ||
+                       RO_MQ_DUNGEONS_RANDOM_NUMBER ||
+                   CVarGetInteger(CVAR_RANDOMIZER_SETTING("MQDungeons"), RO_MQ_DUNGEONS_NONE) ==
+                       RO_MQ_DUNGEONS_SELECTION)) ||
              location.GetQuest() == RCQUEST_VANILLA &&
                  (CVarGetInteger(CVAR_RANDOMIZER_SETTING("MQDungeons"), RO_MQ_DUNGEONS_NONE) !=
                       RO_MQ_DUNGEONS_SET_NUMBER ||

--- a/soh/soh/SohGui/SohMenuRandomizer.cpp
+++ b/soh/soh/SohGui/SohMenuRandomizer.cpp
@@ -30,8 +30,8 @@ static std::set<RandomizerTrick> enabledGlitches;
 
 void DrawLocationsMenu(WidgetInfo& info) {
     auto ctx = OTRGlobals::Instance->gRandoContext;
-    int32_t currMQDungeonSetting = CVarGetInteger(CVAR_RANDOMIZER_SETTING("MQDungeons"), 0) +
-                                   CVarGetInteger(CVAR_RANDOMIZER_SETTING("MQDungeonCount"), 0);
+    int32_t currMQDungeonSetting = CVarGetInteger(CVAR_RANDOMIZER_SETTING("MQDungeons"), 0) |
+                                   CVarGetInteger(CVAR_RANDOMIZER_SETTING("MQDungeonCount"), 0) << 8;
     static ImVec2 cellPadding(8.0f, 8.0f);
     bool generating = CVarGetInteger(CVAR_GENERAL("RandoGenerating"), 0);
     bool disableEditingRandoSettings = generating || CVarGetInteger(CVAR_GENERAL("OnFileSelectNameEntry"), 0);

--- a/soh/soh/SohGui/SohMenuRandomizer.cpp
+++ b/soh/soh/SohGui/SohMenuRandomizer.cpp
@@ -22,6 +22,7 @@ static const std::map<int32_t, const char*> skipGetItemAnimationOptions = {
 
 static bool locationsDirty = true;
 static bool tricksDirty = true;
+static int32_t prevMQDungeonSetting;
 static char seedString[MAX_SEED_STRING_SIZE];
 static std::set<RandomizerCheck> excludedLocations;
 static std::set<RandomizerTrick> enabledTricks;
@@ -29,12 +30,14 @@ static std::set<RandomizerTrick> enabledGlitches;
 
 void DrawLocationsMenu(WidgetInfo& info) {
     auto ctx = OTRGlobals::Instance->gRandoContext;
+    int32_t currMQDungeonSetting = CVarGetInteger(CVAR_RANDOMIZER_SETTING("MQDungeons"), 0) +
+                                   CVarGetInteger(CVAR_RANDOMIZER_SETTING("MQDungeonCount"), 0);
     static ImVec2 cellPadding(8.0f, 8.0f);
     bool generating = CVarGetInteger(CVAR_GENERAL("RandoGenerating"), 0);
     bool disableEditingRandoSettings = generating || CVarGetInteger(CVAR_GENERAL("OnFileSelectNameEntry"), 0);
     ImGui::BeginDisabled(CVarGetInteger(CVAR_SETTING("DisableChanges"), 0) || disableEditingRandoSettings);
     ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, cellPadding);
-    if (locationsDirty) {
+    if (locationsDirty || currMQDungeonSetting != prevMQDungeonSetting) {
         RandomizerCheckObjects::UpdateImGuiVisibility();
         // todo: this efficently when we build out cvar array support
         std::stringstream excludedLocationStringStream(CVarGetString(CVAR_RANDOMIZER_SETTING("ExcludedLocations"), ""));
@@ -45,6 +48,7 @@ void DrawLocationsMenu(WidgetInfo& info) {
         }
         locationsDirty = false;
     }
+    prevMQDungeonSetting = currMQDungeonSetting;
 
     if (ImGui::BeginTable("tableRandoLocations", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
         ImGui::TableSetupColumn("Included", ImGuiTableColumnFlags_WidthStretch, 200.0f);


### PR DESCRIPTION
Fixes #6056 (if i understood them correctly)

Basically when setting MQ Dungeon Setting in the Dungeons tab of the randomizer, the actual locations list wouldn't update if that tab was already generated/initialized. Now it will check if any of the relevant settings have changed between draws.

Also one of the newer MQ Dungeon settings wasn't accounted for in `UpdateImGuiVisibility`

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5368327681.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5368348409.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5368390955.zip)
<!--- section:artifacts:end -->