### PR TITLE
Don't hide Ganon's Boss Key Chest location while Triforce Hunt enabled

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_check_objects.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_objects.cpp
@@ -234,7 +234,8 @@ void RandomizerCheckObjects::UpdateImGuiVisibility() {
                  RO_DUNGEON_ITEM_LOC_VANILLA) &&
             (location.GetRCType() != RCTYPE_GANON_BOSS_KEY ||
              CVarGetInteger(CVAR_RANDOMIZER_SETTING("ShuffleGanonBossKey"), RO_GANON_BOSS_KEY_VANILLA) !=
-                 RO_GANON_BOSS_KEY_VANILLA) && // vanilla ganon boss key
+                 RO_GANON_BOSS_KEY_VANILLA ||
+             CVarGetInteger(CVAR_RANDOMIZER_SETTING("TriforceHunt"), 0)) &&
             (location.GetRandomizerCheck() != RC_TOT_LIGHT_ARROWS_CUTSCENE ||
              (CVarGetInteger(CVAR_RANDOMIZER_SETTING("ShuffleGanonBossKey"), RO_GANON_BOSS_KEY_VANILLA) !=
                   RO_GANON_BOSS_KEY_LACS_DUNGEONS &&


### PR DESCRIPTION
fixes #6437

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6181276939.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6180365703.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6180170674.zip)
<!--- section:artifacts:end -->