### PR TITLE
Fix loading wrong day/night scene after blue warp in rando

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
@@ -140,6 +140,7 @@ void RegisterShouldPlayBlueWarp() {
                        gSaveContext.chamberCutsceneNum == CHAMBER_CS_WATER) {
                 // Normally set in the blue warp cutscene
                 gSaveContext.dayTime = gSaveContext.skyboxTime = 0x4800;
+                gSaveContext.nightFlag = 0;
                 Flags_SetEventChkInf(EVENTCHKINF_RAISED_LAKE_HYLIA_WATER);
 
                 gSaveContext.entranceIndex = ENTR_LAKE_HYLIA_WATER_TEMPLE_BLUE_WARP;
@@ -160,6 +161,7 @@ void RegisterShouldPlayBlueWarp() {
                 if (gSaveContext.entranceIndex != ENTR_LAKE_HYLIA_WATER_TEMPLE_BLUE_WARP) {
                     // Normally set in the blue warp cutscene
                     gSaveContext.dayTime = gSaveContext.skyboxTime = 0x8000;
+                    gSaveContext.nightFlag = 0;
                 }
 
                 *should = false;


### PR DESCRIPTION
When entering a dungeon like well at night, defeating a boss that changes time to day, Kakariko Village would load with daylight but act like it's night

Skipping blue warp cutscene meant dayTime and nightFlag weren't properly in sync. Clear `gSaveContext.nightFlag` when adjusting time of day

fixes #5526

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5934037654.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5934003084.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5933989875.zip)
<!--- section:artifacts:end -->