### PR TITLE
Crowd Control Fixes

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractionEffect.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractionEffect.cpp
@@ -133,6 +133,8 @@ void FillMagic::_Apply() {
 GameInteractionEffectQueryResult EmptyMagic::CanBeApplied() {
     if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
+    } else if (CVarGetInteger(CVAR_CHEAT("InfiniteMagic"), 0)) {
+        return GameInteractionEffectQueryResult::NotPossible;
     } else if (!gSaveContext.isMagicAcquired || gSaveContext.magic <= 0) {
         return GameInteractionEffectQueryResult::NotPossible;
     } else {
@@ -147,6 +149,8 @@ void EmptyMagic::_Apply() {
 GameInteractionEffectQueryResult ModifyRupees::CanBeApplied() {
     if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
+    } else if (CVarGetInteger(CVAR_CHEAT("InfiniteMoney"), 0)) {
+        return GameInteractionEffectQueryResult::NotPossible;
     } else if ((parameters[0] < 0 && gSaveContext.rupees <= 0) ||
                (parameters[0] > 0 && gSaveContext.rupees >= CUR_CAPACITY(UPG_WALLET))) {
         return GameInteractionEffectQueryResult::NotPossible;
@@ -532,6 +536,8 @@ void PressRandomButton::_Apply() {
 GameInteractionEffectQueryResult AddOrTakeAmmo::CanBeApplied() {
     if (!GameInteractor::IsSaveLoaded(true)) {
         return GameInteractionEffectQueryResult::TemporarilyNotPossible;
+    } else if (parameters[1] != ITEM_BEAN && CVarGetInteger(CVAR_CHEAT("InfiniteAmmo"), 0)) {
+        return GameInteractionEffectQueryResult::NotPossible;
     } else if (!GameInteractor::CanAddOrTakeAmmo(parameters[0], parameters[1])) {
         return GameInteractionEffectQueryResult::NotPossible;
     } else {

--- a/soh/soh/Network/CrowdControl/ShipOfHarkinian.cs
+++ b/soh/soh/Network/CrowdControl/ShipOfHarkinian.cs
@@ -74,7 +74,7 @@ public class ShipOfHarkinian : SimpleTCPPack<SimpleTCPServerConnector>
         new("Refill Deku Nuts", "refill_nuts") { Category = "Give Items/Consumables", Quantity = 30, Price = 3, Description = "Only works when the player already had Deku Nuts before." },
         new("Refill Bombs", "refill_bombs") { Category = "Give Items/Consumables", Quantity = 30, Price = 5, Description = "Only works when the player already has a bomb bag." },
         new("Refill Slingshot Seeds", "refill_seeds") { Category = "Give Items/Consumables", Quantity = 30, Price = 1, Description = "Only works when the player already has a Slingshot." },
-        new("Refill Arrows", "refill_arrows") { Category = "Give Items/Consumables", Price = 1, Description = "Only works when the player already has a bow." },
+        new("Refill Arrows", "refill_arrows") { Category = "Give Items/Consumables", Quantity = 30, Price = 1, Description = "Only works when the player already has a bow." },
         new("Refill Bombchus", "refill_bombchus") { Category = "Give Items/Consumables", Quantity = 30, Price = 5, Description = "Only works when the player already had Bombchus before." },
 
         // Take Items and Consumables


### PR DESCRIPTION
Fixes an issue where a user enables infinite ammo/rupees/etc and has Crowd Control effects enabled to give/take those away.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5837290308.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5837156646.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5837154388.zip)
<!--- section:artifacts:end -->