### PR TITLE
Fix market sneak hook

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/MarketSneak.cpp
+++ b/soh/soh/Enhancements/TimeSavers/MarketSneak.cpp
@@ -2,11 +2,17 @@
 
 extern "C" {
 #include <variables.h>
+extern PlayState* gPlayState;
 }
 
 // RANDOTODO: Port the rest of the behavior for this enhancement here.
 
 void BuildNightGuardMessage(uint16_t* textId, bool* loadFromMessageTable) {
+    // Other guards should not have their text overridden
+    if (gPlayState->sceneNum != SCENE_MARKET_ENTRANCE_NIGHT) {
+        return;
+    }
+
     CustomMessage msg = CustomMessage("You look bored. Wanna go out for a walk?\x1B%gYes&No%w",
                                       "Du siehst gelangweilt aus. Willst Du einen Spaziergang machen?\x1B%gJa&Nein%w",
                                       "Tu as l'air de t'ennuyer. Tu veux aller faire un tour?\x1B%gOui&Non%w");


### PR DESCRIPTION
References #6426 

Root cause seems to be that we were not checking the scene in this hook.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6166432080.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6166379958.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6166371880.zip)
<!--- section:artifacts:end -->