### PR TITLE
Make Infinite Ammo Cheat respect Progressive Bombchu Bag Capacities

### DIFF
--- a/soh/soh/Enhancements/Cheats/Infinite/Ammo.cpp
+++ b/soh/soh/Enhancements/Cheats/Infinite/Ammo.cpp
@@ -1,5 +1,6 @@
 #include <libultraship/bridge.h>
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/OTRGlobals.h"
 #include "soh/ShipInit.hpp"
 #include "z64save.h"
 
@@ -24,7 +25,11 @@ void OnGameFrameUpdateInfiniteAmmo() {
     AMMO(ITEM_BOW) = CUR_CAPACITY(UPG_QUIVER);
     AMMO(ITEM_SLINGSHOT) = CUR_CAPACITY(UPG_BULLET_BAG);
     if (INV_CONTENT(ITEM_BOMBCHU) != ITEM_NONE) {
-        AMMO(ITEM_BOMBCHU) = 50;
+        int chuCapacity = 50;
+        if (IS_RANDO && RAND_GET_OPTION(RSK_BOMBCHU_BAG).Is(RO_BOMBCHU_BAG_PROGRESSIVE)) {
+            chuCapacity = OTRGlobals::Instance->gRandoContext->GetBombchuCapacity();
+        }
+        AMMO(ITEM_BOMBCHU) = chuCapacity;
     }
 }
 

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1,4 +1,5 @@
 #include "debugSaveEditor.h"
+#include "soh/Enhancements/randomizer/randomizerTypes.h"
 #include "soh/util.h"
 #include "soh/SohGui/ImGuiUtils.h"
 #include "soh/OTRGlobals.h"
@@ -1392,6 +1393,39 @@ void DrawEquipmentTab() {
         "40",
     };
     DrawUpgrade("Deku Nut Capacity", UPG_NUTS, nutNames);
+
+    if (IS_RANDO &&
+        OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_BOMBCHU_BAG) == RO_BOMBCHU_BAG_PROGRESSIVE) {
+        const std::vector<std::string> bombchuNames = {
+            "None",
+            "20",
+            "30",
+            "50",
+        };
+        ImGui::Text("%s", "Bombchu Bag Capacity");
+        ImGui::SameLine();
+        ImGui::PushID("Bombchu Bag Capacity");
+        PushStyleCombobox(THEME_COLOR);
+        ImGui::AlignTextToFramePadding();
+        auto value = gSaveContext.ship.quest.data.randomizer.bombchuUpgradeLevel;
+        auto name = value < bombchuNames.size() ? bombchuNames[value].c_str() : "Glitched";
+        if (ImGui::BeginCombo("##upgrade", name)) {
+            for (size_t i = 0; i < bombchuNames.size(); i++) {
+                if (ImGui::Selectable(bombchuNames[i].c_str())) {
+                    gSaveContext.ship.quest.data.randomizer.bombchuUpgradeLevel = i;
+                    if (i > 0) {
+                        INV_CONTENT(ITEM_BOMBCHU) = ITEM_BOMBCHU;
+                    } else {
+                        INV_CONTENT(ITEM_BOMBCHU) = ITEM_NONE;
+                    }
+                }
+            }
+            ImGui::EndCombo();
+        }
+        PopStyleCombobox();
+        ImGui::PopID();
+        UIWidgets::Tooltip("Bombchu Bag Capapcity");
+    }
 }
 
 // Draws a toggleable icon for a quest item that is faded when disabled


### PR DESCRIPTION
When Progressive Bombchu Bags are on for Randomizer, enabling the infinite ammo cheat will set the capacity to 50 no matter what capacity you have unlocked. This PR fixes it to grab the current capacity if Progressive Bombchu Bags are on.  Functionally not much different, but visually looks better because it has the number you would expect and the number also turns green, which I think it wasn't when this was forcing the ammo count to 50.

I also added a bombchuUpgradeLevel combobox to the save editor when Progressive Bombchu Bags are on, because I needed it for quicker testing of this fix.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6155501969.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6155276559.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6155233687.zip)
<!--- section:artifacts:end -->