### PR TITLE
Fix `numLoaded` leak for Anchor

### DIFF
--- a/soh/soh/Network/Anchor/DummyPlayer.cpp
+++ b/soh/soh/Network/Anchor/DummyPlayer.cpp
@@ -243,4 +243,10 @@ void DummyPlayer_Draw(Actor* actor, PlayState* play) {
 }
 
 void DummyPlayer_Destroy(Actor* actor, PlayState* play) {
+    // DummyPlayer Actors are initially spawned as ACTOR_PLAYER, but change their
+    // ID shortly afterwards to ACTOR_EN_OE2. This would cause ACTOR_PLAYER's
+    // ActorDB Entry's `numLoaded` to leak, which is mostly harmless but hits debug
+    // asserts. Set the id back to ACTOR_PLAYER so that `numLoaded` will be decremented
+    // correctly.
+    actor->id = ACTOR_PLAYER;
 }


### PR DESCRIPTION
Anchor spawns player actors for showing the other players, initially spawns them as `ACTOR_PLAYER`s, and sets different init and update functions, the former of which then changes the player's `ActorID` to `ACTOR_EN_OE2`, an unused id. The issue is that since `Actor_Spawn` is called with `ACTOR_PLAYER`, The player's ActorDB entry has `numLoaded` incremented, but since the id is changed afterwards, when they are killed the ActorDB entry for `ACTOR_EN_OE2` has `numLoaded` decremented instead. This is actually harmless as far as I can tell, but it does hit some asserts we have to ensure we don't have too many actors loaded in debug mode. This change avoids that by setting the actor id back to `ACTOR_PLAYER` during `Actor_Destroy`, which gets called before the decrement happens.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6040138679.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6040100104.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6040088689.zip)
<!--- section:artifacts:end -->