### PR TITLE
Improve flavour of Navi's boss key hint

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hint_list.cpp
@@ -2237,10 +2237,9 @@ void StaticData::HintTable_Init() {
                                                         /*french*/ "J'ai entendu dire que Ganondorf aurait caché les #Flèches de Lumière# dans #[[1]]#.",
                                                                    {QM_YELLOW, QM_RED}));
 
-    hintTextTable[RHT_BOSS_KEY_HINT] = HintText(CustomMessage("The #boss key# for this door is in #[[1]]#!",
+    hintTextTable[RHT_BOSS_KEY_HINT] = HintText(CustomMessage("%c@! I can hear Rauru's guidance! He's saying the %ykey for this door%c is in %w[[1]]%c!",
                                                    /*german*/ TODO_TRANSLATE,
-                                                   /*french*/ TODO_TRANSLATE,
-                                                              {QM_GREEN, QM_RED}));
+                                                   /*french*/ TODO_TRANSLATE));
 
     hintTextTable[RHT_DAMPE_DIARY] = HintText(CustomMessage("Whoever reads this, please enter #[[1]]#. I will let you have my #stretching, shrinking keepsake#.^I'm waiting for you.&--Dampé",
                                                  /*german*/ "Wer immer dies liest, der möge #[[1]]# nach meinem #langen, kurzen Schatz# suchen.^Ich warte!&Boris",


### PR DESCRIPTION
Hint texts generally try to be written in a way which makes them believable in-universe (gossip stones, Dampé's diary, fishing hole guy, etc), but I thought the boss key hint was a bit lacking. Navi tells the player exactly where the key is, as if she knew the whole time. The text is also not formatted correctly for Navi, who normally uses light blue text.

I changed the text to imply that Rauru is the one that originally knows where the key is. I also removed the redundant reference to a "boss" key - the player is already standing in front of the boss door, so it's pretty obvious which key is being talked about. And I also coloured the text to fit better with other Navi hints.

The text fits easily within three lines in English, which should give some wriggle room for long place names or future translations.

<img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/1a8dac19-ffc8-4056-852e-e54ed9f31832" />

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6110348934.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6109824057.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6109790193.zip)
<!--- section:artifacts:end -->