### PR TITLE
Business Scrubs: don't speak without jabber nut

### DIFF
--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -264,6 +264,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // this->actor.xzDistToPlayer < 130.0f
+    // ```
+    // #### `args`
+    // - None
+    VB_BUSINESS_SCRUB_SPEAK,
+
+    // #### `result`
+    // ```c
     // true
     // ```
     // #### `args`

--- a/soh/soh/Enhancements/randomizer/ShuffleSpeak.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleSpeak.cpp
@@ -9,6 +9,12 @@ extern PlayState* gPlayState;
 void RegisterShuffleSpeak() {
     bool shouldRegister = IS_RANDO && Rando::Context::GetInstance()->GetOption(RSK_SHUFFLE_SPEAK).Get();
 
+    COND_VB_SHOULD(VB_BUSINESS_SCRUB_SPEAK, shouldRegister, {
+        if (!Flags_GetRandomizerInf(RAND_INF_CAN_SPEAK_DEKU)) {
+            *should = false;
+        }
+    });
+
     COND_VB_SHOULD(VB_SPEAK, shouldRegister, {
         Actor* talkActor = GET_PLAYER(gPlayState)->talkActor;
         if (talkActor != NULL && talkActor->category == ACTORCAT_NPC &&

--- a/soh/src/overlays/actors/ovl_En_Dns/z_en_dns.c
+++ b/soh/src/overlays/actors/ovl_En_Dns/z_en_dns.c
@@ -321,7 +321,7 @@ void EnDns_Idle(EnDns* this, PlayState* play) {
         } else {
             this->actor.flags &= ~ACTOR_FLAG_TALK_OFFER_AUTO_ACCEPTED;
         }
-        if (this->actor.xzDistToPlayer < 130.0f) {
+        if (GameInteractor_Should(VB_BUSINESS_SCRUB_SPEAK, this->actor.xzDistToPlayer < 130.0f)) {
             func_8002F2F4(&this->actor, play);
         }
     }

--- a/soh/src/overlays/actors/ovl_En_Shopnuts/z_en_shopnuts.c
+++ b/soh/src/overlays/actors/ovl_En_Shopnuts/z_en_shopnuts.c
@@ -1,7 +1,6 @@
 #include "z_en_shopnuts.h"
 #include "objects/object_shopnuts/object_shopnuts.h"
 #include "overlays/actors/ovl_En_Dns/z_en_dns.h"
-#include "soh/OTRGlobals.h"
 #include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 


### PR DESCRIPTION
most speak checks conservatively only apply to Link initiating speech,
but didn't realize business scrubs speak unprompted & that would make deku jabber nut mostly useless

this doesn't apply to other scrubs (such as 123 scrubs), maybe in future we can block more, such as showing trade items

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5503274970.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5503329623.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5503466210.zip)
<!--- section:artifacts:end -->