### PR TITLE
Fix Jabu Blue Warp in Entrance Rando

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
@@ -168,8 +168,7 @@ void RegisterShouldPlayBlueWarp() {
 
             // This is outside the above condition because we want to handle both first and following visits to the blue
             // warp. Jabu's blue warp doesn't call VB_PLAY_BLUE_WARP_CS without Ruto
-            if ((sEnteredBlueWarp || gSaveContext.entranceIndex == ENTR_ZORAS_FOUNTAIN_JABU_JABU_BLUE_WARP) &&
-                overrideBlueWarpDestinations) {
+            if (sEnteredBlueWarp && overrideBlueWarpDestinations) {
                 Entrance_OverrideBlueWarp();
             }
         }

--- a/soh/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
+++ b/soh/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
@@ -557,6 +557,7 @@ void DoorWarp1_ChildWarpOut(DoorWarp1* this, PlayState* play) {
                 gSaveContext.nextCutsceneIndex = 0;
             }
         } else if (play->sceneNum == SCENE_JABU_JABU_BOSS) {
+            if (GameInteractor_Should(VB_PLAY_BLUE_WARP_CS, true)) {};
             play->nextEntranceIndex = ENTR_ZORAS_FOUNTAIN_JABU_JABU_BLUE_WARP;
             gSaveContext.nextCutsceneIndex = 0;
         }


### PR DESCRIPTION
Fixes #5995 

The fix for going through the Jabu Blue Warp a second time inadvertently had a side effect of calling the Entrance_OverrideBlueWarp twice, causing any blue warp used in the Jabu Jabu entrance to find the overridden entrance for Barinade's blue warp.

This reverts that change, and instead adds the Blue Warp hook to the second code path for the Jabu blue warp without Ruto

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5511578912.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5511589833.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5511694583.zip)
<!--- section:artifacts:end -->