### PR TITLE
Ensure Nabooru Captured flag is correctly set for randomiser

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -481,7 +481,7 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
             }
             break;
         case VB_PLAY_NABOORU_CAPTURED_CS:
-            if (*should == true && CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.Story"), IS_RANDO)) {
+            if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.Story"), IS_RANDO)) {
                 Flags_SetEventChkInf(EVENTCHKINF_NABOORU_CAPTURED_BY_TWINROVA);
                 *should = false;
             }


### PR DESCRIPTION
The Nabooru Captured cutscene skip is implemented oddly compared to others, and was causing the part of the sequence that sets the flag to be skipped in randomiser, causing Nabooru to still spawn and cause impossible seeds with Shuffle Jabber Nuts.

This is a minimal fix to the problem, but someone more experienced with the system may want to investigate why this is handled the way it is and see if it can be done better.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5812535201.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5812500669.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5812491288.zip)
<!--- section:artifacts:end -->