### PR TITLE
fix rando fire temple goron text formatting

### DIFF
--- a/soh/soh/Enhancements/randomizer/Messages/Goron.cpp
+++ b/soh/soh/Enhancements/randomizer/Messages/Goron.cpp
@@ -86,7 +86,7 @@ void BuildGoronMessage(uint16_t* textId, bool* loadFromMessageTable) {
     CustomMessage msg = ShipUtils::RandomElement(FireTempleGoronMessages);
     msg.Replace("[[days]]", std::to_string(gSaveContext.totalDays));
     msg.Replace("[[a_btn]]", std::to_string(gSaveContext.ship.stats.count[COUNT_BUTTON_PRESSES_A]));
-    msg.AutoFormat();
+    msg.Format();
     msg.LoadIntoFont();
     *loadFromMessageTable = false;
 }


### PR DESCRIPTION
AutoFormat isn't suitable for text using escape codes, but unlike other texts this collection uses a mix of escape codes & our formatting codes. In such scenarios `Format` avoids mangling things

fixes #6325