### PR TITLE
Fix Imgui Error on Collapsed Trackers

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1244,12 +1244,12 @@ void CheckTrackerWindow::DrawElement() {
 
         ImGui::EndTable(); // Checks Lead-out
         ImGui::EndTable(); // Quick Options Lead-out
-        Trackers::EndFloatWindows();
         if (doingCollapseOrExpand) {
             optCollapseAll = false;
             optExpandAll = false;
         }
     }
+    Trackers::EndFloatWindows();
 }
 
 bool UpdateFilters() {

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -1067,8 +1067,8 @@ void EntranceTrackerWindow::DrawElement() {
             }
         }
         ImGui::EndChild();
-        Trackers::EndFloatWindows();
     }
+    Trackers::EndFloatWindows();
 }
 
 void EntranceTrackerWindow::InitElement() {


### PR DESCRIPTION
Fixes #6240 

Begin() in Imgui creates the window regardless of the value of the bool it returns for if the content should be displayed, so when the tracker windows were collapsed, Begin() still created the window, but returned false, causing EndFloatWindows() not to be called. This moves the call outside of the if() block.

This solution still avoids any double-calls of EndFloatWindows() because of early returns across every other usage.



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5424199505.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5424205473.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5424234241.zip)
<!--- section:artifacts:end -->