### PR TITLE
Fix displayed token count

### DIFF
--- a/soh/soh/Enhancements/InjectItemCounts.cpp
+++ b/soh/soh/Enhancements/InjectItemCounts.cpp
@@ -24,7 +24,7 @@ void BuildSkulltulaMessage(uint16_t* textId, bool* loadFromMessageTable) {
         // Auto dismiss textbox after 0x3C (60) frames (about 3 seconds for OoT)
         msg = msg + "\x0E\x3C";
     }
-    int16_t gsCount = gSaveContext.inventory.gsTokens + (IS_RANDO ? 1 : 0);
+    int16_t gsCount = gSaveContext.inventory.gsTokens;
     msg.Replace("[[gsCount]]", std::to_string(gsCount));
     msg.AutoFormat(ITEM_SKULL_TOKEN);
     msg.LoadIntoFont();


### PR DESCRIPTION
I've noticed this when playing standard randos (which have tokensanity off)
Collecting my first token will show a message that I've collected 2 in total

I think this ternary may be leftover from pre-hook behavior.  When tokensanity is on, `BuildSkulltulaMessage` is never called.  gsTokens is correct to begin with in this context.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6158890421.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6158852172.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6158843654.zip)
<!--- section:artifacts:end -->