### PR TITLE
Change interior pot access to only check for viable methods.

### DIFF
--- a/soh/soh/Enhancements/randomizer/location_access/overworld/kokiri_forest.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/kokiri_forest.cpp
@@ -123,7 +123,7 @@ void RegionTable_Init_KokiriForest() {
     areaTable[RR_KF_LINKS_HOUSE] = Region("KF Link's House", SCENE_LINKS_HOUSE, {}, {
         //Locations
         LOCATION(RC_KF_LINKS_HOUSE_COW, logic->IsAdult && logic->CanUse(RG_EPONAS_SONG) && logic->Get(LOGIC_LINKS_COW)),
-        LOCATION(RC_KF_LINKS_HOUSE_POT, logic->CanBreakPots()),
+        LOCATION(RC_KF_LINKS_HOUSE_POT, logic->HasItem(RG_POWER_BRACELET)), // TODO: CanBreakPots() restricted
     }, {
         //Exits
         ENTRANCE(RR_KF_LINKS_PORCH, true),
@@ -153,8 +153,8 @@ void RegionTable_Init_KokiriForest() {
 
     areaTable[RR_KF_HOUSE_OF_TWINS] = Region("KF House of Twins", SCENE_TWINS_HOUSE, {}, {
         //Locations
-        LOCATION(RC_KF_TWINS_HOUSE_POT_1, logic->CanBreakPots()),
-        LOCATION(RC_KF_TWINS_HOUSE_POT_2, logic->CanBreakPots()),
+        LOCATION(RC_KF_TWINS_HOUSE_POT_1, logic->HasItem(RG_POWER_BRACELET)), // TODO: CanBreakPots() restricted
+        LOCATION(RC_KF_TWINS_HOUSE_POT_2, logic->HasItem(RG_POWER_BRACELET)), // TODO: CanBreakPots() restricted
     }, {
         //Exits
         ENTRANCE(RR_KOKIRI_FOREST, true),
@@ -162,8 +162,8 @@ void RegionTable_Init_KokiriForest() {
 
     areaTable[RR_KF_KNOW_IT_ALL_HOUSE] = Region("KF Know It All House", SCENE_KNOW_IT_ALL_BROS_HOUSE, {}, {
         // Locations
-        LOCATION(RC_KF_BROTHERS_HOUSE_POT_1, logic->CanBreakPots()),
-        LOCATION(RC_KF_BROTHERS_HOUSE_POT_2, logic->CanBreakPots()),
+        LOCATION(RC_KF_BROTHERS_HOUSE_POT_1, logic->HasItem(RG_POWER_BRACELET)), // TODO: CanBreakPots() restricted
+        LOCATION(RC_KF_BROTHERS_HOUSE_POT_2, logic->HasItem(RG_POWER_BRACELET)), // TODO: CanBreakPots() restricted
     }, {
         //Exits
         ENTRANCE(RR_KOKIRI_FOREST, true),

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/lon_lon_ranch.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/lon_lon_ranch.cpp
@@ -37,9 +37,9 @@ void RegionTable_Init_LonLonRanch() {
     areaTable[RR_LLR_TALONS_HOUSE] = Region("LLR Talons House", SCENE_LON_LON_BUILDINGS, {}, {
         //Locations
         LOCATION(RC_LLR_TALONS_CHICKENS,    logic->HasItem(RG_CHILD_WALLET) && logic->HasItem(RG_SPEAK_HYLIAN) && logic->IsChild && logic->AtDay && logic->HasItem(RG_ZELDAS_LETTER)),
-        LOCATION(RC_LLR_TALONS_HOUSE_POT_1, logic->CanBreakPots()),
-        LOCATION(RC_LLR_TALONS_HOUSE_POT_2, logic->CanBreakPots()),
-        LOCATION(RC_LLR_TALONS_HOUSE_POT_3, logic->CanBreakPots()),
+        LOCATION(RC_LLR_TALONS_HOUSE_POT_1, logic->HasItem(RG_POWER_BRACELET) || logic->CanUseSword()), // TODO: CanBreakPots() restricted
+        LOCATION(RC_LLR_TALONS_HOUSE_POT_2, logic->HasItem(RG_POWER_BRACELET) || logic->CanUseSword()), // TODO: CanBreakPots() restricted
+        LOCATION(RC_LLR_TALONS_HOUSE_POT_3, logic->HasItem(RG_POWER_BRACELET) || logic->CanUseSword()), // TODO: CanBreakPots() restricted
     }, {
         //Exits
         ENTRANCE(RR_LON_LON_RANCH, true),

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/market.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/market.cpp
@@ -235,9 +235,9 @@ void RegionTable_Init_Market() {
 
     areaTable[RR_MARKET_MAN_IN_GREEN_HOUSE] = Region("Market Man in Green House", SCENE_BACK_ALLEY_HOUSE, {}, {
         // Locations
-        LOCATION(RC_MK_BACK_ALLEY_HOUSE_POT_1, logic->CanBreakPots()),
-        LOCATION(RC_MK_BACK_ALLEY_HOUSE_POT_2, logic->CanBreakPots()),
-        LOCATION(RC_MK_BACK_ALLEY_HOUSE_POT_3, logic->CanBreakPots()),
+        LOCATION(RC_MK_BACK_ALLEY_HOUSE_POT_1, logic->HasItem(RG_POWER_BRACELET)), // TODO: CanBreakPots() restricted
+        LOCATION(RC_MK_BACK_ALLEY_HOUSE_POT_2, logic->HasItem(RG_POWER_BRACELET)), // TODO: CanBreakPots() restricted
+        LOCATION(RC_MK_BACK_ALLEY_HOUSE_POT_3, logic->HasItem(RG_POWER_BRACELET)), // TODO: CanBreakPots() restricted
     }, {
         //Exits
         ENTRANCE(RR_MARKET_BACK_ALLEY, true),


### PR DESCRIPTION
This essentially means `HasItem(RG_POWER_BRACELET)` in each interior except for Talon's house, where a sword is also viable.

Would not be surprised if I missed some.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5367918812.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5367934999.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5367974775.zip)
<!--- section:artifacts:end -->