### PR TITLE
Move retrieval of dbEntry after Actor_Destroy

### DIFF
--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -3491,12 +3491,6 @@ Actor* Actor_Delete(ActorContext* actorCtx, Actor* actor, PlayState* play) {
     // Execute before actor memory is freed
     GameInteractor_ExecuteOnActorDestroy(actor);
 
-    dbEntry = ActorDB_Retrieve(actor->id);
-
-    if (HREG(20) != 0) {
-        osSyncPrintf("アクタークラス削除 [%s]\n", dbEntry->name); // "Actor class deleted [%s]"
-    }
-
     if ((player != NULL) && (actor == player->focusActor)) {
         Player_ReleaseLockOn(player);
         Camera_ChangeMode(Play_GetCamera(play, Play_GetActiveCamId(play)), 0);
@@ -3516,6 +3510,12 @@ Actor* Actor_Delete(ActorContext* actorCtx, Actor* actor, PlayState* play) {
 
     Audio_StopSfxByPos(&actor->projectedPos);
     Actor_Destroy(actor, play);
+
+    dbEntry = ActorDB_Retrieve(actor->id);
+
+    if (HREG(20) != 0) {
+        osSyncPrintf("アクタークラス削除 [%s]\n", dbEntry->name); // "Actor class deleted [%s]"
+    }
 
     newHead = Actor_RemoveFromCategory(play, actorCtx, actor);
 


### PR DESCRIPTION
Before I had the change back to the placeholder actor id the Dummy Player actors were spawned with, but since we grabbed the actorDB entry before Actor_Destroy was called it didn't matter. Move it and the requisite log statement to after Actor_Destroy.

This should only affect debug builds since the only place where the ActorDB entry's numLoaded value being incorrect is actually a problem is in an assert. This time there were way more players in the global anchor room while I was testing, so I definitely hit the assert once during a recent playtest, which is when I noticed this discrepancy. After fixing this I played for around 3 more hours and saw plenty of other people from the global room, and didn't hit the assert again.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6111162406.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6110589125.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6110537096.zip)
<!--- section:artifacts:end -->