### PR TITLE
Adds a more compact Clear button to Check Tracker search

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1082,7 +1082,7 @@ void CheckTrackerWindow::DrawElement() {
         }
         UIWidgets::PushStyleCombobox(THEME_COLOR);
         if (CVarGetInteger(CVAR_TRACKER_CHECK("SearchInputVisible"), 1)) {
-            if (checkSearch.Draw("", ImGui::GetContentRegionAvail().x - 40)) {
+            if (checkSearch.Draw("", ImGui::GetContentRegionAvail().x - 42)) {
                 UpdateFilters();
             }
             std::string checkSearchText = "";
@@ -1091,11 +1091,12 @@ void CheckTrackerWindow::DrawElement() {
                                   checkSearchText.end());
             ImGui::SameLine();
             if (UIWidgets::Button(ICON_FA_ERASER, UIWidgets::ButtonOptions()
-                                                    .Size(UIWidgets::Sizes::Inline)
-                                                    .Color(THEME_COLOR)
-                                                    .Padding(ImVec2(10.f, 6.f)))) {
-              checkSearch.Clear();
-              UpdateFilters();
+                                                      .Size(UIWidgets::Sizes::Inline)
+                                                      .Color(THEME_COLOR)
+                                                      .Padding(ImVec2(10.f, 6.f)))) {
+                checkSearch.Clear();
+                UpdateFilters();
+                doAreaScroll = true;
             }
             if (checkSearchText.length() < 1) {
                 ImGui::SameLine(20.0f);

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1082,13 +1082,21 @@ void CheckTrackerWindow::DrawElement() {
         }
         UIWidgets::PushStyleCombobox(THEME_COLOR);
         if (CVarGetInteger(CVAR_TRACKER_CHECK("SearchInputVisible"), 1)) {
-            if (checkSearch.Draw("", ImGui::GetContentRegionAvail().x - 6)) {
+            if (checkSearch.Draw("", ImGui::GetContentRegionAvail().x - 40)) {
                 UpdateFilters();
             }
             std::string checkSearchText = "";
             checkSearchText = checkSearch.InputBuf;
             checkSearchText.erase(std::remove(checkSearchText.begin(), checkSearchText.end(), ' '),
                                   checkSearchText.end());
+            ImGui::SameLine();
+            if (UIWidgets::Button(ICON_FA_ERASER, UIWidgets::ButtonOptions()
+                                                    .Size(UIWidgets::Sizes::Inline)
+                                                    .Color(THEME_COLOR)
+                                                    .Padding(ImVec2(10.f, 6.f)))) {
+              checkSearch.Clear();
+              UpdateFilters();
+            }
             if (checkSearchText.length() < 1) {
                 ImGui::SameLine(20.0f);
                 ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, 0.4f), "Search...");

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1085,8 +1085,7 @@ void CheckTrackerWindow::DrawElement() {
             if (checkSearch.Draw("", ImGui::GetContentRegionAvail().x - 42)) {
                 UpdateFilters();
             }
-            std::string checkSearchText = "";
-            checkSearchText = checkSearch.InputBuf;
+            std::string checkSearchText = checkSearch.InputBuf;
             checkSearchText.erase(std::remove(checkSearchText.begin(), checkSearchText.end(), ' '),
                                   checkSearchText.end());
             ImGui::SameLine();


### PR DESCRIPTION
In a previous rework, the clear button was removed from the Check Tracker, this adds it back in, using the eraser icon instead of the full text "Clear" for compactness.

<img width="383" height="587" alt="image" src="https://github.com/user-attachments/assets/36faf3af-c548-41e7-adf6-b9e864d5f4ad" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6065977727.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6065865872.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6065819019.zip)
<!--- section:artifacts:end -->