### PR TITLE
Change Non-CMC Pot Model to Major

### DIFF
--- a/soh/soh/Enhancements/randomizer/ShufflePots.cpp
+++ b/soh/soh/Enhancements/randomizer/ShufflePots.cpp
@@ -54,7 +54,7 @@ extern "C" void ObjTsubo_RandomizerDraw(Actor* thisx, PlayState* play) {
                     break;
             }
         } else {
-            gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gPotStandardDL);
+            gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gPotMajorDL);
         }
     } else {
         gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gPotDL);


### PR DESCRIPTION
Responding to feedback that junk pot is visually similar to regular pot model. Major pot model makes it clear in non-CMC if visible pots are shuffled or not