### PR TITLE
Fix carpet man logic brackets

### DIFF
--- a/soh/soh/Enhancements/randomizer/location_access/overworld/haunted_wasteland.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/haunted_wasteland.cpp
@@ -23,7 +23,7 @@ void RegionTable_Init_HauntedWasteland() {
     }, {
         //Locations
         LOCATION(RC_WASTELAND_CHEST,            logic->HasFireSource() && logic->HasItem(RG_OPEN_CHEST)),
-        LOCATION(RC_WASTELAND_BOMBCHU_SALESMAN, logic->CanJumpslash() || logic->CanUse(RG_HOVER_BOOTS) && logic->HasItem(RG_SPEAK_HYLIAN) && GetCheckPrice() <= GetWalletCapacity()),
+        LOCATION(RC_WASTELAND_BOMBCHU_SALESMAN, (logic->CanJumpslash() || logic->CanUse(RG_HOVER_BOOTS)) && logic->HasItem(RG_SPEAK_HYLIAN) && GetCheckPrice() <= GetWalletCapacity()),
         LOCATION(RC_WASTELAND_GS,               logic->HookshotOrBoomerang() || (logic->IsAdult && ctx->GetTrickOption(RT_GROUND_JUMP_HARD) && logic->CanGroundJump() && logic->CanJumpslash())), // need to jumpslash immediately with two handed weapons
         LOCATION(RC_WASTELAND_NEAR_GS_POT_1,    logic->CanBreakPots()),
         LOCATION(RC_WASTELAND_NEAR_GS_POT_2,    logic->CanBreakPots()),


### PR DESCRIPTION
A missing pair of brackets seemed to allow the check with just jumpslash.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5601692750.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5601701315.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5601723373.zip)
<!--- section:artifacts:end -->