### PR TITLE
Fix leak of shuffled fairy bottle-swipe behavior to other actors

### DIFF
--- a/soh/soh/Enhancements/randomizer/ShuffleFairies.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleFairies.cpp
@@ -106,11 +106,13 @@ void RegisterShuffleFairies() {
 
     COND_VB_SHOULD(VB_BOTTLE_ACTOR, shouldRegister, {
         Actor* actor = va_arg(args, Actor*);
-        const auto fairyIdentity = ObjectExtension::GetInstance().Get<CheckIdentity>(actor);
-        if (fairyIdentity != nullptr && fairyIdentity->randomizerInf != RAND_INF_MAX) {
-            Flags_SetRandomizerInf(fairyIdentity->randomizerInf);
-            actor->parent = &GET_PLAYER(gPlayState)->actor;
-            *should = false;
+        if (actor->id == ACTOR_EN_ELF) {
+            const auto fairyIdentity = ObjectExtension::GetInstance().Get<CheckIdentity>(actor);
+            if (fairyIdentity != nullptr && fairyIdentity->randomizerInf != RAND_INF_MAX) {
+                Flags_SetRandomizerInf(fairyIdentity->randomizerInf);
+                actor->parent = &GET_PLAYER(gPlayState)->actor;
+                *should = false;
+            }
         }
     });
 


### PR DESCRIPTION
The `VB_BOTTLE_ACTOR` hook in `ShuffleFairies.cpp` wasn't checking the actor id of the actor it was bottling, and since we store the same type of CheckIdentity object for every actor with a check in the ObjectExtension system, it was just grabbing whatever actor you swiped, grabbing its check identity, and giving you the item.

This surrounds everything in that hook in `if(actor->id == ACTOR_EN_ELF)`. I confirmed you can no longer bottle grass and pots but can still bottle fairies.

Fixes #6404 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6087590832.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6086978414.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6086933954.zip)
<!--- section:artifacts:end -->