### PR TITLE
Console include cleanup

### DIFF
--- a/soh/soh/Enhancements/debugger/SohConsoleWindow.cpp
+++ b/soh/soh/Enhancements/debugger/SohConsoleWindow.cpp
@@ -3,14 +3,6 @@
 #include "soh/SohGui/UIWidgets.hpp"
 #include "soh/SohGui/SohGui.hpp"
 
-void SohConsoleWindow::InitElement() {
-    ConsoleWindow::InitElement();
-}
-
-void SohConsoleWindow::UpdateElement() {
-    ConsoleWindow::UpdateElement();
-}
-
 void SohConsoleWindow::DrawElement() {
     ImGui::BeginDisabled(CVarGetInteger(CVAR_SETTING("DisableChanges"), 0));
     UIWidgets::PushStyleInput(THEME_COLOR);

--- a/soh/soh/Enhancements/debugger/SohConsoleWindow.h
+++ b/soh/soh/Enhancements/debugger/SohConsoleWindow.h
@@ -9,8 +9,6 @@ class SohConsoleWindow : public Ship::ConsoleWindow {
     using ConsoleWindow::ConsoleWindow;
 
   protected:
-    void InitElement() override;
-    void UpdateElement() override;
     void DrawElement() override;
 };
 

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.h
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <array>
 #include <map>
 #include <string>
 #include <vector>

--- a/soh/soh/SohGui/SohGui.cpp
+++ b/soh/soh/SohGui/SohGui.cpp
@@ -20,14 +20,7 @@
 #include <port/switch/SwitchImpl.h>
 #endif
 #include "include/global.h"
-#include "include/z64audio.h"
-#include "soh/SaveManager.h"
-#include "soh/OTRGlobals.h"
-#include "soh/Enhancements/Presets/Presets.h"
-#include "soh/resource/type/Skeleton.h"
 
-#include "soh/Enhancements/game-interactor/GameInteractor.h"
-#include "soh/Enhancements/cosmetics/authenticGfxPatches.h"
 #include "soh/Enhancements/debugger/MessageViewer.h"
 #include "soh/Notification/Notification.h"
 #include "soh/Enhancements/TimeDisplay/TimeDisplay.h"


### PR DESCRIPTION
Looking into fixing warnings about commands already being bound, LUS initializes a console window which we ignore,
but it registers global command handlers,
SohConsoleWindow does this again, but that's also where mInputBuffer/mFilterBuffer get set

Proper fix would be removing SohConsoleWindow, but it exists to have mono font

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6113953385.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6113651087.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6113597665.zip)
<!--- section:artifacts:end -->