### PR TITLE
Make item category adjustments more consistent

### DIFF
--- a/soh/soh/Enhancements/randomizer/ShuffleCrates.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleCrates.cpp
@@ -4,6 +4,7 @@
 #include <libultraship/libultra.h>
 #include "global.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
+#include "item_category_adj.h"
 
 extern "C" {
 #include "variables.h"
@@ -35,24 +36,7 @@ extern "C" void ObjKibako2_RandomizerDraw(Actor* thisx, PlayState* play) {
 
     GetItemEntry crateItem =
         Rando::Context::GetInstance()->GetFinalGIEntry(crateIdentity->randomizerCheck, true, GI_NONE);
-    getItemCategory = crateItem.getItemCategory;
-
-    // If they have bombchus, don't consider the bombchu item major
-    if (INV_CONTENT(ITEM_BOMBCHU) == ITEM_BOMBCHU &&
-        ((crateItem.modIndex == MOD_RANDOMIZER && crateItem.getItemId == RG_PROGRESSIVE_BOMBCHU_BAG) ||
-         (crateItem.modIndex == MOD_NONE &&
-          (crateItem.getItemId == GI_BOMBCHUS_5 || crateItem.getItemId == GI_BOMBCHUS_10 ||
-           crateItem.getItemId == GI_BOMBCHUS_20)))) {
-        getItemCategory = ITEM_CATEGORY_JUNK;
-        // If it's a bottle and they already have one, consider the item lesser
-    } else if ((crateItem.modIndex == MOD_RANDOMIZER && crateItem.getItemId >= RG_BOTTLE_WITH_RED_POTION &&
-                crateItem.getItemId <= RG_BOTTLE_WITH_POE) ||
-               (crateItem.modIndex == MOD_NONE &&
-                (crateItem.getItemId == GI_BOTTLE || crateItem.getItemId == GI_MILK_BOTTLE))) {
-        if (gSaveContext.inventory.items[SLOT_BOTTLE_1] != ITEM_NONE) {
-            getItemCategory = ITEM_CATEGORY_LESSER;
-        }
-    }
+    getItemCategory = Randomizer_AdjustItemCategory(crateItem);
 
     // Change texture
     switch (getItemCategory) {
@@ -102,24 +86,7 @@ extern "C" void ObjKibako_RandomizerDraw(Actor* thisx, PlayState* play) {
 
     GetItemEntry smallCrateItem =
         Rando::Context::GetInstance()->GetFinalGIEntry(crateIdentity->randomizerCheck, true, GI_NONE);
-    getItemCategory = smallCrateItem.getItemCategory;
-
-    // If they have bombchus, don't consider the bombchu item major
-    if (INV_CONTENT(ITEM_BOMBCHU) == ITEM_BOMBCHU &&
-        ((smallCrateItem.modIndex == MOD_RANDOMIZER && smallCrateItem.getItemId == RG_PROGRESSIVE_BOMBCHU_BAG) ||
-         (smallCrateItem.modIndex == MOD_NONE &&
-          (smallCrateItem.getItemId == GI_BOMBCHUS_5 || smallCrateItem.getItemId == GI_BOMBCHUS_10 ||
-           smallCrateItem.getItemId == GI_BOMBCHUS_20)))) {
-        getItemCategory = ITEM_CATEGORY_JUNK;
-        // If it's a bottle and they already have one, consider the item lesser
-    } else if ((smallCrateItem.modIndex == MOD_RANDOMIZER && smallCrateItem.getItemId >= RG_BOTTLE_WITH_RED_POTION &&
-                smallCrateItem.getItemId <= RG_BOTTLE_WITH_POE) ||
-               (smallCrateItem.modIndex == MOD_NONE &&
-                (smallCrateItem.getItemId == GI_BOTTLE || smallCrateItem.getItemId == GI_MILK_BOTTLE))) {
-        if (gSaveContext.inventory.items[SLOT_BOTTLE_1] != ITEM_NONE) {
-            getItemCategory = ITEM_CATEGORY_LESSER;
-        }
-    }
+    getItemCategory = Randomizer_AdjustItemCategory(smallCrateItem);
 
     // Change texture
     switch (getItemCategory) {

--- a/soh/soh/Enhancements/randomizer/ShuffleGrass.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleGrass.cpp
@@ -1,6 +1,7 @@
 #include <soh/OTRGlobals.h>
 #include "soh_assets.h"
 #include "static_data.h"
+#include "item_category_adj.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
 
 extern "C" {
@@ -38,7 +39,7 @@ extern "C" void EnKusa_RandomizerDraw(Actor* thisx, PlayState* play) {
         if (csmc && (!requiresStoneAgony || (requiresStoneAgony && CHECK_QUEST_ITEM(QUEST_STONE_OF_AGONY)))) {
             auto itemEntry =
                 Rando::Context::GetInstance()->GetFinalGIEntry(grassIdentity->randomizerCheck, true, GI_NONE);
-            GetItemCategory getItemCategory = itemEntry.getItemCategory;
+            GetItemCategory getItemCategory = Randomizer_AdjustItemCategory(itemEntry);
 
             switch (getItemCategory) {
                 case ITEM_CATEGORY_JUNK:

--- a/soh/soh/Enhancements/randomizer/ShufflePots.cpp
+++ b/soh/soh/Enhancements/randomizer/ShufflePots.cpp
@@ -1,6 +1,7 @@
 #include "soh/OTRGlobals.h"
 #include "soh_assets.h"
 #include "static_data.h"
+#include "item_category_adj.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
 
 extern "C" {
@@ -28,7 +29,7 @@ extern "C" void ObjTsubo_RandomizerDraw(Actor* thisx, PlayState* play) {
         if (csmc && (!requiresStoneAgony || (requiresStoneAgony && CHECK_QUEST_ITEM(QUEST_STONE_OF_AGONY)))) {
             auto itemEntry =
                 Rando::Context::GetInstance()->GetFinalGIEntry(potIdentity->randomizerCheck, true, GI_NONE);
-            GetItemCategory getItemCategory = itemEntry.getItemCategory;
+            GetItemCategory getItemCategory = Randomizer_AdjustItemCategory(itemEntry);
 
             switch (getItemCategory) {
                 case ITEM_CATEGORY_LESSER:

--- a/soh/soh/Enhancements/randomizer/ShuffleTrees.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleTrees.cpp
@@ -2,6 +2,7 @@
 #include "soh_assets.h"
 #include "static_data.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
+#include "item_category_adj.h"
 
 extern "C" {
 #include "variables.h"
@@ -60,24 +61,7 @@ extern "C" void EnWood02_RandomizerDraw(Actor* thisx, PlayState* play) {
         getItemCategory = ITEM_CATEGORY_JUNK;
     } else {
         treeItem = Rando::Context::GetInstance()->GetFinalGIEntry(treeIdentity->randomizerCheck, true, GI_NONE);
-        getItemCategory = treeItem.getItemCategory;
-
-        // If they have bombchus, don't consider the bombchu item major
-        if (INV_CONTENT(ITEM_BOMBCHU) == ITEM_BOMBCHU &&
-            ((treeItem.modIndex == MOD_RANDOMIZER && treeItem.getItemId == RG_PROGRESSIVE_BOMBCHU_BAG) ||
-             (treeItem.modIndex == MOD_NONE &&
-              (treeItem.getItemId == GI_BOMBCHUS_5 || treeItem.getItemId == GI_BOMBCHUS_10 ||
-               treeItem.getItemId == GI_BOMBCHUS_20)))) {
-            getItemCategory = ITEM_CATEGORY_JUNK;
-            // If it's a bottle and they already have one, consider the item lesser
-        } else if ((treeItem.modIndex == MOD_RANDOMIZER && treeItem.getItemId >= RG_BOTTLE_WITH_RED_POTION &&
-                    treeItem.getItemId <= RG_BOTTLE_WITH_POE) ||
-                   (treeItem.modIndex == MOD_NONE &&
-                    (treeItem.getItemId == GI_BOTTLE || treeItem.getItemId == GI_MILK_BOTTLE))) {
-            if (gSaveContext.inventory.items[SLOT_BOTTLE_1] != ITEM_NONE) {
-                getItemCategory = ITEM_CATEGORY_LESSER;
-            }
-        }
+        getItemCategory = Randomizer_AdjustItemCategory(treeItem);
     }
 
     GraphicsContext* gfxCtx = play->state.gfxCtx;

--- a/soh/soh/Enhancements/randomizer/item_category_adj.cpp
+++ b/soh/soh/Enhancements/randomizer/item_category_adj.cpp
@@ -1,0 +1,28 @@
+#include <stdint.h>
+#include "item_category_adj.h"
+#include "z64item.h"
+#include "variables.h"
+#include "macros.h"
+
+GetItemCategory Randomizer_AdjustItemCategory(GetItemEntry item) {
+    GetItemCategory category = item.getItemCategory;
+
+    // Downgrade bombchus to lesser if the player already has bombchus
+    if (INV_CONTENT(ITEM_BOMBCHU) == ITEM_BOMBCHU &&
+        ((item.modIndex == MOD_RANDOMIZER && item.getItemId == RG_PROGRESSIVE_BOMBCHU_BAG) ||
+         (item.modIndex == MOD_NONE &&
+          (item.getItemId == GI_BOMBCHUS_5 || item.getItemId == GI_BOMBCHUS_10 || item.getItemId == GI_BOMBCHUS_20)))) {
+        category = ITEM_CATEGORY_LESSER;
+    }
+
+    // Downgrade bottles to lesser if the player already has a bottle
+    if ((item.modIndex == MOD_RANDOMIZER && item.getItemId >= RG_BOTTLE_WITH_RED_POTION &&
+         item.getItemId <= RG_BOTTLE_WITH_POE) ||
+        (item.modIndex == MOD_NONE && (item.getItemId == GI_BOTTLE || item.getItemId == GI_MILK_BOTTLE))) {
+        if (gSaveContext.inventory.items[SLOT_BOTTLE_1] != ITEM_NONE) {
+            category = ITEM_CATEGORY_LESSER;
+        }
+    }
+
+    return category;
+}

--- a/soh/soh/Enhancements/randomizer/item_category_adj.h
+++ b/soh/soh/Enhancements/randomizer/item_category_adj.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#ifndef ITEM_CATEGORY_ADJ_H
+#define ITEM_CATEGORY_ADJ_H
+
+#include "../item-tables/ItemTableTypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+GetItemCategory Randomizer_AdjustItemCategory(GetItemEntry item);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/soh/src/overlays/actors/ovl_En_Box/z_en_box.c
+++ b/soh/src/overlays/actors/ovl_En_Box/z_en_box.c
@@ -5,6 +5,7 @@
 #include "soh/OTRGlobals.h"
 #include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/Enhancements/randomizer/item_category_adj.h"
 
 #define FLAGS 0
 
@@ -580,21 +581,7 @@ void EnBox_UpdateTexture(EnBox* this, PlayState* play) {
                      this->dyna.actor.room != 6); // Exclude treasure game chests except for the final room
 
     if (!isVanilla) {
-        getItemCategory = chestItem.getItemCategory;
-        // If they have bombchus, don't consider the bombchu item major
-        if ((INV_CONTENT(ITEM_BOMBCHU) == ITEM_BOMBCHU &&
-             ((chestItem.modIndex == MOD_RANDOMIZER && chestItem.getItemId == RG_PROGRESSIVE_BOMBCHU_BAG) ||
-              (chestItem.modIndex == MOD_NONE &&
-               (chestItem.getItemId == GI_BOMBCHUS_5 || chestItem.getItemId == GI_BOMBCHUS_10 ||
-                chestItem.getItemId == GI_BOMBCHUS_20)))) ||
-            // If it's a bottle and they already have one, consider the item lesser
-            ((chestItem.modIndex == MOD_RANDOMIZER && chestItem.getItemId >= RG_BOTTLE_WITH_RED_POTION &&
-              chestItem.getItemId <= RG_BOTTLE_WITH_POE) ||
-             (chestItem.modIndex == MOD_NONE &&
-              (chestItem.getItemId == GI_BOTTLE || chestItem.getItemId == GI_MILK_BOTTLE)) &&
-                 gSaveContext.inventory.items[SLOT_BOTTLE_1] != ITEM_NONE)) {
-            getItemCategory = ITEM_CATEGORY_LESSER;
-        }
+        getItemCategory = Randomizer_AdjustItemCategory(chestItem);
     }
 
     switch (this->type) {


### PR DESCRIPTION
A few things here to make item categorization more consistent
- Created a helper file to contain item category changing logic (used in box, crate, tree)
- Bombchus after bag now show as lesser (was lesser for box, junk for crate and tree)
- Bottles are now consistent too.  Boxes in randomizer would always downgrade to lesser regardless of inventory
- Applies to grass and pots now too

Had some trouble finding a good place to keep this logic consolidated.  Open to feedback or better locations.
Tested both box and crate paths with simple plandomizers.  Works as intended.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6162281401.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6162209487.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6162208629.zip)
<!--- section:artifacts:end -->