### PR TITLE
Remove castle moat spawn override

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -701,14 +701,6 @@ void Entrance_OverrideSpawnScene(s32 sceneNum, s32 spawn) {
     modifiedLinkActorEntry.params = gPlayState->linkActorEntry->params;
 
     if (Randomizer_GetSettingValue(RSK_SHUFFLE_DUNGEON_ENTRANCES) == RO_DUNGEON_ENTRANCE_SHUFFLE_ON_PLUS_GANON) {
-        // Move Hyrule's Castle Courtyard exit spawn to be before the crates so players don't skip Talon
-        if (sceneNum == SCENE_HYRULE_CASTLE && spawn == 1) {
-            modifiedLinkActorEntry.pos.x = 0x033A;
-            modifiedLinkActorEntry.pos.y = 0x0623;
-            modifiedLinkActorEntry.pos.z = 0xFF22;
-            gPlayState->linkActorEntry = &modifiedLinkActorEntry;
-        }
-
         // Move Ganon's Castle exit spawn to be on the small ledge near the castle and not over the void
         // to prevent Link from falling if the bridge isn't spawned
         if (sceneNum == SCENE_OUTSIDE_GANONS_CASTLE && spawn == 1) {


### PR DESCRIPTION
When dungeon entrance rando was on with ganons, if child link left from the "rainbow bridge" exit they would be placed next to talons sleeping spot instead of on the ledge. This was originally done to make sure the player did not break the Malon/Talon/Zelda sequence, as it used to be fragile. However in the modern codebase it was robust enough to handle this and can even be skipped in logic with the damage boost trick on, so this is no longer needed and was simply causing a logic bug. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5601545773.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5601549684.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5601573368.zip)
<!--- section:artifacts:end -->