### PR TITLE
Added Starting Age/Time to Available Checks

### DIFF
--- a/soh/soh/Enhancements/debugconsole.cpp
+++ b/soh/soh/Enhancements/debugconsole.cpp
@@ -1478,6 +1478,7 @@ static bool AvailableChecksProcessUndiscoveredExitsHandler(std::shared_ptr<Ship:
 static bool AvailableChecksRecalculateHandler(std::shared_ptr<Ship::Console> Console,
                                               const std::vector<std::string>& args, std::string* output) {
     RandomizerRegion startingRegion = RR_ROOT;
+    RandoAgeTime startingAgeTime = RAT_NONE;
 
     if (args.size() > 1) {
         try {
@@ -1493,7 +1494,21 @@ static bool AvailableChecksRecalculateHandler(std::shared_ptr<Ship::Console> Con
         }
     }
 
-    CheckTracker::RecalculateAvailableChecks(startingRegion);
+    if (args.size() > 2) {
+        if (args[2] == "ChildDay") {
+            startingAgeTime = RAT_CHILD_DAY;
+        } else if (args[2] == "ChildNight") {
+            startingAgeTime = RAT_CHILD_NIGHT;
+        } else if (args[2] == "AdultDay") {
+            startingAgeTime = RAT_ADULT_DAY;
+        } else if (args[2] == "AdultNight") {
+            startingAgeTime = RAT_ADULT_NIGHT;
+        } else {
+            ERROR_MESSAGE("[SOH] Age Time should be ChildDay, ChildNight, AdultDay, or AdultNight");
+        }
+    }
+
+    CheckTracker::RecalculateAvailableChecks(startingRegion, startingAgeTime);
     return 0;
 }
 
@@ -1759,11 +1774,13 @@ void DebugConsole_Init(void) {
                             "Available Checks - Process Undiscovered Exits",
                             { { "enable", Ship::ArgumentType::NUMBER, true } } });
 
-    CMD_REGISTER("acr", { AvailableChecksRecalculateHandler,
-                          "Available Checks - Recalculate",
-                          {
-                              { "starting_region", Ship::ArgumentType::NUMBER, true },
-                          } });
+    Ship::Context::GetInstance()->GetConsole()->AddCommand(
+        "acr", { AvailableChecksRecalculateHandler,
+                 "Available Checks - Recalculate",
+                 {
+                     { "starting_region", Ship::ArgumentType::NUMBER, true },
+                     { "ChildDay|ChildNight|AdultDay|AdultNight", Ship::ArgumentType::TEXT, true },
+                 } });
 
     Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
 }

