### PR TITLE
Reduce trailing newlines in tooltips/logs

### DIFF
--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -935,7 +935,7 @@ void RegisterAudioWidgets() {
                     "- On New Scene : Randomizes when you enter a new scene.\n"
                     "- On Rando Gen Only: Randomizes only when you generate a new randomizer.\n"
                     "- On File Load: Randomizes on File Load.\n"
-                    "- On File Load (Seeded): Randomizes on file load based on the current randomizer seed/file.\n"));
+                    "- On File Load (Seeded): Randomizes on file load based on the current randomizer seed/file."));
     SohGui::mSohMenu->AddSearchWidget({ randomAudioGenModes, "Enhancements", "Audio Editor", "Audio Options" });
 
     lowerOctaves = { .name = "Lower Octaves of Unplayable High Notes", .type = WidgetType::WIDGET_CVAR_CHECKBOX };

--- a/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
+++ b/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
@@ -346,7 +346,7 @@ void SohInputEditorWindow::DrawButtonLineEditMappingButton(uint8_t port, N64Butt
         if (ImGui::BeginPopup(popupId.c_str())) {
             mInputEditorPopupOpen = true;
             ImGui::Text("Axis Threshold\n\nThe extent to which the joystick\nmust be moved or the trigger\npressed to "
-                        "initiate the assigned\nbutton action.\n\n");
+                        "initiate the assigned\nbutton action.");
 
             auto globalSettings = Ship::Context::GetInstance()->GetControlDeck()->GetGlobalSDLDeviceSettings();
 

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -2410,7 +2410,7 @@ void CosmeticsEditorWindow::DrawElement() {
                      "- On New Scene : Randomizes when you enter a new scene.\n"
                      "- On Rando Gen Only: Randomizes only when you generate a new randomizer.\n"
                      "- On File Load: Randomizes on File Load.\n"
-                     "- On File Load (Seeded): Randomizes on file load based on the current randomizer seed/file.\n"));
+                     "- On File Load (Seeded): Randomizes on file load based on the current randomizer seed/file."));
     UIWidgets::CVarCheckbox(
         "Advanced Mode", CVAR_COSMETIC("AdvancedMode"),
         UIWidgets::CheckboxOptions()

--- a/soh/soh/Enhancements/debugger/colViewer.cpp
+++ b/soh/soh/Enhancements/debugger/colViewer.cpp
@@ -1,12 +1,10 @@
 #include "colViewer.h"
-#include "../../frame_interpolation.h"
 #include "soh/SohGui/UIWidgets.hpp"
 #include "soh/SohGui/SohGui.hpp"
 
 #include <vector>
 #include <string>
 #include <cmath>
-#include "soh/OTRGlobals.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 
 extern "C" {
@@ -322,7 +320,7 @@ void CreateSphereData() {
 
     size_t vtxStartIndex = sphereVtx.size();
     sphereVtx.reserve(sphereVtx.size() + faces.size() * 3);
-    for (int32_t faceIndex = 0; faceIndex < faces.size(); faceIndex++) {
+    for (size_t faceIndex = 0; faceIndex < faces.size(); faceIndex++) {
         sphereVtx.push_back(sphereVtx[std::get<0>(faces[faceIndex])]);
         sphereVtx.push_back(sphereVtx[std::get<1>(faces[faceIndex])]);
         sphereVtx.push_back(sphereVtx[std::get<2>(faces[faceIndex])]);
@@ -777,7 +775,7 @@ extern "C" void DrawColViewer() {
 
     if ((vtxDl.size() > vtxDlCapacity) || (mtxDl.size() > mtxDlCapacity)) {
         // If the sizes somehow changed between the two draws, we can't continue because we may be using invalid data
-        printf("Error drawing collision, vertex/matrix sizes didn't settle.\n");
+        SPDLOG_WARN("Error drawing collision, vertex/matrix sizes didn't settle.");
         return;
     }
 

--- a/soh/soh/Enhancements/randomizer/3drando/fill.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/fill.cpp
@@ -641,11 +641,9 @@ void ValidateEntrances(bool checkOtherEntranceAccess) {
         for (const RandomizerCheck loc : ctx->allLocations) {
             if (!ctx->GetItemLocation(loc)->IsAddedToPool()) {
                 ctx->allLocationsReachable = false;
-                auto message =
-                    "Location " +
-                    Rando::StaticData::GetLocation(ctx->GetItemLocation(loc)->GetRandomizerCheck())->GetName() +
-                    " not reachable\n";
-                LUSLOG_DEBUG("%s", message.c_str());
+                SPDLOG_DEBUG(
+                    "Location {} not reachable",
+                    Rando::StaticData::GetLocation(ctx->GetItemLocation(loc)->GetRandomizerCheck())->GetName());
 #ifndef ENABLE_DEBUG
                 break;
 #endif
@@ -836,19 +834,15 @@ static void AssumedFill(const std::vector<RandomizerGet>& items, const std::vect
     auto ctx = Rando::Context::GetInstance();
     if (items.size() > allowedLocations.size()) {
         SPDLOG_ERROR("ERROR: MORE ITEMS THAN LOCATIONS IN GIVEN LISTS");
-        SPDLOG_DEBUG("Items:\n");
+        SPDLOG_DEBUG("Items:");
         // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
         for (const RandomizerGet item : items) {
-            SPDLOG_DEBUG("\t");
-            SPDLOG_DEBUG(Rando::StaticData::RetrieveItem(item).GetName().GetEnglish());
-            SPDLOG_DEBUG("\n");
+            SPDLOG_DEBUG("\t{}", Rando::StaticData::RetrieveItem(item).GetName().GetEnglish());
         }
-        SPDLOG_DEBUG("\nAllowed Locations:\n");
+        SPDLOG_DEBUG("\nAllowed Locations:");
         // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
         for (const RandomizerCheck loc : allowedLocations) {
-            SPDLOG_DEBUG("\t");
-            SPDLOG_DEBUG(Rando::StaticData::GetLocation(loc)->GetName());
-            SPDLOG_DEBUG("\n");
+            SPDLOG_DEBUG("\t{}", Rando::StaticData::GetLocation(loc)->GetName());
         }
         placementFailure = true;
         return;
@@ -898,9 +892,8 @@ static void AssumedFill(const std::vector<RandomizerGet>& items, const std::vect
             // retry if there are no more locations to place items
             if (accessibleLocations.empty()) {
 
-                SPDLOG_DEBUG("\nCANNOT PLACE ");
-                SPDLOG_DEBUG(Rando::StaticData::RetrieveItem(item).GetName().GetEnglish());
-                SPDLOG_DEBUG(". TRYING AGAIN...\n");
+                SPDLOG_DEBUG("CANNOT PLACE {}. TRYING_AGAIN...",
+                             Rando::StaticData::RetrieveItem(item).GetName().GetEnglish());
 
                 // reset any locations that got an item
                 for (RandomizerCheck loc : attemptedLocations) {
@@ -930,8 +923,8 @@ static void AssumedFill(const std::vector<RandomizerGet>& items, const std::vect
             if (!ctx->GetOption(RSK_ALL_LOCATIONS_REACHABLE)) {
                 logic->Reset();
                 if (CheckBeatable()) {
-                    SPDLOG_DEBUG("Game beatable, now placing items randomly. " + std::to_string(itemsToPlace.size()) +
-                                 " major items remaining.\n\n");
+                    SPDLOG_DEBUG("Game beatable, now placing items randomly. {} major items remaining",
+                                 itemsToPlace.size());
                     FastFill(itemsToPlace, GetEmptyLocations(allowedLocations), true);
                     return;
                 }

--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -1,8 +1,6 @@
 #include "hints.hpp"
 
-#include "item_pool.hpp"
 #include "random.hpp"
-#include "spoiler_log.hpp"
 #include "fill.hpp"
 #include "../trial.h"
 #include "../entrance.h"
@@ -401,7 +399,7 @@ static void AddGossipStoneHintCopies(uint8_t copies, const HintType hintType, co
         // get a random gossip stone
         auto gossipStones = GetEmptyGossipStones();
         if (gossipStones.empty()) {
-            SPDLOG_DEBUG("\tNO GOSSIP STONES TO PLACE HINT\n\n");
+            SPDLOG_DEBUG("\tNO GOSSIP STONES TO PLACE HINT");
             return;
         }
         auto gossipStone = RandomElement(gossipStones, false);
@@ -415,7 +413,7 @@ static bool CreateHint(RandomizerCheck location, uint8_t copies, HintType type, 
     // get a gossip stone accessible without the hinted item
     std::vector<RandomizerCheck> gossipStoneLocations = GetAccessibleGossipStones(location);
     if (gossipStoneLocations.empty()) {
-        SPDLOG_DEBUG("\tNO IN LOGIC GOSSIP STONE\n\n");
+        SPDLOG_DEBUG("\tNO IN LOGIC GOSSIP STONE");
         return false;
     }
     RandomizerCheck gossipStone = RandomElement(gossipStoneLocations);
@@ -437,7 +435,7 @@ static RandomizerCheck CreateRandomHint(std::vector<RandomizerCheck>& possibleHi
 
     // return if there aren't any hintable locations or gossip stones available
     if (GetEmptyGossipStones().size() < copies) {
-        SPDLOG_DEBUG("\tNOT ENOUGH GOSSIP STONES TO PLACE HINTS\n\n");
+        SPDLOG_DEBUG("\tNOT ENOUGH GOSSIP STONES TO PLACE HINTS");
         return RC_UNKNOWN_CHECK;
     }
 
@@ -445,19 +443,14 @@ static RandomizerCheck CreateRandomHint(std::vector<RandomizerCheck>& possibleHi
     bool placed = false;
     while (!placed) {
         if (possibleHintLocations.empty()) {
-            SPDLOG_DEBUG("\tNO LOCATIONS TO HINT\n\n");
+            SPDLOG_DEBUG("\tNO LOCATIONS TO HINT");
             return RC_UNKNOWN_CHECK;
         }
         hintedLocation =
             RandomElement(possibleHintLocations, true); // removing the location to avoid it being hinted again on fail
 
-        SPDLOG_DEBUG("\tLocation: ");
-        SPDLOG_DEBUG(Rando::StaticData::GetLocation(hintedLocation)->GetName());
-        SPDLOG_DEBUG("\n");
-
-        SPDLOG_DEBUG("\tItem: ");
-        SPDLOG_DEBUG(ctx->GetItemLocation(hintedLocation)->GetPlacedItemName().GetEnglish());
-        SPDLOG_DEBUG("\n");
+        SPDLOG_DEBUG("\tLocation: {}", Rando::StaticData::GetLocation(hintedLocation)->GetName());
+        SPDLOG_DEBUG("\tItem: {}", ctx->GetItemLocation(hintedLocation)->GetPlacedItemName().GetEnglish());
 
         placed = CreateHint(hintedLocation, copies, type, distributionName);
     }
@@ -609,8 +602,8 @@ uint8_t PlaceHints(std::vector<uint8_t>& selectedHints, std::vector<HintDistribu
         std::vector<RandomizerCheck> hintTypePool = FilterHintability(ctx->allLocations, distribution.filter);
         for (uint8_t numHint = 0; numHint < selectedHints[curSlot]; numHint++) {
             hintTypePool = FilterHintability(hintTypePool);
-            SPDLOG_DEBUG("Attempting to make hint of type: " +
-                         StaticData::hintTypeNames[distribution.type].GetEnglish(MF_CLEAN) + "\n");
+            SPDLOG_DEBUG("Attempting to make hint of type: {}",
+                         StaticData::hintTypeNames[distribution.type].GetEnglish(MF_CLEAN));
             RandomizerCheck hintedLocation = RC_UNKNOWN_CHECK;
 
             hintedLocation = CreateRandomHint(hintTypePool, distribution.copies, distribution.type, distribution.name);
@@ -640,7 +633,7 @@ uint8_t PlaceHints(std::vector<uint8_t>& selectedHints, std::vector<HintDistribu
 
 void CreateStoneHints() {
     auto ctx = Rando::Context::GetInstance();
-    SPDLOG_DEBUG("\nNOW CREATING HINTS\n");
+    SPDLOG_DEBUG("NOW CREATING HINTS");
     const HintSetting& hintSetting = hintSettingTable[ctx->GetOption(RSK_HINT_DISTRIBUTION).Get()];
     std::vector<HintDistributionSetting> distTable = hintSetting.distTable;
 
@@ -686,11 +679,8 @@ void CreateStoneHints() {
     }
 
     size_t totalStones = GetEmptyGossipStones().size();
-    std::vector<uint8_t> selectedHints = {};
-    for (size_t c = 0; c < distTable.size(); c++) {
-        selectedHints.push_back(0);
-    }
-    selectedHints.push_back(0);
+    std::vector<uint8_t> selectedHints;
+    selectedHints.resize(distTable.size() + 1);
     DistributeHints(selectedHints, totalStones, distTable, hintSetting.junkWeight);
 
     while (totalStones != 0) {

--- a/soh/soh/Enhancements/randomizer/SeedContext.cpp
+++ b/soh/soh/Enhancements/randomizer/SeedContext.cpp
@@ -2,7 +2,6 @@
 #include "static_data.h"
 #include "soh/OTRGlobals.h"
 #include "soh/Enhancements/item-tables/ItemTableManager.h"
-#include "3drando/shops.hpp"
 #include "dungeon.h"
 #include "logic.h"
 #include "entrance.h"
@@ -136,8 +135,8 @@ ItemOverride& Context::GetItemOverride(size_t locKey) {
 void Context::PlaceItemInLocation(const RandomizerCheck locKey, const RandomizerGet item,
                                   const bool applyEffectImmediately, const bool setHidden) {
     const auto loc = GetItemLocation(locKey);
-    SPDLOG_DEBUG(StaticData::RetrieveItem(item).GetName().GetEnglish() + " placed at " +
-                 StaticData::GetLocation(locKey)->GetName() + "\n");
+    SPDLOG_DEBUG("{} placed at {}", StaticData::RetrieveItem(item).GetName().GetEnglish(),
+                 StaticData::GetLocation(locKey)->GetName());
 
     if (applyEffectImmediately || mOptions[RSK_LOGIC_RULES].Is(RO_LOGIC_GLITCHLESS)) {
         StaticData::RetrieveItem(item).ApplyEffect();
@@ -332,7 +331,7 @@ void Context::HintReset() {
 }
 
 void Context::CreateItemOverrides() {
-    SPDLOG_DEBUG("NOW CREATING OVERRIDES\n\n");
+    SPDLOG_DEBUG("NOW CREATING OVERRIDES");
     for (RandomizerCheck locKey : allLocations) {
         const auto loc = StaticData::GetLocation(locKey);
         // If this is an ice trap, store the disguise model in iceTrapModels
@@ -344,13 +343,9 @@ void Context::CreateItemOverrides() {
             // If this is ice trap is in a shop, change the name based on what the model will look like
             overrides[locKey] = val;
         }
-        SPDLOG_DEBUG(loc->GetName());
-        SPDLOG_DEBUG(": ");
-        SPDLOG_DEBUG(itemLoc->GetPlacedItemName().GetEnglish());
-        SPDLOG_DEBUG("\n");
+        SPDLOG_DEBUG("{}: {}", loc->GetName(), itemLoc->GetPlacedItemName().GetEnglish());
     }
-    SPDLOG_DEBUG("Overrides Created: ");
-    SPDLOG_DEBUG(std::to_string(overrides.size()));
+    SPDLOG_DEBUG("Overrides Created: {}", std::to_string(overrides.size()));
 }
 
 bool Context::IsSeedGenerated() const {

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/death_mountain_crater.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/death_mountain_crater.cpp
@@ -92,13 +92,13 @@ void RegionTable_Init_DeathMountainCrater() {
         ENTRANCE(RR_DMC_POTS,            logic->FireTimer() >= 8 || logic->Hearts() >= 2),
         ENTRANCE(RR_DMC_POT_GROTTO_EXIT, logic->FireTimer() >= 16 || logic->Hearts() >= 3),
         ENTRANCE(RR_DMC_CENTRAL,         ((logic->FireTimer() >= 40 || logic->Hearts() >= 8) && logic->DMCPotsToPad()) ||
-                                         (logic->IsAdult && (logic->FireTimer() >= 48 || logic->Hearts() >= 9) && logic->ReachDistantScarecrow() && logic->TakeDamage() && (logic->CanUse(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT)))),
+                                         (logic->IsAdult && (logic->FireTimer() >= 48 || logic->Hearts() >= 9) && logic->ReachDistantScarecrow() && logic->TakeDamage() && (logic->HasItem(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT)))),
         ENTRANCE(RR_DMC_FAR_PLATFORM,    (logic->IsAdult && (logic->FireTimer() >= 48 || logic->Hearts() >= 9) && logic->DMCPotsToPad() && logic->ReachDistantScarecrow()) ||
-                                         ((logic->FireTimer() >= 32 || logic->Hearts() >= 6) && logic->TakeDamage() && (logic->CanUse(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT))) || 
+                                         ((logic->FireTimer() >= 32 || logic->Hearts() >= 6) && logic->TakeDamage() && (logic->HasItem(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT))) || 
                                          (logic->IsAdult && (logic->FireTimer() >= 48 || logic->Hearts() >= 9) && logic->DMCPotsToPad() && CanPlantBean(RR_DMC_CENTRAL, RG_DEATH_MOUNTAIN_CRATER_BEAN_SOUL)) ||
                                          ((logic->FireTimer() >= 32 || logic->Hearts() >= 6) && logic->TakeDamage() && ctx->GetTrickOption(RT_DMC_HOVER_BEAN_POH) && logic->CanUse(RG_HOVER_BOOTS))),
         ENTRANCE(RR_DMC_TEMPLE_EXIT,     ((logic->FireTimer() >= 48 || logic->Hearts() >= 9) && logic->DMCPotsToPad()) ||
-                                         (logic->IsAdult && (logic->FireTimer() >= 56 || logic->Hearts() >= 11) && logic->TakeDamage() && logic->ReachDistantScarecrow() && (logic->CanUse(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT)))),
+                                         (logic->IsAdult && (logic->FireTimer() >= 56 || logic->Hearts() >= 11) && logic->TakeDamage() && logic->ReachDistantScarecrow() && (logic->HasItem(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT)))),
     });
 
     areaTable[RR_DMC_POTS_ENTRY] = Region("DMC Pots Entry", SCENE_DEATH_MOUNTAIN_CRATER, {}, {
@@ -124,11 +124,11 @@ void RegionTable_Init_DeathMountainCrater() {
         ENTRANCE(RR_DMC_POTS,            true),
         ENTRANCE(RR_DMC_POT_GROTTO_EXIT, logic->FireTimer() >= 8 || logic->Hearts() >= 2),
         ENTRANCE(RR_DMC_CENTRAL,         ((logic->FireTimer() >= 32 || logic->Hearts() >= 6) && logic->DMCPotsToPad()) ||
-                                         (logic->IsAdult && (logic->FireTimer() >= 56 || logic->Hearts() >= 11) && logic->TakeDamage() && logic->ReachDistantScarecrow() && (logic->CanUse(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT)))),
+                                         (logic->IsAdult && (logic->FireTimer() >= 56 || logic->Hearts() >= 11) && logic->TakeDamage() && logic->ReachDistantScarecrow() && (logic->HasItem(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT)))),
         ENTRANCE(RR_DMC_FAR_PLATFORM,    (logic->IsAdult && (logic->FireTimer() >= 40 || logic->Hearts() >= 8) && logic->DMCPotsToPad() && logic->ReachDistantScarecrow()) ||
-                                         ((logic->FireTimer() >= 32 || logic->Hearts() >= 6) && logic->TakeDamage() && (logic->CanUse(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT)))),
+                                         ((logic->FireTimer() >= 32 || logic->Hearts() >= 6) && logic->TakeDamage() && (logic->HasItem(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT)))),
         ENTRANCE(RR_DMC_TEMPLE_EXIT,     ((logic->FireTimer() >= 40 || logic->Hearts() >= 8) && logic->DMCPotsToPad()) ||
-                                         (logic->IsAdult && (logic->FireTimer() >= 56 || logic->Hearts() >= 11) && logic->TakeDamage() && logic->ReachDistantScarecrow() && (logic->CanUse(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT)))),
+                                         (logic->IsAdult && (logic->FireTimer() >= 56 || logic->Hearts() >= 11) && logic->TakeDamage() && logic->ReachDistantScarecrow() && (logic->HasItem(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT)))),
     });
 
     areaTable[RR_DMC_POT_GROTTO_ENTRY] = Region("DMC Pot Grotto Entry", SCENE_DEATH_MOUNTAIN_CRATER, {}, {
@@ -154,11 +154,11 @@ void RegionTable_Init_DeathMountainCrater() {
         ENTRANCE(RR_DMC_POTS,            logic->FireTimer() >= 8 || logic->Hearts() >= 2),
         ENTRANCE(RR_DMC_POT_GROTTO_EXIT, true),
         ENTRANCE(RR_DMC_CENTRAL,         ((logic->FireTimer() >= 32 || logic->Hearts() >= 6) && logic->DMCPotsToPad()) ||
-                                         (logic->IsAdult && (logic->FireTimer() >= 56 || logic->Hearts() >= 11) && logic->TakeDamage() && logic->ReachDistantScarecrow() && (logic->CanUse(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT)))),
+                                         (logic->IsAdult && (logic->FireTimer() >= 56 || logic->Hearts() >= 11) && logic->TakeDamage() && logic->ReachDistantScarecrow() && (logic->HasItem(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT)))),
         ENTRANCE(RR_DMC_FAR_PLATFORM,    (logic->IsAdult && (logic->FireTimer() >= 40 || logic->Hearts() >= 8) && logic->DMCPotsToPad() && logic->ReachDistantScarecrow()) ||
-                                         ((logic->FireTimer() >= 40 || logic->Hearts() >= 8) && logic->TakeDamage() && (logic->CanUse(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT)))),
+                                         ((logic->FireTimer() >= 40 || logic->Hearts() >= 8) && logic->TakeDamage() && (logic->HasItem(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT)))),
         ENTRANCE(RR_DMC_TEMPLE_EXIT,     ((logic->FireTimer() >= 40 || logic->Hearts() >= 8) && logic->DMCPotsToPad()) ||
-                                         (logic->IsAdult && (logic->FireTimer() >= 56 || logic->Hearts() >= 11) && logic->TakeDamage() && logic->ReachDistantScarecrow() && (logic->CanUse(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT)))),
+                                         (logic->IsAdult && (logic->FireTimer() >= 56 || logic->Hearts() >= 11) && logic->TakeDamage() && logic->ReachDistantScarecrow() && (logic->HasItem(RG_CLIMB) || logic->CanUse(RG_HOOKSHOT)))),
     });
 
     areaTable[RR_DMC_PAD_ENTRY] = Region("DMC Pad Entry", SCENE_DEATH_MOUNTAIN_CRATER, {}, {

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/death_mountain_trail.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/death_mountain_trail.cpp
@@ -37,7 +37,7 @@ void RegionTable_Init_DeathMountainTrail() {
         //Exits
         ENTRANCE(RR_DEATH_MOUNTAIN_TRAIL,  true),
         ENTRANCE(RR_DEATH_MOUNTAIN_SUMMIT, logic->HasItem(RG_CLIMB) &&
-                                           (logic->IsAdult || ctx->GetTrickOption(RT_DMT_SHIELDLESS_CLIMB) || logic->CanUse(RG_HYLIAN_SHIELD) || logic->CanUse(RG_NAYRUS_LOVE))),
+                                           (logic->IsAdult || ctx->GetTrickOption(RT_DMT_SHIELDLESS_CLIMB) || logic->HasItem(RG_HYLIAN_SHIELD) || logic->CanUse(RG_NAYRUS_LOVE))),
         ENTRANCE(RR_DMT_COW_GROTTO,        AnyAgeTime([]{return logic->BlastOrSmash();})),
     });
 

--- a/soh/soh/Enhancements/randomizer/location_access/overworld/kokiri_forest.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/overworld/kokiri_forest.cpp
@@ -70,7 +70,7 @@ void RegionTable_Init_KokiriForest() {
     }, {
         //Exits
         ENTRANCE(RR_KF_BOULDER_LOOP,       logic->CanUse(RG_CRAWL)),
-        ENTRANCE(RR_KF_LINKS_PORCH,        logic->IsChild ? logic->CanClimbLadder() : logic->CanUse(RG_CLIMB) || logic->CanUse(RG_HOVER_BOOTS)),
+        ENTRANCE(RR_KF_LINKS_PORCH,        logic->IsChild ? logic->CanClimbLadder() : logic->HasItem(RG_CLIMB) || logic->CanUse(RG_HOVER_BOOTS)),
         ENTRANCE(RR_KF_MIDOS_HOUSE,        true),
         ENTRANCE(RR_KF_SARIAS_HOUSE,       true),
         ENTRANCE(RR_KF_HOUSE_OF_TWINS,     true),

--- a/soh/soh/Enhancements/randomizer/logic.cpp
+++ b/soh/soh/Enhancements/randomizer/logic.cpp
@@ -2548,11 +2548,11 @@ bool Logic::ReachDistantScarecrow() {
 }
 
 bool Logic::CanClimbLadder() {
-    return CanUse(RG_CLIMB) || (ctx->GetTrickOption(RT_HOOKSHOT_LADDERS) && CanUse(RG_HOOKSHOT));
+    return HasItem(RG_CLIMB) || (ctx->GetTrickOption(RT_HOOKSHOT_LADDERS) && CanUse(RG_HOOKSHOT));
 }
 
 bool Logic::CanClimbHighLadder() {
-    return CanUse(RG_CLIMB) || (ctx->GetTrickOption(RT_HOOKSHOT_LADDERS) && CanUse(RG_LONGSHOT));
+    return HasItem(RG_CLIMB) || (ctx->GetTrickOption(RT_HOOKSHOT_LADDERS) && CanUse(RG_LONGSHOT));
 }
 
 bool Logic::SummonEpona() {

--- a/soh/soh/SohGui/SohMenuDevTools.cpp
+++ b/soh/soh/SohGui/SohMenuDevTools.cpp
@@ -122,8 +122,7 @@ void SohMenu::AddMenuDevTools() {
         .Callback([](WidgetInfo& info) {
             Ship::Context::GetInstance()->GetLogger()->set_level(
                 (spdlog::level::level_enum)CVarGetInteger(CVAR_DEVELOPER_TOOLS("LogLevel"), defaultLogLevel));
-        })
-        .PreFunc([](WidgetInfo& info) { info.isHidden = mSohMenu->disabledMap.at(DISABLE_FOR_DEBUG_MODE_OFF).active; });
+        });
 
     path.column = SECTION_COLUMN_2;
     AddWidget(path, "Warping", WIDGET_SEPARATOR_TEXT);

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -740,7 +740,7 @@ void SohMenu::AddMenuEnhancements() {
             " - Boulders\n"
             " - Blue Warps\n"
             " - Darunia\n"
-            " - Gold Skulltulas\n"));
+            " - Gold Skulltulas"));
 
     path.sidebarName = "Items";
     AddSidebarEntry("Enhancements", path.sidebarName, 3);
@@ -1136,7 +1136,7 @@ void SohMenu::AddMenuEnhancements() {
                 .Tooltip("Disabled: Paths vanish more the higher the resolution (Z-Fighting is based on resolution).\n"
                          "Consistent: Certain paths vanish the same way in all resolutions.\n"
                          "No Vanish: Paths do not vanish, Link seems to sink in to some paths.\n"
-                         "This might affect other decal effects.\n"));
+                         "This might affect other decal effects."));
 
     AddWidget(path, "Audio Fixes", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Fix Missing Jingle after 5 Silver Rupees", WIDGET_CVAR_CHECKBOX)
@@ -1584,7 +1584,7 @@ void SohMenu::AddMenuEnhancements() {
                     " - Dungeons (Vanilla): Mirror the world in Vanilla Dungeons.\n"
                     " - Dungeons (MQ): Mirror the world in MQ Dungeons.\n"
                     " - Dungeons Random: Randomly decide to mirror the world in Dungeons.\n"
-                    " - Dungeons Random (Seeded): Dungeons are mirrored based on the current randomizer seed/file.\n"));
+                    " - Dungeons Random (Seeded): Dungeons are mirrored based on the current randomizer seed/file."));
     AddWidget(path, "Ivan the Fairy (Coop Mode)", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("IvanCoopModeEnabled"))
         .Options(CheckboxOptions().Tooltip(
@@ -1682,7 +1682,7 @@ void SohMenu::AddMenuEnhancements() {
                          "Enemies that need more than Deku Nuts & either Deku Sticks or a sword to kill are excluded "
                          "from spawning in \"clear enemy\" rooms.\n\n"
                          "- Random: Enemies are randomized every time you load a room.\n"
-                         "- Random (Seeded): Enemies are randomized based on the current randomizer seed/file.\n"));
+                         "- Random (Seeded): Enemies are randomized based on the current randomizer seed/file."));
     AddWidget(path, "Randomized Enemy Sizes", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("RandomizedEnemySizes"))
         .Options(CheckboxOptions().Tooltip("Enemies and Bosses spawn with random sizes."));

--- a/soh/soh/SohGui/SohMenuRandomizer.cpp
+++ b/soh/soh/SohGui/SohMenuRandomizer.cpp
@@ -539,7 +539,7 @@ void SohMenu::AddMenuRandomizer() {
             ImGui::InputText("##RandomizerSeed", seedString, MAX_SEED_STRING_SIZE,
                              ImGuiInputTextFlags_CallbackCharFilter, UIWidgets::TextFilters::FilterAlphaNum);
             UIWidgets::Tooltip("Characters from a-z, A-Z, and 0-9 are supported.\n"
-                               "Character limit is 1023, after which the seed will be truncated.\n");
+                               "Character limit is 1023, after which the seed will be truncated.");
             ImGui::SameLine();
             if (UIWidgets::Button(
                     ICON_FA_RANDOM,


### PR DESCRIPTION
Clean up code which seemed to not realize each call to logger gets its own line, & always show log level option in dev tools menu

Fix misc compiler warnings in same files

Fix some `CanUse` warnings noticed while testing improved logging

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5821281237.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5821251224.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5821241943.zip)
<!--- section:artifacts:end -->