### PR TITLE
Consolidate ganon2 hooks

### DIFF
--- a/soh/soh/Enhancements/GameplayStats/BossDefeatTimestamps.cpp
+++ b/soh/soh/Enhancements/GameplayStats/BossDefeatTimestamps.cpp
@@ -17,10 +17,10 @@ static void RegisterBossDefeatTimestamps() {
     BOSS_DEFEAT_TIMESTAMP(ACTOR_BOSS_SST, TIMESTAMP_DEFEAT_BONGO_BONGO);
     BOSS_DEFEAT_TIMESTAMP(ACTOR_BOSS_TW, TIMESTAMP_DEFEAT_TWINROVA);
     BOSS_DEFEAT_TIMESTAMP(ACTOR_BOSS_GANON, TIMESTAMP_DEFEAT_GANONDORF);
-    BOSS_DEFEAT_TIMESTAMP(ACTOR_BOSS_GANON2, TIMESTAMP_DEFEAT_GANON);
-
-    COND_ID_HOOK(OnBossDefeat, ACTOR_BOSS_GANON2, true,
-                 [](void* refActor) { gSaveContext.ship.stats.gameComplete = true; });
+    COND_ID_HOOK(OnBossDefeat, ACTOR_BOSS_GANON2, true, [](void* refActor) {
+        gSaveContext.ship.stats.itemTimestamp[TIMESTAMP_DEFEAT_GANON] = GAMEPLAYSTAT_TOTAL_TIME;
+        gSaveContext.ship.stats.gameComplete = true;
+    });
 }
 
 static RegisterShipInitFunc initFunc(RegisterBossDefeatTimestamps);

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -225,6 +225,9 @@ class GameInteractor {
     static GameInteractionEffectQueryResult RemoveEffect(RemovableGameInteractionEffect& effect);
 
     // Game Hooks
+    //
+    // Hooks should be idempotent and execution order is not guaranteed.
+    // If two operations must happen in a specific order, they should be placed in the same hook.
     HOOK_ID nextHookId = 1;
 
     template <typename H> struct RegisteredGameHooks {


### PR DESCRIPTION
Two hooks around ganon2 were dependent on each other, and execution order is not guaranteed, particularly under Linux platforms.
This consolidates them into a single hook.
Started a randomizer with RTA timing enabled and warped to ganon using debug mode to confirm.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6160160266.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6160079513.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6160063419.zip)
<!--- section:artifacts:end -->