### PR TITLE
Restores Greg's textbox icon

### DIFF
--- a/soh/soh/Enhancements/randomizer/Messages/ItemMessages.cpp
+++ b/soh/soh/Enhancements/randomizer/Messages/ItemMessages.cpp
@@ -65,6 +65,7 @@ void BuildTriforcePieceMessage(CustomMessage& msg) {
 
 void BuildCustomItemMessage(Player* player, CustomMessage& msg) {
     int16_t rgid;
+    ItemID icon = ITEM_NONE;
     msg = CustomMessage("You found [[article]][[color]][[name]]%w!",
                         "Du erhältst [[article]][[color]][[name]]%w gefunden!",
                         "Vous avez trouvé [[article]][[color]][[name]]%w!", TEXTBOX_TYPE_BLUE);
@@ -73,6 +74,14 @@ void BuildCustomItemMessage(Player* player, CustomMessage& msg) {
     } else {
         rgid = player->getItemId;
     }
+    // Icon Overrides
+    switch (rgid) {
+        case RG_GREG_RUPEE:
+            icon = ITEM_MASK_GORON;
+            break;
+        default:
+            break;
+    }
     CustomMessage name =
         CustomMessage(Rando::StaticData::RetrieveItem(static_cast<RandomizerGet>(rgid)).GetName(), TEXTBOX_TYPE_BLUE);
     CustomMessage article = CustomMessage(
@@ -80,7 +89,11 @@ void BuildCustomItemMessage(Player* player, CustomMessage& msg) {
     msg.Replace("[[article]]", article);
     msg.Replace("[[color]]", Rando::StaticData::RetrieveItem(static_cast<RandomizerGet>(rgid)).GetColor());
     msg.Replace("[[name]]", name);
-    msg.AutoFormat();
+    if (icon != ITEM_NONE) {
+        msg.AutoFormat(icon);
+    } else {
+        msg.AutoFormat();
+    }
 }
 
 void BuildItemMessage(u16* textId, bool* loadFromMessageTable) {


### PR DESCRIPTION
The Custom Message Hooks PR lost Greg's Goron Mask Icon for the Textbox, this fixes that.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5731927045.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5731949610.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5732031298.zip)
<!--- section:artifacts:end -->