### PR TITLE
Fix Altar Hint formatting

### DIFF
--- a/soh/soh/Enhancements/randomizer/Messages/StaticHints.cpp
+++ b/soh/soh/Enhancements/randomizer/Messages/StaticHints.cpp
@@ -98,14 +98,12 @@ void BuildSheikMessage(uint16_t* textId, bool* loadFromMessageTable) {
 
 void BuildChildAltarMessage(uint16_t* textId, bool* loadFromMessageTable) {
     CustomMessage msg = RAND_GET_HINT(RH_ALTAR_CHILD)->GetHintMessage();
-    msg.AutoFormat();
     msg.LoadIntoFont();
     *loadFromMessageTable = false;
 }
 
 void BuildAdultAltarMessage(uint16_t* textId, bool* loadFromMessageTable) {
     CustomMessage msg = RAND_GET_HINT(RH_ALTAR_ADULT)->GetHintMessage();
-    msg.AutoFormat();
     msg.LoadIntoFont();
     *loadFromMessageTable = false;
 }


### PR DESCRIPTION
Pretty simple, GetHintMessage already runs formatting and there's already all the box breaks and such it would need hardcoded into the strings. Formatting it again just causes weird stuff to happen. The autoformat function *could* probably be modified to also look for box break and line break characters in addition to our human-readable substitutions, but that would result in it processing these strings and ultimately doing nothing, so the correct solution is to just not run the AutoFormat on them in the hooks.