--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -510,7 +510,8 @@ void ProcessRegion(Region* region, GetAccessibleLocationsStruct& gals, Randomize
 std::vector<RandomizerCheck> ReachabilitySearch(const std::vector<RandomizerCheck>& targetLocations,
                                                 RandomizerGet ignore /* = RG_NONE*/,
                                                 bool calculatingAvailableChecks /* = false */,
-                                                RandomizerRegion startingRegion /* = RR_ROOT */) {
+                                                RandomizerRegion startingRegion /* = RR_ROOT */,
+                                                RandoAgeTime startingAgeTime /* = RAT_NONE*/) {
     auto ctx = Rando::Context::GetInstance();
     GetAccessibleLocationsStruct gals(0);
     ResetLogic(ctx, gals, !calculatingAvailableChecks);
@@ -518,17 +519,18 @@ std::vector<RandomizerCheck> ReachabilitySearch(const std::vector<RandomizerChec
         gals.regionPool.insert(gals.regionPool.begin(), startingRegion);
 
         const auto& region = RegionTable(startingRegion);
-        if (ctx->GetOption(RSK_SELECTED_STARTING_AGE).Is(RO_AGE_CHILD)) {
+        if (startingAgeTime == RAT_CHILD_DAY) {
             region->childDay = true;
-        } else {
+            region->childNight = region->timePass;
+        } else if (startingAgeTime == RAT_CHILD_NIGHT) {
+            region->childNight = true;
+            region->childDay = region->timePass;
+        } else if (startingAgeTime == RAT_ADULT_DAY) {
             region->adultDay = true;
-        }
-        if (region->timePass) {
-            if (ctx->GetOption(RSK_SELECTED_STARTING_AGE).Is(RO_AGE_CHILD)) {
-                region->childNight = true;
-            } else {
-                region->adultNight = true;
-            }
+            region->adultNight = region->timePass;
+        } else if (startingAgeTime == RAT_ADULT_NIGHT) {
+            region->adultNight = true;
+            region->adultDay = region->timePass;
         }
     }
     if (calculatingAvailableChecks) {

--- a/soh/soh/Enhancements/randomizer/3drando/fill.hpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.hpp
@@ -66,7 +66,8 @@ void ProcessRegion(Region* region, GetAccessibleLocationsStruct& gals, Randomize
 
 std::vector<RandomizerCheck> ReachabilitySearch(const std::vector<RandomizerCheck>& allowedLocations,
                                                 RandomizerGet ignore = RG_NONE, bool calculatingAvailableChecks = false,
-                                                RandomizerRegion startingRegion = RR_ROOT);
+                                                RandomizerRegion startingRegion = RR_ROOT,
+                                                RandoAgeTime startingAgeTime = RAT_NONE);
 
 void GeneratePlaythrough();
 

--- a/soh/soh/Enhancements/randomizer/randomizerTypes.h
+++ b/soh/soh/Enhancements/randomizer/randomizerTypes.h
@@ -7238,6 +7238,15 @@ typedef enum {
     WL_HIGH_OR_MID,
 } RandoWaterLevel;
 
+typedef enum {
+    RAT_NONE,
+    RAT_CHILD_DAY,
+    RAT_CHILD_NIGHT,
+    RAT_ADULT_DAY,
+    RAT_ADULT_NIGHT,
+    RAT_MAX,
+} RandoAgeTime;
+
 #define ENTRANCE_GROTTO_LOAD_START 0x0700
 #define ENTRANCE_GROTTO_EXIT_START 0x0800
 

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -262,6 +262,7 @@ Color_RGBA8 Color_Saved_Extra = { 0, 185, 0, 255 };               // Green
 static ImGuiTextFilter checkSearch;
 static bool recalculateAvailable = false;
 static RandomizerRegion availableChecksStartingRegion = RR_ROOT;
+static RandoAgeTime availableChecksStartingAgeTime = RAT_NONE;
 static int16_t previousEntrance = 0;
 std::array<bool, RCAREA_INVALID> filterAreasHidden = { 0 };
 std::array<bool, RC_MAX> filterChecksHidden = { 0 };
@@ -945,7 +946,7 @@ void SetAreaSpoiled(RandomizerCheckArea rcArea) {
     SaveManager::Instance->SaveSection(gSaveContext.fileNum, sectionId, true);
 }
 
-void InternalRecalculateAvailableChecks(RandomizerRegion startingRegion);
+void InternalRecalculateAvailableChecks(RandomizerRegion startingRegion, RandoAgeTime startingAgeTime);
 
 void CheckTrackerWindow::DrawElement() {
     Color_Background = CVarGetColor(CVAR_TRACKER_CHECK("BgColor.Value"), Color_Bg_Default);
@@ -1024,8 +1025,9 @@ void CheckTrackerWindow::DrawElement() {
 
         if (recalculateAvailable) {
             recalculateAvailable = false;
-            InternalRecalculateAvailableChecks(availableChecksStartingRegion);
+            InternalRecalculateAvailableChecks(availableChecksStartingRegion, availableChecksStartingAgeTime);
             availableChecksStartingRegion = RR_ROOT;
+            availableChecksStartingAgeTime = RAT_NONE;
         }
 
         // Quick Options
@@ -2017,7 +2019,7 @@ void ImGuiDrawTwoColorPickerSection(const char* text, const char* cvarMainName, 
     UIWidgets::PopStyleCombobox();
 }
 
-void InternalRecalculateAvailableChecks(RandomizerRegion startingRegion) {
+void InternalRecalculateAvailableChecks(RandomizerRegion startingRegion, RandoAgeTime startingAgeTime) {
     if (!enableAvailableChecks || !GameInteractor::IsSaveLoaded()) {
         return;
     }
@@ -2042,6 +2044,18 @@ void InternalRecalculateAvailableChecks(RandomizerRegion startingRegion) {
         }
     }
 
+    if (startingAgeTime == RAT_NONE) {
+        if (LINK_IS_CHILD && IS_DAY) {
+            startingAgeTime = RAT_CHILD_DAY;
+        } else if (LINK_IS_CHILD && IS_NIGHT) {
+            startingAgeTime = RAT_CHILD_NIGHT;
+        } else if (LINK_IS_ADULT && IS_DAY) {
+            startingAgeTime = RAT_ADULT_DAY;
+        } else if (LINK_IS_ADULT && IS_NIGHT) {
+            startingAgeTime = RAT_ADULT_NIGHT;
+        }
+    }
+
     std::vector<RandomizerCheck> targetLocations;
     targetLocations.reserve(RC_MAX);
     for (auto& location : Rando::StaticData::GetLocationTable()) {
@@ -2053,7 +2067,8 @@ void InternalRecalculateAvailableChecks(RandomizerRegion startingRegion) {
         }
     }
 
-    std::vector<RandomizerCheck> availableChecks = ReachabilitySearch(targetLocations, RG_NONE, true, startingRegion);
+    std::vector<RandomizerCheck> availableChecks =
+        ReachabilitySearch(targetLocations, RG_NONE, true, startingRegion, startingAgeTime);
     for (auto& rc : availableChecks) {
         const auto& itemLocation = ctx->GetItemLocation(rc);
         itemLocation->SetAvailable(true);
@@ -2076,9 +2091,11 @@ void InternalRecalculateAvailableChecks(RandomizerRegion startingRegion) {
                 GetPerformanceTimer(PT_RECALCULATE_AVAILABLE_CHECKS).count());
 }
 
-void RecalculateAvailableChecks(RandomizerRegion startingRegion /* = RR_ROOT */) {
+void RecalculateAvailableChecks(RandomizerRegion startingRegion /* = RR_ROOT */,
+                                RandoAgeTime startingAgeTime /* = RAT_NONE */) {
     recalculateAvailable = true;
     availableChecksStartingRegion = startingRegion;
+    availableChecksStartingAgeTime = startingAgeTime;
 }
 
 void LoadFromPreset(nlohmann::json info) {

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.h
@@ -62,6 +62,6 @@ void UpdateAllOrdering();
 void UpdateAllAreas();
 void RecalculateAllAreaTotals();
 void SpoilAreaFromCheck(RandomizerCheck rc);
-void RecalculateAvailableChecks(RandomizerRegion startingRegion = RR_ROOT);
+void RecalculateAvailableChecks(RandomizerRegion startingRegion = RR_ROOT, RandoAgeTime startingAgeTime = RAT_NONE);
 void LoadFromPreset(nlohmann::json info);
 } // namespace CheckTracker


### PR DESCRIPTION
For Available Checks, when using a starting region, the starting age in that region was assigned the starting age arbitrarily. This PR calculates the current starting age/time and uses it with the starting region.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5419769023.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5419785648.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5419989250.zip)
<!--- section:artifacts:end -->