### PR TITLE
Add .zip to Artifact Names

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -139,7 +139,7 @@ jobs:
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:
-        name: soh-mac
+        name: soh-mac.zip
         path: |
           SoH.dmg
           readme.txt
@@ -253,7 +253,7 @@ jobs:
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:
-        name: soh-linux
+        name: soh-linux.zip
         path: |
           soh.appimage
           readme.txt
@@ -319,7 +319,7 @@ jobs:
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:
-        name: soh-windows
+        name: soh-windows.zip
         path: soh-windows
     - name: Save Cache VCPKG folder
       if: ${{ github.ref_name == github.event.repository.default_branch }}

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -136,13 +136,12 @@ jobs:
 
         mv _packages/*.dmg SoH.dmg
         mv README.md readme.txt
+        zip -9 soh-mac.zip SoH.dmg readme.txt
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:
-        name: soh-mac.zip
-        path: |
-          SoH.dmg
-          readme.txt
+        name: soh-mac
+        path: soh-mac.zip
     - name: Save Cache MacPorts
       if: ${{ github.ref_name == github.event.repository.default_branch }}
       uses: actions/cache/save@v4
@@ -247,16 +246,15 @@ jobs:
 
         mv README.md readme.txt
         mv build-cmake/*.appimage soh.appimage
+        zip -9 soh-linux.zip soh.appimage readme.txt
       env:
         CC: gcc-12
         CXX: g++-12
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:
-        name: soh-linux.zip
-        path: |
-          soh.appimage
-          readme.txt
+        name: soh-linux
+        path: soh-linux.zip
     - name: Save Cache deps folder
       if: ${{ github.ref_name == github.event.repository.default_branch }}
       uses: actions/cache/save@v4
@@ -314,13 +312,11 @@ jobs:
         (cd build-windows && cpack)
         cd ..
         mv _packages/*.zip _packages/soh-windows.zip
-    - name: Unzip package
-      run: Expand-Archive -Path _packages/soh-windows.zip -DestinationPath soh-windows
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:
-        name: soh-windows.zip
-        path: soh-windows
+        name: soh-windows
+        path: _packages/soh-windows.zip
     - name: Save Cache VCPKG folder
       if: ${{ github.ref_name == github.event.repository.default_branch }}
       uses: actions/cache/save@v4

--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -50,7 +50,7 @@ jobs:
             return allArtifacts.data.artifacts.reduce((acc, item) => {
               if (item.name === "soh.o2r") return acc;
               acc += `
-              - [${item.name}.zip](https://nightly.link/${context.repo.owner}/${context.repo.repo}/actions/artifacts/${item.id}.zip)`;
+              - [${item.name}](https://nightly.link/${context.repo.owner}/${context.repo.repo}/actions/artifacts/${item.id})`;
               return acc;
             }, '### Build Artifacts');
       - id: 'add-to-pr'

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ If you want to manually compile SoH, please consult the [building instructions](
 ### Playtesting
 If you want to playtest a continuous integration build, you can find them at the links below. Keep in mind that these are for playtesting only, and you will likely encounter bugs and possibly crashes. 
 
-* [Windows](https://nightly.link/xxAtrain223/Shipwright/workflows/generate-builds/develop/soh-windows.zip)
-* [macOS](https://nightly.link/xxAtrain223/Shipwright/workflows/generate-builds/develop/soh-mac.zip)
-* [Linux](https://nightly.link/xxAtrain223/Shipwright/workflows/generate-builds/develop/soh-linux.zip)
+* [Windows](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-windows.zip)
+* [macOS](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-mac.zip)
+* [Linux](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-linux.zip)
 
 ### Further Reading
 More detailed documentation can be found in the 'docs' directory, including the aforementioned [building instructions](docs/BUILDING.md).

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ If you want to manually compile SoH, please consult the [building instructions](
 ### Playtesting
 If you want to playtest a continuous integration build, you can find them at the links below. Keep in mind that these are for playtesting only, and you will likely encounter bugs and possibly crashes. 
 
-* [Windows](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-windows.zip)
-* [macOS](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-mac.zip)
-* [Linux](https://nightly.link/HarbourMasters/Shipwright/workflows/generate-builds/develop/soh-linux.zip)
+* [Windows](https://nightly.link/xxAtrain223/Shipwright/workflows/generate-builds/develop/soh-windows.zip)
+* [macOS](https://nightly.link/xxAtrain223/Shipwright/workflows/generate-builds/develop/soh-mac.zip)
+* [Linux](https://nightly.link/xxAtrain223/Shipwright/workflows/generate-builds/develop/soh-linux.zip)
 
 ### Further Reading
 More detailed documentation can be found in the 'docs' directory, including the aforementioned [building instructions](docs/BUILDING.md).


### PR DESCRIPTION
Updates the artifact names to add `.zip` so that they download with `.zip`. I'm not sure if the nightly/PR links will need to be updated as well.

Note, that the artifacts will always be zip files. [@actions/upload-artifact#zip-archives](https://github.com/[actions/upload-artifact](https://github.com/actions/upload-artifact?tab=readme-ov-file#zip-archives)?tab=readme-ov-file#zip-archives)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5604082113.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5604085004.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5604115688.zip)
<!--- section:artifacts:end -->