### PR TITLE
Bean guy text formatting and rando fixes

### DIFF
--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -1357,6 +1357,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*EnMs`
+    VB_MAGIC_BEAN_SALESMAN_TAKE_MONEY,
+
+    // #### `result`
+    // ```c
     // CHECK_QUEST_ITEM(QUEST_SONG_EPONA)
     // ```
     // #### `args`

--- a/soh/soh/Enhancements/randomizer/Messages/MerchantMessages.cpp
+++ b/soh/soh/Enhancements/randomizer/Messages/MerchantMessages.cpp
@@ -49,9 +49,9 @@ void BuildBeanGuyMessage(uint16_t* textId, bool* loadFromMessageTable) {
             "I never thought I'd say this, but I'm selling the last %rMagic Bean%w.^%y99 Rupees%w, no "
             "less.\x1B%gYes&No%w",
             "Ich hätte nie gedacht, daß ich das sage, aber ich verkaufe die letzte^%rWundererbse%w für %y99 "
-            "Rubine%w.\x1B&%gJa&Nein%w",
-            "Je te vends mon dernier %rHaricot&magique%g pour %y99 Rubis%w.\x1B&%gAcheterNe pas acheter%w");
-        msg.Format();
+            "Rubine%w.\x1B%gJa&Nein%w",
+            "Je te vends mon dernier %rHaricot&magique%w pour %y99 Rubis%w.\x1B%gAcheter&Ne pas acheter%w");
+        msg.AutoFormat();
     } else if (*textId == TEXT_BEAN_SALESMAN_BUY_FOR_10) {
         msg = CustomMessage("Want to buy [[color]][[1]]%w for %y[[2]] Rupees%w?\x1B%gYes&No%w",
                             "Möchten Sie [[color]][[1]]%w für %y[[2]] Rubin%w kaufen?\x1B%gJa&Nein%w",

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -980,6 +980,15 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
                           OTRGlobals::Instance->gRandoContext->GetItemLocation(RC_ZR_MAGIC_BEAN_SALESMAN)->GetPrice();
             } else if (RAND_GET_OPTION(RSK_SKIP_PLANTING_BEANS)) {
                 *should = gSaveContext.rupees >= 60;
+            } else if (BEANS_BOUGHT == 9) {
+                *should = gSaveContext.rupees >= 99;
+            }
+            break;
+        }
+        case VB_MAGIC_BEAN_SALESMAN_TAKE_MONEY: {
+            if (BEANS_BOUGHT == 9) {
+                Rupees_ChangeBy(-99);
+                *should = false;
             }
             break;
         }

--- a/soh/src/overlays/actors/ovl_En_Ms/z_en_ms.c
+++ b/soh/src/overlays/actors/ovl_En_Ms/z_en_ms.c
@@ -150,7 +150,9 @@ void EnMs_Talk(EnMs* this, PlayState* play) {
 
 void EnMs_Sell(EnMs* this, PlayState* play) {
     if (Actor_HasParent(&this->actor, play)) {
-        Rupees_ChangeBy(-sPrices[BEANS_BOUGHT]);
+        if (GameInteractor_Should(VB_MAGIC_BEAN_SALESMAN_TAKE_MONEY, true, this)) {
+            Rupees_ChangeBy(-sPrices[BEANS_BOUGHT]);
+        }
         this->actor.parent = NULL;
         this->actionFunc = EnMs_TalkAfterPurchase;
     } else {


### PR DESCRIPTION
Fixes what appear to be a few regressions around bean guy with hooks and modifications to vanilla behavior.

- Message was using `.Format` instead of `.AutoFormat`.  This appears to have been the only occurrence.  In English this resulted in the first textbox not wrapping, and the second only having No as a option that can be selected.
- Checked German and French and found some formatting issues with French.
- Hook didn't exist for taking money for the final bean.  Text would say 99 but expect 100 in the eligibility check.  Used what I think is the correct pattern for `GameInteractor_Should`

I've never bought so many beans in my life.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6168779771.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6168777058.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6168772600.zip)
<!--- section:artifacts:end -->