### PR TITLE
Alt Toggle for Custom animation

### DIFF
--- a/soh/soh/ResourceManagerHelpers.cpp
+++ b/soh/soh/ResourceManagerHelpers.cpp
@@ -518,33 +518,39 @@ extern "C" int ResourceMgr_OTRSigCheck(char* imgData) {
 }
 
 // Load animation with explicit alt asset path checking.
-// This ensures animations are loaded with the correct alt/ prefix when alt assets are enabled,
-// matching the behavior of skeleton loading and preventing cached vanilla animations from
-// overriding alternate animations when toggling.
+// When Alt Assets is OFF: use original path directly (O2R or vanilla)
+// When Alt Assets is ON: try alt/ prefix first, fall back to regular path if not found
 extern "C" AnimationHeaderCommon* ResourceMgr_LoadAnimByName(const char* path) {
-    std::string pathStr = std::string(path);
-    static const std::string sOtr = "__OTR__";
-
-    // Strip the OTR signature prefix if present
-    if (pathStr.starts_with(sOtr)) {
-        pathStr = pathStr.substr(sOtr.length());
-    }
-
     bool isAlt = ResourceMgr_IsAltAssetsEnabled();
 
-    // Explicitly add alt prefix when alternate assets are enabled
     if (isAlt) {
+        std::string pathStr = std::string(path);
+        static const std::string sOtr = "__OTR__";
+
+        if (pathStr.starts_with(sOtr)) {
+            pathStr = pathStr.substr(sOtr.length());
+        }
+
+        // Try alt/ first
         pathStr = Ship::IResource::gAltAssetPrefix + pathStr;
+        AnimationHeaderCommon* animHeader = (AnimationHeaderCommon*)ResourceGetDataByName(pathStr.c_str());
+
+        // If alt loaded successfully and has valid frame data, return it
+        if (animHeader != NULL) {
+            // Check if it's a Link animation and has valid segment data
+            LinkAnimationHeader* linkAnim = (LinkAnimationHeader*)animHeader;
+            if (linkAnim->segment != NULL) {
+                return animHeader;
+            }
+            // Alt loaded but segment is null (broken), fall through to original path
+        }
+
+        // Fall back to original path
+        return (AnimationHeaderCommon*)ResourceGetDataByName(path);
     }
 
-    AnimationHeaderCommon* animHeader = (AnimationHeaderCommon*)ResourceGetDataByName(pathStr.c_str());
-
-    // If there isn't an alternate animation, fall back to the regular one
-    if (isAlt && animHeader == NULL) {
-        animHeader = (AnimationHeaderCommon*)ResourceGetDataByName(path);
-    }
-
-    return animHeader;
+    // Alt OFF: use original path directly
+    return (AnimationHeaderCommon*)ResourceGetDataByName(path);
 }
 
 extern "C" SkeletonHeader* ResourceMgr_LoadSkeletonByName(const char* path, SkelAnime* skelAnime) {

--- a/soh/soh/ResourceManagerHelpers.cpp
+++ b/soh/soh/ResourceManagerHelpers.cpp
@@ -517,8 +517,34 @@ extern "C" int ResourceMgr_OTRSigCheck(char* imgData) {
     return 0;
 }
 
+// Load animation with explicit alt asset path checking.
+// This ensures animations are loaded with the correct alt/ prefix when alt assets are enabled,
+// matching the behavior of skeleton loading and preventing cached vanilla animations from
+// overriding alternate animations when toggling.
 extern "C" AnimationHeaderCommon* ResourceMgr_LoadAnimByName(const char* path) {
-    return (AnimationHeaderCommon*)ResourceGetDataByName(path);
+    std::string pathStr = std::string(path);
+    static const std::string sOtr = "__OTR__";
+
+    // Strip the OTR signature prefix if present
+    if (pathStr.starts_with(sOtr)) {
+        pathStr = pathStr.substr(sOtr.length());
+    }
+
+    bool isAlt = ResourceMgr_IsAltAssetsEnabled();
+
+    // Explicitly add alt prefix when alternate assets are enabled
+    if (isAlt) {
+        pathStr = Ship::IResource::gAltAssetPrefix + pathStr;
+    }
+
+    AnimationHeaderCommon* animHeader = (AnimationHeaderCommon*)ResourceGetDataByName(pathStr.c_str());
+
+    // If there isn't an alternate animation, fall back to the regular one
+    if (isAlt && animHeader == NULL) {
+        animHeader = (AnimationHeaderCommon*)ResourceGetDataByName(path);
+    }
+
+    return animHeader;
 }
 
 extern "C" SkeletonHeader* ResourceMgr_LoadSkeletonByName(const char* path, SkelAnime* skelAnime) {

--- a/soh/soh/ResourceManagerHelpers.cpp
+++ b/soh/soh/ResourceManagerHelpers.cpp
@@ -519,7 +519,7 @@ extern "C" int ResourceMgr_OTRSigCheck(char* imgData) {
 
 // Load animation with explicit alt asset path checking.
 // When Alt Assets is OFF: use original path directly (O2R or vanilla)
-// When Alt Assets is ON: try alt/ prefix first, fall back to regular path if not found
+// When Alt Assets is ON: try alt/ prefix first, fall back to regular path if not found or invalid
 extern "C" AnimationHeaderCommon* ResourceMgr_LoadAnimByName(const char* path) {
     bool isAlt = ResourceMgr_IsAltAssetsEnabled();
 
@@ -535,14 +535,22 @@ extern "C" AnimationHeaderCommon* ResourceMgr_LoadAnimByName(const char* path) {
         pathStr = Ship::IResource::gAltAssetPrefix + pathStr;
         AnimationHeaderCommon* animHeader = (AnimationHeaderCommon*)ResourceGetDataByName(pathStr.c_str());
 
-        // If alt loaded successfully and has valid frame data, return it
+        // If alt loaded successfully, verify it has valid data
         if (animHeader != NULL) {
-            // Check if it's a Link animation and has valid segment data
-            LinkAnimationHeader* linkAnim = (LinkAnimationHeader*)animHeader;
-            if (linkAnim->segment != NULL) {
-                return animHeader;
+            // Check for valid frame count (> 0)
+            if (animHeader->frameCount > 0) {
+                // For Normal animations: check frameData (comes after frameCount in AnimationHeader)
+                // For Link animations: check segment (comes after frameCount in LinkAnimationHeader)
+                // We check both to be safe - if either is valid, the animation is usable
+                AnimationHeader* normalAnim = (AnimationHeader*)animHeader;
+                LinkAnimationHeader* linkAnim = (LinkAnimationHeader*)animHeader;
+
+                // Valid if Normal animation has frameData OR Link animation has segment
+                if (normalAnim->frameData != NULL || linkAnim->segment != NULL) {
+                    return animHeader;
+                }
             }
-            // Alt loaded but segment is null (broken), fall through to original path
+            // Alt loaded but is invalid (broken), fall through to original path
         }
 
         // Fall back to original path

--- a/soh/soh/resource/importer/AnimationFactory.cpp
+++ b/soh/soh/resource/importer/AnimationFactory.cpp
@@ -78,15 +78,33 @@ ResourceFactoryBinaryAnimationV0::ReadResource(std::shared_ptr<Ship::File> file,
         }
         animation->animationData.transformUpdateIndex.copyValues = animation->copyValuesArr.data();
     } else if (animType == AnimationType::Link) {
+        // Initialize segment to nullptr (important for alt asset fallback)
+        animation->animationData.linkAnimationHeader.segment = nullptr;
+
         // Read the frame count
         animation->animationData.linkAnimationHeader.common.frameCount = reader->ReadInt16();
 
         // Read the segment pointer (always 32 bit, doesn't adjust for system pointer size)
         std::string path = reader->ReadString();
-        const auto animData = std::static_pointer_cast<Animation>(
+        auto animData = std::static_pointer_cast<Animation>(
             Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(path.c_str()));
 
-        animation->animationData.linkAnimationHeader.segment = animData->GetPointer();
+        // If direct load failed and alt assets are enabled, try with alt/ prefix
+        if (animData == nullptr && Ship::Context::GetInstance()->GetResourceManager()->IsAltAssetsEnabled()) {
+            std::string altPath = path;
+            if (altPath.find("__OTR__") == 0) {
+                altPath = altPath.substr(7); // Strip __OTR__
+            }
+            altPath = "alt/" + altPath;
+            animData = std::static_pointer_cast<Animation>(
+                Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(altPath.c_str()));
+        }
+
+        if (animData != nullptr) {
+            animation->animationData.linkAnimationHeader.segment = animData->GetPointer();
+        } else {
+            SPDLOG_WARN("Animation data segment not found: {}", path);
+        }
     } else if (animType == AnimationType::Legacy) {
         SPDLOG_DEBUG("BEYTAH ANIMATION?!");
     }

--- a/soh/src/code/z_skelanime.c
+++ b/soh/src/code/z_skelanime.c
@@ -902,6 +902,10 @@ void AnimationContext_SetLoadFrame(PlayState* play, LinkAnimationHeader* animati
         if (frame < 0) {
             frame = 0;
         }
+        // SOH [Alt Assets] Check if animData is null (can happen if animation data segment failed to load)
+        if (animData == NULL) {
+            return;
+        }
         memcpy(ram, (uintptr_t)animData + (((sizeof(Vec3s) * limbCount + 2) * frame)), sizeof(Vec3s) * limbCount + 2);
     }
 }


### PR DESCRIPTION
Makes ResourceMgr_LoadAnimByName alt-toggleable this will work for Link and any other animations files

- [x] Has been tested with custom animation (obviously)
- [x] Has been tested with custom models
- [x] Has been tested to have the custom animation played with the mods enabled or not like any other kind of mods if there is no alt folder

### Auto Alt appending in your O2R for modders
For modders like Peyton or Fado or anyone that would shout in fear of needing to remake all their O2R with an alt/ path, fear not, I even thought about you guys until I provides better tooling: [https://github.com/PurpleHato/O2R-Alt-Appender/releases/tag/v1.0](https://github.com/PurpleHato/O2R-Alt-Appender/releases/)




<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6161256806.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6161221049.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6161211522.zip)
<!--- section:artifacts:end -->