### PR TITLE
Fix Extractor Found ROM Path Assumption

### DIFF
--- a/soh/soh/Extractor/Extract.cpp
+++ b/soh/soh/Extractor/Extract.cpp
@@ -238,7 +238,7 @@ void Extractor::GetRoms(std::vector<std::string>& roms) {
 
             // Check for any standard N64 rom file extensions.
             if ((strcmp(ext, ".z64") == 0) || (strcmp(ext, ".n64") == 0) || (strcmp(ext, ".v64") == 0))
-                roms.push_back(ffd.cFileName);
+                roms.push_back(mSearchPath + "\\" + ffd.cFileName);
         }
     } while (FindNextFileA(h, &ffd) != 0);
     // if (h != nullptr) {


### PR DESCRIPTION
The ROM file search on Windows for the Extractor currently was making the assumption that all files found were in the build/x64/soh directory, but this would crash if ROMs were in the x64 subfolders (Debug and Release) and NOT also in working directory. This fixes that by adding the full path to the vector reference in `GetRoms()` instead of just the filename.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5424414725.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5424422118.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5424457091.zip)
<!--- section:artifacts:end -->