### PR TITLE
Fix happy mask salesman to check flags instead of inventory for SOLD OUT

### DIFF
--- a/soh/soh/Enhancements/MaskSelect.cpp
+++ b/soh/soh/Enhancements/MaskSelect.cpp
@@ -1,0 +1,23 @@
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+
+extern "C" {
+#include "functions.h"
+#include "src/overlays/actors/ovl_En_Ossan/z_en_ossan.h"
+}
+
+static void RegisterMaskSelectFixes() {
+    // Fix mask quest so replacing SOLD OUT with mask select doesn't break quest
+    COND_VB_SHOULD(VB_HAPPY_MASK_SHOP_CHECK_SOLD_OUT, CVarGetInteger(CVAR_ENHANCEMENT("MaskSelect"), 0), {
+        Actor* actor = va_arg(args, Actor*);
+        if (actor->params == OSSAN_TYPE_MASK &&
+                (Flags_GetItemGetInf(ITEMGETINF_3B) && !Flags_GetEventChkInf(EVENTCHKINF_PAID_BACK_BUNNY_HOOD_FEE)) ||
+            (Flags_GetItemGetInf(ITEMGETINF_3A) && !Flags_GetEventChkInf(EVENTCHKINF_PAID_BACK_SPOOKY_MASK_FEE)) ||
+            (Flags_GetItemGetInf(ITEMGETINF_39) && !Flags_GetEventChkInf(EVENTCHKINF_PAID_BACK_SKULL_MASK_FEE)) ||
+            (Flags_GetItemGetInf(ITEMGETINF_38) && !Flags_GetEventChkInf(EVENTCHKINF_PAID_BACK_KEATON_MASK_FEE))) {
+            *should = true;
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterMaskSelectFixes, { CVAR_ENHANCEMENT("MaskSelect") });

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -304,6 +304,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // INV_CONTENT(ITEM_TRADE_CHILD) == ITEM_SOLD_OUT
+    // ```
+    // #### `args`
+    // - `*EnOssan` (Happy Mask Shopkeeper)
+    VB_HAPPY_MASK_SHOP_CHECK_SOLD_OUT,
+
+    // #### `result`
+    // ```c
     // true
     // ```
     // #### `args`

--- a/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -2128,7 +2128,8 @@ u16 EnOssan_SetupHelloDialog(EnOssan* this) {
     this->happyMaskShopState = OSSAN_HAPPY_STATE_NONE;
     // mask shop messages
     if (this->actor.params == OSSAN_TYPE_MASK) {
-        if (INV_CONTENT(ITEM_TRADE_CHILD) == ITEM_SOLD_OUT) {
+        if (GameInteractor_Should(VB_HAPPY_MASK_SHOP_CHECK_SOLD_OUT, INV_CONTENT(ITEM_TRADE_CHILD) == ITEM_SOLD_OUT,
+                                  this)) {
             if (Flags_GetItemGetInf(ITEMGETINF_3B)) {
                 if (!Flags_GetEventChkInf(EVENTCHKINF_PAID_BACK_BUNNY_HOOD_FEE)) {
                     // Pay back Bunny Hood


### PR DESCRIPTION
Fixes getting locked out of mask quest with mask select

Fixes #5266

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5947313069.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5947095124.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/5947068765.zip)
<!--- section:artifacts:end -->