### PR TITLE
title card ia8 fix

### DIFF
--- a/soh/assets/xml/GC_MQ_D/objects/object_bv.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1DBB0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1E6B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="ia8" Width="128" Height="120" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x15B18"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x17498"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_fd.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/>
+        <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="ia8" Width="128" Height="120" Offset="0xD700"/>
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x114E0"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_fhg.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xC180"/>
 
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="120" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="ia8" Width="128" Height="120" Offset="0x59A0"/>
 
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xFAA0"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_ganon.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="120" Offset="0xCF00"/>
+        <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="ia8" Width="128" Height="120" Offset="0xCF00"/>
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0x11348"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/GC_MQ_D/objects/object_goma.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="120" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="ia8" Width="128" Height="120" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1EC20"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="120" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x1B010"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x1B01C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x1B028"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_mo.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x5520" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x5D20" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="ia8" Width="128" Height="120" Offset="0x1010"/>
 
         <!-- DLists for Morpha's Core -->
         <DList Name="gMorphaCoreMembraneDL" Offset="0x6700"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_sst.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_sst.xml
@@ -18,7 +18,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x1A730" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x1A7B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="ia8" Width="128" Height="120" Offset="0x13D80"/>
 
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/GC_MQ_D/objects/object_tw.xml
+++ b/soh/assets/xml/GC_MQ_D/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="120" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x31D70"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x31D7C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x31D88"/>

--- a/soh/assets/xml/GC_MQ_D/textures/boss_title_cards.xml
+++ b/soh/assets/xml/GC_MQ_D/textures/boss_title_cards.xml
@@ -1,52 +1,52 @@
 <Root>
 	<File Name="object_bv" Segment="6">
-		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1230" />
-		<Texture Name="gBarinadeTitleCardGERTex" OutName="barinade_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2630" />
-		<Texture Name="gBarinadeTitleCardFRATex" OutName="barinade_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x3a30" />
+		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1230" />
+		<Texture Name="gBarinadeTitleCardGERTex" OutName="barinade_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2630" />
+		<Texture Name="gBarinadeTitleCardFRATex" OutName="barinade_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x3a30" />
 	</File>
 	<File Name="object_fd" Segment="6">
-		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xd700" />
-		<Texture Name="gVolvagiaBossTitleCardGERTex" OutName="volvagia_boss_ger_title_card" Format="i8" Width="128" Height="40" Offset="0xeb00" />
-		<Texture Name="gVolvagiaBossTitleCardFRATex" OutName="volvagia_boss_fra_title_card" Format="i8" Width="128" Height="40" Offset="0xff00" />
+		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xd700" />
+		<Texture Name="gVolvagiaBossTitleCardGERTex" OutName="volvagia_boss_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0xeb00" />
+		<Texture Name="gVolvagiaBossTitleCardFRATex" OutName="volvagia_boss_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0xff00" />
 	</File>
 	<File Name="object_fhg" Segment="6">
-		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x59a0" />
-		<Texture Name="gPhantomGanonTitleCardGERTex" OutName="phantom_ganon_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x6da0" />
-		<Texture Name="gPhantomGanonTitleCardFRATex" OutName="phantom_ganon_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x81a0" />
+		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x59a0" />
+		<Texture Name="gPhantomGanonTitleCardGERTex" OutName="phantom_ganon_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x6da0" />
+		<Texture Name="gPhantomGanonTitleCardFRATex" OutName="phantom_ganon_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x81a0" />
 	</File>
 	<File Name="object_ganon" Segment="6">
-		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xcf00" />
-		<Texture Name="gGanondorfTitleCardGERTex" OutName="ganondorf_ger_title_card" Format="i8" Width="128" Height="40" Offset="0xe300" />
-		<Texture Name="gGanondorfTitleCardFRATex" OutName="ganondorf_fra_title_card" Format="i8" Width="128" Height="40" Offset="0xf700" />
+		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xcf00" />
+		<Texture Name="gGanondorfTitleCardGERTex" OutName="ganondorf_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0xe300" />
+		<Texture Name="gGanondorfTitleCardFRATex" OutName="ganondorf_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0xf700" />
 	</File>
 	<File Name="object_ganon2" Segment="6">
-		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x21a90" />
-		<Texture Name="gGanonTitleCardGERTex" OutName="ganon_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x22e90" />
-		<Texture Name="gGanonTitleCardFRATex" OutName="ganon_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x24290" />
+		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x21a90" />
+		<Texture Name="gGanonTitleCardGERTex" OutName="ganon_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x22e90" />
+		<Texture Name="gGanonTitleCardFRATex" OutName="ganon_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x24290" />
 	</File>
 	<File Name="object_goma" Segment="6">
-		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x19ba8" />
-		<Texture Name="gGohmaTitleCardGERTex" OutName="gohma_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x1afa8" />
-		<Texture Name="gGohmaTitleCardFRATex" OutName="gohma_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x1c3a8" />
+		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x19ba8" />
+		<Texture Name="gGohmaTitleCardGERTex" OutName="gohma_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x1afa8" />
+		<Texture Name="gGohmaTitleCardFRATex" OutName="gohma_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x1c3a8" />
 	</File>
 	<File Name="object_kingdodongo" Segment="6">
-		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x17410" />
-		<Texture Name="gKingDodongoTitleCardGERTex" OutName="king_dodongo_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x18810" />
-		<Texture Name="gKingDodongoTitleCardFRATex" OutName="king_dodongo_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x19c10" />
+		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x17410" />
+		<Texture Name="gKingDodongoTitleCardGERTex" OutName="king_dodongo_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x18810" />
+		<Texture Name="gKingDodongoTitleCardFRATex" OutName="king_dodongo_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x19c10" />
 	</File>
 	<File Name="object_mo" Segment="6">
-		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1010" />
-		<Texture Name="gMorphaTitleCardGERTex" OutName="morpha_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2410" />
-		<Texture Name="gMorphaTitleCardFRATex" OutName="morpha_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x3810" />
+		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1010" />
+		<Texture Name="gMorphaTitleCardGERTex" OutName="morpha_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2410" />
+		<Texture Name="gMorphaTitleCardFRATex" OutName="morpha_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x3810" />
 	</File>
 	<File Name="object_sst" Segment="6">
-		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x13d80" />
-		<Texture Name="gBongoTitleCardGERTex" OutName="bongo_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x15180" />
-		<Texture Name="gBongoTitleCardFRATex" OutName="bongo_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x16580" />
+		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x13d80" />
+		<Texture Name="gBongoTitleCardGERTex" OutName="bongo_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x15180" />
+		<Texture Name="gBongoTitleCardFRATex" OutName="bongo_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x16580" />
 	</File>
 	<File Name="object_tw" Segment="6">
-		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2e170" />
-		<Texture Name="gTwinrovaTitleCardGERTex" OutName="twinrova_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2f570" />
-		<Texture Name="gTwinrovaTitleCardFRATex" OutName="twinrova_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x30970" />
+		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2e170" />
+		<Texture Name="gTwinrovaTitleCardGERTex" OutName="twinrova_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2f570" />
+		<Texture Name="gTwinrovaTitleCardFRATex" OutName="twinrova_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x30970" />
 	</File>
 </Root>

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_bv.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1C7B0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1D2B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="80" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="ia8" Width="128" Height="80" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x14718"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16098"/>

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_fd.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="80" Offset="0xD700"/> -->
+        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="ia8" Width="128" Height="80" Offset="0xD700"/> -->
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x100E0"/>

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_fhg.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xAD80"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="80" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="ia8" Width="128" Height="80" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xE6A0"/>

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_ganon.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="80" Offset="0xCF00"/> -->
+        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="ia8" Width="128" Height="80" Offset="0xCF00"/> -->
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0xFF48"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_goma.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="80" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="ia8" Width="128" Height="80" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1D820"/>

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="80" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x19C10"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x19C1C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x19C28"/>

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_mo.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x4120" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x4920" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="80" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="ia8" Width="128" Height="80" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x7470"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_sst.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x19330" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x193B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="80" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="ia8" Width="128" Height="80" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/GC_MQ_NTSC_J/objects/object_tw.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="80" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x30970"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x3097C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x30988"/>

--- a/soh/assets/xml/GC_MQ_NTSC_J/textures/boss_title_cards.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_J/textures/boss_title_cards.xml
@@ -1,42 +1,42 @@
 <Root>
 	<File Name="object_bv" Segment="6">
-		<Texture Name="gBarinadeTitleCardJPNTex" OutName="barinade_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x1230" />
-		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2630" />
+		<Texture Name="gBarinadeTitleCardJPNTex" OutName="barinade_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x1230" />
+		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2630" />
 	</File>
 	<File Name="object_fd" Segment="6">
-		<Texture Name="gVolvagiaBossTitleCardJPNTex" OutName="volvagia_boss_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0xd700" />
-		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xeb00" />
+		<Texture Name="gVolvagiaBossTitleCardJPNTex" OutName="volvagia_boss_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0xd700" />
+		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xeb00" />
 	</File>
 	<File Name="object_fhg" Segment="6">
-		<Texture Name="gPhantomGanonTitleCardJPNTex" OutName="phantom_ganon_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x59a0" />
-		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x6da0" />
+		<Texture Name="gPhantomGanonTitleCardJPNTex" OutName="phantom_ganon_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x59a0" />
+		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x6da0" />
 	</File>
 	<File Name="object_ganon" Segment="6">
-		<Texture Name="gGanondorfTitleCardJPNTex" OutName="ganondorf_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0xcf00" />
-		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xe300" />
+		<Texture Name="gGanondorfTitleCardJPNTex" OutName="ganondorf_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0xcf00" />
+		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xe300" />
 	</File>
 	<File Name="object_ganon2" Segment="6">
-		<Texture Name="gGanonTitleCardJPNTex" OutName="ganon_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x21a90" />
-		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x22e90" />
+		<Texture Name="gGanonTitleCardJPNTex" OutName="ganon_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x21a90" />
+		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x22e90" />
 	</File>
 	<File Name="object_goma" Segment="6">
-		<Texture Name="gGohmaTitleCardJPNTex" OutName="gohma_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x19ba8" />
-		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1afa8" />
+		<Texture Name="gGohmaTitleCardJPNTex" OutName="gohma_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x19ba8" />
+		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1afa8" />
 	</File>
 	<File Name="object_kingdodongo" Segment="6">
-		<Texture Name="gKingDodongoTitleCardJPNTex" OutName="king_dodongo_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x17410" />
-		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x18810" />
+		<Texture Name="gKingDodongoTitleCardJPNTex" OutName="king_dodongo_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x17410" />
+		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x18810" />
 	</File>
 	<File Name="object_mo" Segment="6">
-		<Texture Name="gMorphaTitleCardJPNTex" OutName="morpha_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x1010" />
-		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2410" />
+		<Texture Name="gMorphaTitleCardJPNTex" OutName="morpha_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x1010" />
+		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2410" />
 	</File>
 	<File Name="object_sst" Segment="6">
-		<Texture Name="gBongoTitleCardJPNTex" OutName="bongo_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x13d80" />
-		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x15180" />
+		<Texture Name="gBongoTitleCardJPNTex" OutName="bongo_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x13d80" />
+		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x15180" />
 	</File>
 	<File Name="object_tw" Segment="6">
-		<Texture Name="gTwinrovaTitleCardJPNTex" OutName="twinrova_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x2e170" />
-		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2f570" />
+		<Texture Name="gTwinrovaTitleCardJPNTex" OutName="twinrova_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x2e170" />
+		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2f570" />
 	</File>
 </Root>

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_bv.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1C7B0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1D2B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="80" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="ia8" Width="128" Height="80" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x14718"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16098"/>

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_fd.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="80" Offset="0xD700"/> -->
+        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="ia8" Width="128" Height="80" Offset="0xD700"/> -->
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x100E0"/>

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_fhg.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xAD80"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="80" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="ia8" Width="128" Height="80" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xE6A0"/>

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_ganon.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="80" Offset="0xCF00"/> -->
+        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="ia8" Width="128" Height="80" Offset="0xCF00"/> -->
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0xFF48"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_goma.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="80" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="ia8" Width="128" Height="80" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1D820"/>

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="80" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x19C10"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x19C1C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x19C28"/>

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_mo.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x4120" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x4920" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="80" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="ia8" Width="128" Height="80" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x7470"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_sst.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x19330" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x193B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="80" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="ia8" Width="128" Height="80" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/GC_MQ_NTSC_U/objects/object_tw.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="80" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x30970"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x3097C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x30988"/>

--- a/soh/assets/xml/GC_MQ_NTSC_U/textures/boss_title_cards.xml
+++ b/soh/assets/xml/GC_MQ_NTSC_U/textures/boss_title_cards.xml
@@ -1,42 +1,42 @@
 <Root>
 	<File Name="object_bv" Segment="6">
-		<Texture Name="gBarinadeTitleCardJPNTex" OutName="barinade_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x1230" />
-		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2630" />
+		<Texture Name="gBarinadeTitleCardJPNTex" OutName="barinade_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x1230" />
+		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2630" />
 	</File>
 	<File Name="object_fd" Segment="6">
-		<Texture Name="gVolvagiaBossTitleCardJPNTex" OutName="volvagia_boss_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0xd700" />
-		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xeb00" />
+		<Texture Name="gVolvagiaBossTitleCardJPNTex" OutName="volvagia_boss_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0xd700" />
+		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xeb00" />
 	</File>
 	<File Name="object_fhg" Segment="6">
-		<Texture Name="gPhantomGanonTitleCardJPNTex" OutName="phantom_ganon_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x59a0" />
-		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x6da0" />
+		<Texture Name="gPhantomGanonTitleCardJPNTex" OutName="phantom_ganon_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x59a0" />
+		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x6da0" />
 	</File>
 	<File Name="object_ganon" Segment="6">
-		<Texture Name="gGanondorfTitleCardJPNTex" OutName="ganondorf_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0xcf00" />
-		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xe300" />
+		<Texture Name="gGanondorfTitleCardJPNTex" OutName="ganondorf_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0xcf00" />
+		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xe300" />
 	</File>
 	<File Name="object_ganon2" Segment="6">
-		<Texture Name="gGanonTitleCardJPNTex" OutName="ganon_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x21a90" />
-		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x22e90" />
+		<Texture Name="gGanonTitleCardJPNTex" OutName="ganon_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x21a90" />
+		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x22e90" />
 	</File>
 	<File Name="object_goma" Segment="6">
-		<Texture Name="gGohmaTitleCardJPNTex" OutName="gohma_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x19ba8" />
-		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1afa8" />
+		<Texture Name="gGohmaTitleCardJPNTex" OutName="gohma_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x19ba8" />
+		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1afa8" />
 	</File>
 	<File Name="object_kingdodongo" Segment="6">
-		<Texture Name="gKingDodongoTitleCardJPNTex" OutName="king_dodongo_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x17410" />
-		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x18810" />
+		<Texture Name="gKingDodongoTitleCardJPNTex" OutName="king_dodongo_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x17410" />
+		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x18810" />
 	</File>
 	<File Name="object_mo" Segment="6">
-		<Texture Name="gMorphaTitleCardJPNTex" OutName="morpha_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x1010" />
-		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2410" />
+		<Texture Name="gMorphaTitleCardJPNTex" OutName="morpha_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x1010" />
+		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2410" />
 	</File>
 	<File Name="object_sst" Segment="6">
-		<Texture Name="gBongoTitleCardJPNTex" OutName="bongo_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x13d80" />
-		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x15180" />
+		<Texture Name="gBongoTitleCardJPNTex" OutName="bongo_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x13d80" />
+		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x15180" />
 	</File>
 	<File Name="object_tw" Segment="6">
-		<Texture Name="gTwinrovaTitleCardJPNTex" OutName="twinrova_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x2e170" />
-		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2f570" />
+		<Texture Name="gTwinrovaTitleCardJPNTex" OutName="twinrova_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x2e170" />
+		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2f570" />
 	</File>
 </Root>

--- a/soh/assets/xml/GC_MQ_PAL_F/objects/object_bv.xml
+++ b/soh/assets/xml/GC_MQ_PAL_F/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1DBB0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1E6B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="ia8" Width="128" Height="120" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x15B18"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x17498"/>

--- a/soh/assets/xml/GC_MQ_PAL_F/objects/object_fd.xml
+++ b/soh/assets/xml/GC_MQ_PAL_F/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/>
+        <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="ia8" Width="128" Height="120" Offset="0xD700"/>
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x114E0"/>

--- a/soh/assets/xml/GC_MQ_PAL_F/objects/object_fhg.xml
+++ b/soh/assets/xml/GC_MQ_PAL_F/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xC180"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="120" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="ia8" Width="128" Height="120" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xFAA0"/>

--- a/soh/assets/xml/GC_MQ_PAL_F/objects/object_ganon.xml
+++ b/soh/assets/xml/GC_MQ_PAL_F/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="120" Offset="0xCF00"/>
+        <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="ia8" Width="128" Height="120" Offset="0xCF00"/>
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0x11348"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/GC_MQ_PAL_F/objects/object_goma.xml
+++ b/soh/assets/xml/GC_MQ_PAL_F/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="120" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="ia8" Width="128" Height="120" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1EC20"/>

--- a/soh/assets/xml/GC_MQ_PAL_F/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/GC_MQ_PAL_F/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="120" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x1B010"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x1B01C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x1B028"/>

--- a/soh/assets/xml/GC_MQ_PAL_F/objects/object_mo.xml
+++ b/soh/assets/xml/GC_MQ_PAL_F/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x5520" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x5D20" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="ia8" Width="128" Height="120" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x8870"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/GC_MQ_PAL_F/objects/object_sst.xml
+++ b/soh/assets/xml/GC_MQ_PAL_F/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x1A730" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x1A7B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="ia8" Width="128" Height="120" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/GC_MQ_PAL_F/objects/object_tw.xml
+++ b/soh/assets/xml/GC_MQ_PAL_F/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="120" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x31D70"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x31D7C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x31D88"/>

--- a/soh/assets/xml/GC_MQ_PAL_F/textures/boss_title_cards.xml
+++ b/soh/assets/xml/GC_MQ_PAL_F/textures/boss_title_cards.xml
@@ -1,52 +1,52 @@
 <Root>
 	<File Name="object_bv" Segment="6">
-		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1230" />
-		<Texture Name="gBarinadeTitleCardGERTex" OutName="barinade_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2630" />
-		<Texture Name="gBarinadeTitleCardFRATex" OutName="barinade_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x3a30" />
+		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1230" />
+		<Texture Name="gBarinadeTitleCardGERTex" OutName="barinade_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2630" />
+		<Texture Name="gBarinadeTitleCardFRATex" OutName="barinade_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x3a30" />
 	</File>
 	<File Name="object_fd" Segment="6">
-		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xd700" />
-		<Texture Name="gVolvagiaBossTitleCardGERTex" OutName="volvagia_boss_ger_title_card" Format="i8" Width="128" Height="40" Offset="0xeb00" />
-		<Texture Name="gVolvagiaBossTitleCardFRATex" OutName="volvagia_boss_fra_title_card" Format="i8" Width="128" Height="40" Offset="0xff00" />
+		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xd700" />
+		<Texture Name="gVolvagiaBossTitleCardGERTex" OutName="volvagia_boss_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0xeb00" />
+		<Texture Name="gVolvagiaBossTitleCardFRATex" OutName="volvagia_boss_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0xff00" />
 	</File>
 	<File Name="object_fhg" Segment="6">
-		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x59a0" />
-		<Texture Name="gPhantomGanonTitleCardGERTex" OutName="phantom_ganon_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x6da0" />
-		<Texture Name="gPhantomGanonTitleCardFRATex" OutName="phantom_ganon_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x81a0" />
+		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x59a0" />
+		<Texture Name="gPhantomGanonTitleCardGERTex" OutName="phantom_ganon_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x6da0" />
+		<Texture Name="gPhantomGanonTitleCardFRATex" OutName="phantom_ganon_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x81a0" />
 	</File>
 	<File Name="object_ganon" Segment="6">
-		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xcf00" />
-		<Texture Name="gGanondorfTitleCardGERTex" OutName="ganondorf_ger_title_card" Format="i8" Width="128" Height="40" Offset="0xe300" />
-		<Texture Name="gGanondorfTitleCardFRATex" OutName="ganondorf_fra_title_card" Format="i8" Width="128" Height="40" Offset="0xf700" />
+		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xcf00" />
+		<Texture Name="gGanondorfTitleCardGERTex" OutName="ganondorf_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0xe300" />
+		<Texture Name="gGanondorfTitleCardFRATex" OutName="ganondorf_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0xf700" />
 	</File>
 	<File Name="object_ganon2" Segment="6">
-		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x21a90" />
-		<Texture Name="gGanonTitleCardGERTex" OutName="ganon_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x22e90" />
-		<Texture Name="gGanonTitleCardFRATex" OutName="ganon_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x24290" />
+		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x21a90" />
+		<Texture Name="gGanonTitleCardGERTex" OutName="ganon_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x22e90" />
+		<Texture Name="gGanonTitleCardFRATex" OutName="ganon_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x24290" />
 	</File>
 	<File Name="object_goma" Segment="6">
-		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x19ba8" />
-		<Texture Name="gGohmaTitleCardGERTex" OutName="gohma_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x1afa8" />
-		<Texture Name="gGohmaTitleCardFRATex" OutName="gohma_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x1c3a8" />
+		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x19ba8" />
+		<Texture Name="gGohmaTitleCardGERTex" OutName="gohma_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x1afa8" />
+		<Texture Name="gGohmaTitleCardFRATex" OutName="gohma_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x1c3a8" />
 	</File>
 	<File Name="object_kingdodongo" Segment="6">
-		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x17410" />
-		<Texture Name="gKingDodongoTitleCardGERTex" OutName="king_dodongo_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x18810" />
-		<Texture Name="gKingDodongoTitleCardFRATex" OutName="king_dodongo_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x19c10" />
+		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x17410" />
+		<Texture Name="gKingDodongoTitleCardGERTex" OutName="king_dodongo_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x18810" />
+		<Texture Name="gKingDodongoTitleCardFRATex" OutName="king_dodongo_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x19c10" />
 	</File>
 	<File Name="object_mo" Segment="6">
-		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1010" />
-		<Texture Name="gMorphaTitleCardGERTex" OutName="morpha_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2410" />
-		<Texture Name="gMorphaTitleCardFRATex" OutName="morpha_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x3810" />
+		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1010" />
+		<Texture Name="gMorphaTitleCardGERTex" OutName="morpha_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2410" />
+		<Texture Name="gMorphaTitleCardFRATex" OutName="morpha_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x3810" />
 	</File>
 	<File Name="object_sst" Segment="6">
-		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x13d80" />
-		<Texture Name="gBongoTitleCardGERTex" OutName="bongo_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x15180" />
-		<Texture Name="gBongoTitleCardFRATex" OutName="bongo_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x16580" />
+		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x13d80" />
+		<Texture Name="gBongoTitleCardGERTex" OutName="bongo_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x15180" />
+		<Texture Name="gBongoTitleCardFRATex" OutName="bongo_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x16580" />
 	</File>
 	<File Name="object_tw" Segment="6">
-		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2e170" />
-		<Texture Name="gTwinrovaTitleCardGERTex" OutName="twinrova_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2f570" />
-		<Texture Name="gTwinrovaTitleCardFRATex" OutName="twinrova_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x30970" />
+		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2e170" />
+		<Texture Name="gTwinrovaTitleCardGERTex" OutName="twinrova_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2f570" />
+		<Texture Name="gTwinrovaTitleCardFRATex" OutName="twinrova_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x30970" />
 	</File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_bv.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1DBB0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1E6B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="ia8" Width="128" Height="120" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x15B18"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x17498"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_fd.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/>
+        <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="ia8" Width="128" Height="120" Offset="0xD700"/>
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x114E0"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_fhg.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xC180"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="120" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="ia8" Width="128" Height="120" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xFAA0"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_ganon.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="120" Offset="0xCF00"/>
+        <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="ia8" Width="128" Height="120" Offset="0xCF00"/>
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0x11348"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/GC_NMQ_D/objects/object_goma.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="120" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="ia8" Width="128" Height="120" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1EC20"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="120" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x1B010"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x1B01C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x1B028"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_mo.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x5520" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x5D20" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="ia8" Width="128" Height="120" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x8870"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/GC_NMQ_D/objects/object_sst.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x1A730" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x1A7B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="ia8" Width="128" Height="120" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/GC_NMQ_D/objects/object_tw.xml
+++ b/soh/assets/xml/GC_NMQ_D/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="120" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x31D70"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x31D7C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x31D88"/>

--- a/soh/assets/xml/GC_NMQ_D/textures/boss_title_cards.xml
+++ b/soh/assets/xml/GC_NMQ_D/textures/boss_title_cards.xml
@@ -1,52 +1,52 @@
 <Root>
 	<File Name="object_bv" Segment="6">
-		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1230" />
-		<Texture Name="gBarinadeTitleCardGERTex" OutName="barinade_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2630" />
-		<Texture Name="gBarinadeTitleCardFRATex" OutName="barinade_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x3a30" />
+		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1230" />
+		<Texture Name="gBarinadeTitleCardGERTex" OutName="barinade_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2630" />
+		<Texture Name="gBarinadeTitleCardFRATex" OutName="barinade_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x3a30" />
 	</File>
 	<File Name="object_fd" Segment="6">
-		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xd700" />
-		<Texture Name="gVolvagiaBossTitleCardGERTex" OutName="volvagia_boss_ger_title_card" Format="i8" Width="128" Height="40" Offset="0xeb00" />
-		<Texture Name="gVolvagiaBossTitleCardFRATex" OutName="volvagia_boss_fra_title_card" Format="i8" Width="128" Height="40" Offset="0xff00" />
+		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xd700" />
+		<Texture Name="gVolvagiaBossTitleCardGERTex" OutName="volvagia_boss_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0xeb00" />
+		<Texture Name="gVolvagiaBossTitleCardFRATex" OutName="volvagia_boss_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0xff00" />
 	</File>
 	<File Name="object_fhg" Segment="6">
-		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x59a0" />
-		<Texture Name="gPhantomGanonTitleCardGERTex" OutName="phantom_ganon_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x6da0" />
-		<Texture Name="gPhantomGanonTitleCardFRATex" OutName="phantom_ganon_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x81a0" />
+		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x59a0" />
+		<Texture Name="gPhantomGanonTitleCardGERTex" OutName="phantom_ganon_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x6da0" />
+		<Texture Name="gPhantomGanonTitleCardFRATex" OutName="phantom_ganon_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x81a0" />
 	</File>
 	<File Name="object_ganon" Segment="6">
-		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xcf00" />
-		<Texture Name="gGanondorfTitleCardGERTex" OutName="ganondorf_ger_title_card" Format="i8" Width="128" Height="40" Offset="0xe300" />
-		<Texture Name="gGanondorfTitleCardFRATex" OutName="ganondorf_fra_title_card" Format="i8" Width="128" Height="40" Offset="0xf700" />
+		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xcf00" />
+		<Texture Name="gGanondorfTitleCardGERTex" OutName="ganondorf_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0xe300" />
+		<Texture Name="gGanondorfTitleCardFRATex" OutName="ganondorf_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0xf700" />
 	</File>
 	<File Name="object_ganon2" Segment="6">
-		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x21a90" />
-		<Texture Name="gGanonTitleCardGERTex" OutName="ganon_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x22e90" />
-		<Texture Name="gGanonTitleCardFRATex" OutName="ganon_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x24290" />
+		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x21a90" />
+		<Texture Name="gGanonTitleCardGERTex" OutName="ganon_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x22e90" />
+		<Texture Name="gGanonTitleCardFRATex" OutName="ganon_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x24290" />
 	</File>
 	<File Name="object_goma" Segment="6">
-		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x19ba8" />
-		<Texture Name="gGohmaTitleCardGERTex" OutName="gohma_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x1afa8" />
-		<Texture Name="gGohmaTitleCardFRATex" OutName="gohma_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x1c3a8" />
+		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x19ba8" />
+		<Texture Name="gGohmaTitleCardGERTex" OutName="gohma_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x1afa8" />
+		<Texture Name="gGohmaTitleCardFRATex" OutName="gohma_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x1c3a8" />
 	</File>
 	<File Name="object_kingdodongo" Segment="6">
-		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x17410" />
-		<Texture Name="gKingDodongoTitleCardGERTex" OutName="king_dodongo_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x18810" />
-		<Texture Name="gKingDodongoTitleCardFRATex" OutName="king_dodongo_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x19c10" />
+		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x17410" />
+		<Texture Name="gKingDodongoTitleCardGERTex" OutName="king_dodongo_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x18810" />
+		<Texture Name="gKingDodongoTitleCardFRATex" OutName="king_dodongo_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x19c10" />
 	</File>
 	<File Name="object_mo" Segment="6">
-		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1010" />
-		<Texture Name="gMorphaTitleCardGERTex" OutName="morpha_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2410" />
-		<Texture Name="gMorphaTitleCardFRATex" OutName="morpha_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x3810" />
+		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1010" />
+		<Texture Name="gMorphaTitleCardGERTex" OutName="morpha_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2410" />
+		<Texture Name="gMorphaTitleCardFRATex" OutName="morpha_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x3810" />
 	</File>
 	<File Name="object_sst" Segment="6">
-		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x13d80" />
-		<Texture Name="gBongoTitleCardGERTex" OutName="bongo_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x15180" />
-		<Texture Name="gBongoTitleCardFRATex" OutName="bongo_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x16580" />
+		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x13d80" />
+		<Texture Name="gBongoTitleCardGERTex" OutName="bongo_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x15180" />
+		<Texture Name="gBongoTitleCardFRATex" OutName="bongo_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x16580" />
 	</File>
 	<File Name="object_tw" Segment="6">
-		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2e170" />
-		<Texture Name="gTwinrovaTitleCardGERTex" OutName="twinrova_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2f570" />
-		<Texture Name="gTwinrovaTitleCardFRATex" OutName="twinrova_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x30970" />
+		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2e170" />
+		<Texture Name="gTwinrovaTitleCardGERTex" OutName="twinrova_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2f570" />
+		<Texture Name="gTwinrovaTitleCardFRATex" OutName="twinrova_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x30970" />
 	</File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_bv.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1C7B0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1D2B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="80" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="ia8" Width="128" Height="80" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x14718"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16098"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_fd.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="80" Offset="0xD700"/> -->
+        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="ia8" Width="128" Height="80" Offset="0xD700"/> -->
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x100E0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_fhg.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xAD80"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="80" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="ia8" Width="128" Height="80" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xE6A0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_ganon.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="80" Offset="0xCF00"/> -->
+        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="ia8" Width="128" Height="80" Offset="0xCF00"/> -->
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0xFF48"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_goma.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="80" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="ia8" Width="128" Height="80" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1D820"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="80" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x19C10"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x19C1C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x19C28"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_mo.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x4120" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x4920" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="80" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="ia8" Width="128" Height="80" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x7470"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_sst.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x19330" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x193B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="80" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="ia8" Width="128" Height="80" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_tw.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="80" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x30970"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x3097C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x30988"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J/textures/boss_title_cards.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J/textures/boss_title_cards.xml
@@ -1,42 +1,42 @@
 <Root>
 	<File Name="object_bv" Segment="6">
-		<Texture Name="gBarinadeTitleCardJPNTex" OutName="barinade_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x1230" />
-		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2630" />
+		<Texture Name="gBarinadeTitleCardJPNTex" OutName="barinade_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x1230" />
+		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2630" />
 	</File>
 	<File Name="object_fd" Segment="6">
-		<Texture Name="gVolvagiaBossTitleCardJPNTex" OutName="volvagia_boss_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0xd700" />
-		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xeb00" />
+		<Texture Name="gVolvagiaBossTitleCardJPNTex" OutName="volvagia_boss_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0xd700" />
+		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xeb00" />
 	</File>
 	<File Name="object_fhg" Segment="6">
-		<Texture Name="gPhantomGanonTitleCardJPNTex" OutName="phantom_ganon_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x59a0" />
-		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x6da0" />
+		<Texture Name="gPhantomGanonTitleCardJPNTex" OutName="phantom_ganon_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x59a0" />
+		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x6da0" />
 	</File>
 	<File Name="object_ganon" Segment="6">
-		<Texture Name="gGanondorfTitleCardJPNTex" OutName="ganondorf_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0xcf00" />
-		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xe300" />
+		<Texture Name="gGanondorfTitleCardJPNTex" OutName="ganondorf_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0xcf00" />
+		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xe300" />
 	</File>
 	<File Name="object_ganon2" Segment="6">
-		<Texture Name="gGanonTitleCardJPNTex" OutName="ganon_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x21a90" />
-		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x22e90" />
+		<Texture Name="gGanonTitleCardJPNTex" OutName="ganon_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x21a90" />
+		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x22e90" />
 	</File>
 	<File Name="object_goma" Segment="6">
-		<Texture Name="gGohmaTitleCardJPNTex" OutName="gohma_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x19ba8" />
-		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1afa8" />
+		<Texture Name="gGohmaTitleCardJPNTex" OutName="gohma_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x19ba8" />
+		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1afa8" />
 	</File>
 	<File Name="object_kingdodongo" Segment="6">
-		<Texture Name="gKingDodongoTitleCardJPNTex" OutName="king_dodongo_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x17410" />
-		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x18810" />
+		<Texture Name="gKingDodongoTitleCardJPNTex" OutName="king_dodongo_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x17410" />
+		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x18810" />
 	</File>
 	<File Name="object_mo" Segment="6">
-		<Texture Name="gMorphaTitleCardJPNTex" OutName="morpha_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x1010" />
-		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2410" />
+		<Texture Name="gMorphaTitleCardJPNTex" OutName="morpha_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x1010" />
+		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2410" />
 	</File>
 	<File Name="object_sst" Segment="6">
-		<Texture Name="gBongoTitleCardJPNTex" OutName="bongo_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x13d80" />
-		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x15180" />
+		<Texture Name="gBongoTitleCardJPNTex" OutName="bongo_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x13d80" />
+		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x15180" />
 	</File>
 	<File Name="object_tw" Segment="6">
-		<Texture Name="gTwinrovaTitleCardJPNTex" OutName="twinrova_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x2e170" />
-		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2f570" />
+		<Texture Name="gTwinrovaTitleCardJPNTex" OutName="twinrova_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x2e170" />
+		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2f570" />
 	</File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_bv.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1C7B0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1D2B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="80" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="ia8" Width="128" Height="80" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x14718"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16098"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_fd.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="80" Offset="0xD700"/> -->
+        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="ia8" Width="128" Height="80" Offset="0xD700"/> -->
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x100E0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_fhg.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xAD80"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="80" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="ia8" Width="128" Height="80" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xE6A0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_ganon.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="80" Offset="0xCF00"/> -->
+        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="ia8" Width="128" Height="80" Offset="0xCF00"/> -->
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0xFF48"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_goma.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="80" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="ia8" Width="128" Height="80" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1D820"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="80" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x19C10"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x19C1C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x19C28"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_mo.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x4120" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x4920" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="80" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="ia8" Width="128" Height="80" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x7470"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_sst.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x19330" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x193B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="80" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="ia8" Width="128" Height="80" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_tw.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="80" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x30970"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x3097C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x30988"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_J_CE/textures/boss_title_cards.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_J_CE/textures/boss_title_cards.xml
@@ -1,42 +1,42 @@
 <Root>
 	<File Name="object_bv" Segment="6">
-		<Texture Name="gBarinadeTitleCardJPNTex" OutName="barinade_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x1230" />
-		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2630" />
+		<Texture Name="gBarinadeTitleCardJPNTex" OutName="barinade_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x1230" />
+		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2630" />
 	</File>
 	<File Name="object_fd" Segment="6">
-		<Texture Name="gVolvagiaBossTitleCardJPNTex" OutName="volvagia_boss_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0xd700" />
-		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xeb00" />
+		<Texture Name="gVolvagiaBossTitleCardJPNTex" OutName="volvagia_boss_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0xd700" />
+		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xeb00" />
 	</File>
 	<File Name="object_fhg" Segment="6">
-		<Texture Name="gPhantomGanonTitleCardJPNTex" OutName="phantom_ganon_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x59a0" />
-		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x6da0" />
+		<Texture Name="gPhantomGanonTitleCardJPNTex" OutName="phantom_ganon_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x59a0" />
+		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x6da0" />
 	</File>
 	<File Name="object_ganon" Segment="6">
-		<Texture Name="gGanondorfTitleCardJPNTex" OutName="ganondorf_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0xcf00" />
-		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xe300" />
+		<Texture Name="gGanondorfTitleCardJPNTex" OutName="ganondorf_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0xcf00" />
+		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xe300" />
 	</File>
 	<File Name="object_ganon2" Segment="6">
-		<Texture Name="gGanonTitleCardJPNTex" OutName="ganon_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x21a90" />
-		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x22e90" />
+		<Texture Name="gGanonTitleCardJPNTex" OutName="ganon_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x21a90" />
+		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x22e90" />
 	</File>
 	<File Name="object_goma" Segment="6">
-		<Texture Name="gGohmaTitleCardJPNTex" OutName="gohma_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x19ba8" />
-		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1afa8" />
+		<Texture Name="gGohmaTitleCardJPNTex" OutName="gohma_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x19ba8" />
+		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1afa8" />
 	</File>
 	<File Name="object_kingdodongo" Segment="6">
-		<Texture Name="gKingDodongoTitleCardJPNTex" OutName="king_dodongo_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x17410" />
-		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x18810" />
+		<Texture Name="gKingDodongoTitleCardJPNTex" OutName="king_dodongo_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x17410" />
+		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x18810" />
 	</File>
 	<File Name="object_mo" Segment="6">
-		<Texture Name="gMorphaTitleCardJPNTex" OutName="morpha_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x1010" />
-		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2410" />
+		<Texture Name="gMorphaTitleCardJPNTex" OutName="morpha_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x1010" />
+		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2410" />
 	</File>
 	<File Name="object_sst" Segment="6">
-		<Texture Name="gBongoTitleCardJPNTex" OutName="bongo_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x13d80" />
-		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x15180" />
+		<Texture Name="gBongoTitleCardJPNTex" OutName="bongo_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x13d80" />
+		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x15180" />
 	</File>
 	<File Name="object_tw" Segment="6">
-		<Texture Name="gTwinrovaTitleCardJPNTex" OutName="twinrova_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x2e170" />
-		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2f570" />
+		<Texture Name="gTwinrovaTitleCardJPNTex" OutName="twinrova_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x2e170" />
+		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2f570" />
 	</File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_bv.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1C7B0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1D2B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="80" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="ia8" Width="128" Height="80" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x14718"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16098"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_fd.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="80" Offset="0xD700"/> -->
+        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="ia8" Width="128" Height="80" Offset="0xD700"/> -->
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x100E0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_fhg.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xAD80"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="80" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="ia8" Width="128" Height="80" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xE6A0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_ganon.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="80" Offset="0xCF00"/> -->
+        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="ia8" Width="128" Height="80" Offset="0xCF00"/> -->
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0xFF48"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_goma.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="80" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="ia8" Width="128" Height="80" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1D820"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="80" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x19C10"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x19C1C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x19C28"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_mo.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x4120" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x4920" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="80" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="ia8" Width="128" Height="80" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x7470"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_sst.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x19330" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x193B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="80" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="ia8" Width="128" Height="80" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_tw.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="80" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x30970"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x3097C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x30988"/>

--- a/soh/assets/xml/GC_NMQ_NTSC_U/textures/boss_title_cards.xml
+++ b/soh/assets/xml/GC_NMQ_NTSC_U/textures/boss_title_cards.xml
@@ -1,42 +1,42 @@
 <Root>
 	<File Name="object_bv" Segment="6">
-		<Texture Name="gBarinadeTitleCardJPNTex" OutName="barinade_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x1230" />
-		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2630" />
+		<Texture Name="gBarinadeTitleCardJPNTex" OutName="barinade_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x1230" />
+		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2630" />
 	</File>
 	<File Name="object_fd" Segment="6">
-		<Texture Name="gVolvagiaBossTitleCardJPNTex" OutName="volvagia_boss_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0xd700" />
-		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xeb00" />
+		<Texture Name="gVolvagiaBossTitleCardJPNTex" OutName="volvagia_boss_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0xd700" />
+		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xeb00" />
 	</File>
 	<File Name="object_fhg" Segment="6">
-		<Texture Name="gPhantomGanonTitleCardJPNTex" OutName="phantom_ganon_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x59a0" />
-		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x6da0" />
+		<Texture Name="gPhantomGanonTitleCardJPNTex" OutName="phantom_ganon_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x59a0" />
+		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x6da0" />
 	</File>
 	<File Name="object_ganon" Segment="6">
-		<Texture Name="gGanondorfTitleCardJPNTex" OutName="ganondorf_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0xcf00" />
-		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xe300" />
+		<Texture Name="gGanondorfTitleCardJPNTex" OutName="ganondorf_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0xcf00" />
+		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xe300" />
 	</File>
 	<File Name="object_ganon2" Segment="6">
-		<Texture Name="gGanonTitleCardJPNTex" OutName="ganon_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x21a90" />
-		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x22e90" />
+		<Texture Name="gGanonTitleCardJPNTex" OutName="ganon_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x21a90" />
+		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x22e90" />
 	</File>
 	<File Name="object_goma" Segment="6">
-		<Texture Name="gGohmaTitleCardJPNTex" OutName="gohma_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x19ba8" />
-		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1afa8" />
+		<Texture Name="gGohmaTitleCardJPNTex" OutName="gohma_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x19ba8" />
+		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1afa8" />
 	</File>
 	<File Name="object_kingdodongo" Segment="6">
-		<Texture Name="gKingDodongoTitleCardJPNTex" OutName="king_dodongo_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x17410" />
-		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x18810" />
+		<Texture Name="gKingDodongoTitleCardJPNTex" OutName="king_dodongo_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x17410" />
+		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x18810" />
 	</File>
 	<File Name="object_mo" Segment="6">
-		<Texture Name="gMorphaTitleCardJPNTex" OutName="morpha_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x1010" />
-		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2410" />
+		<Texture Name="gMorphaTitleCardJPNTex" OutName="morpha_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x1010" />
+		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2410" />
 	</File>
 	<File Name="object_sst" Segment="6">
-		<Texture Name="gBongoTitleCardJPNTex" OutName="bongo_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x13d80" />
-		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x15180" />
+		<Texture Name="gBongoTitleCardJPNTex" OutName="bongo_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x13d80" />
+		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x15180" />
 	</File>
 	<File Name="object_tw" Segment="6">
-		<Texture Name="gTwinrovaTitleCardJPNTex" OutName="twinrova_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x2e170" />
-		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2f570" />
+		<Texture Name="gTwinrovaTitleCardJPNTex" OutName="twinrova_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x2e170" />
+		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2f570" />
 	</File>
 </Root>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_bv.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1DBB0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1E6B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="ia8" Width="128" Height="120" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x15B18"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x17498"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_fd.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/>
+        <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="ia8" Width="128" Height="120" Offset="0xD700"/>
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x114E0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_fhg.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xC180"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="120" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="ia8" Width="128" Height="120" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xFAA0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_ganon.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="120" Offset="0xCF00"/>
+        <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="ia8" Width="128" Height="120" Offset="0xCF00"/>
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0x11348"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_goma.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="120" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="ia8" Width="128" Height="120" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1EC20"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="120" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x1B010"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x1B01C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x1B028"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_mo.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x5520" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x5D20" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="ia8" Width="128" Height="120" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x8870"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_sst.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x1A730" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x1A7B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="ia8" Width="128" Height="120" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/objects/object_tw.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="120" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x31D70"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x31D7C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x31D88"/>

--- a/soh/assets/xml/GC_NMQ_PAL_F/textures/boss_title_cards.xml
+++ b/soh/assets/xml/GC_NMQ_PAL_F/textures/boss_title_cards.xml
@@ -1,52 +1,52 @@
 <Root>
 	<File Name="object_bv" Segment="6">
-		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1230" />
-		<Texture Name="gBarinadeTitleCardGERTex" OutName="barinade_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2630" />
-		<Texture Name="gBarinadeTitleCardFRATex" OutName="barinade_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x3a30" />
+		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1230" />
+		<Texture Name="gBarinadeTitleCardGERTex" OutName="barinade_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2630" />
+		<Texture Name="gBarinadeTitleCardFRATex" OutName="barinade_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x3a30" />
 	</File>
 	<File Name="object_fd" Segment="6">
-		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xd700" />
-		<Texture Name="gVolvagiaBossTitleCardGERTex" OutName="volvagia_boss_ger_title_card" Format="i8" Width="128" Height="40" Offset="0xeb00" />
-		<Texture Name="gVolvagiaBossTitleCardFRATex" OutName="volvagia_boss_fra_title_card" Format="i8" Width="128" Height="40" Offset="0xff00" />
+		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xd700" />
+		<Texture Name="gVolvagiaBossTitleCardGERTex" OutName="volvagia_boss_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0xeb00" />
+		<Texture Name="gVolvagiaBossTitleCardFRATex" OutName="volvagia_boss_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0xff00" />
 	</File>
 	<File Name="object_fhg" Segment="6">
-		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x59a0" />
-		<Texture Name="gPhantomGanonTitleCardGERTex" OutName="phantom_ganon_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x6da0" />
-		<Texture Name="gPhantomGanonTitleCardFRATex" OutName="phantom_ganon_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x81a0" />
+		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x59a0" />
+		<Texture Name="gPhantomGanonTitleCardGERTex" OutName="phantom_ganon_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x6da0" />
+		<Texture Name="gPhantomGanonTitleCardFRATex" OutName="phantom_ganon_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x81a0" />
 	</File>
 	<File Name="object_ganon" Segment="6">
-		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xcf00" />
-		<Texture Name="gGanondorfTitleCardGERTex" OutName="ganondorf_ger_title_card" Format="i8" Width="128" Height="40" Offset="0xe300" />
-		<Texture Name="gGanondorfTitleCardFRATex" OutName="ganondorf_fra_title_card" Format="i8" Width="128" Height="40" Offset="0xf700" />
+		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xcf00" />
+		<Texture Name="gGanondorfTitleCardGERTex" OutName="ganondorf_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0xe300" />
+		<Texture Name="gGanondorfTitleCardFRATex" OutName="ganondorf_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0xf700" />
 	</File>
 	<File Name="object_ganon2" Segment="6">
-		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x21a90" />
-		<Texture Name="gGanonTitleCardGERTex" OutName="ganon_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x22e90" />
-		<Texture Name="gGanonTitleCardFRATex" OutName="ganon_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x24290" />
+		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x21a90" />
+		<Texture Name="gGanonTitleCardGERTex" OutName="ganon_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x22e90" />
+		<Texture Name="gGanonTitleCardFRATex" OutName="ganon_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x24290" />
 	</File>
 	<File Name="object_goma" Segment="6">
-		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x19ba8" />
-		<Texture Name="gGohmaTitleCardGERTex" OutName="gohma_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x1afa8" />
-		<Texture Name="gGohmaTitleCardFRATex" OutName="gohma_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x1c3a8" />
+		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x19ba8" />
+		<Texture Name="gGohmaTitleCardGERTex" OutName="gohma_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x1afa8" />
+		<Texture Name="gGohmaTitleCardFRATex" OutName="gohma_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x1c3a8" />
 	</File>
 	<File Name="object_kingdodongo" Segment="6">
-		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x17410" />
-		<Texture Name="gKingDodongoTitleCardGERTex" OutName="king_dodongo_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x18810" />
-		<Texture Name="gKingDodongoTitleCardFRATex" OutName="king_dodongo_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x19c10" />
+		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x17410" />
+		<Texture Name="gKingDodongoTitleCardGERTex" OutName="king_dodongo_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x18810" />
+		<Texture Name="gKingDodongoTitleCardFRATex" OutName="king_dodongo_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x19c10" />
 	</File>
 	<File Name="object_mo" Segment="6">
-		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1010" />
-		<Texture Name="gMorphaTitleCardGERTex" OutName="morpha_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2410" />
-		<Texture Name="gMorphaTitleCardFRATex" OutName="morpha_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x3810" />
+		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1010" />
+		<Texture Name="gMorphaTitleCardGERTex" OutName="morpha_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2410" />
+		<Texture Name="gMorphaTitleCardFRATex" OutName="morpha_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x3810" />
 	</File>
 	<File Name="object_sst" Segment="6">
-		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x13d80" />
-		<Texture Name="gBongoTitleCardGERTex" OutName="bongo_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x15180" />
-		<Texture Name="gBongoTitleCardFRATex" OutName="bongo_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x16580" />
+		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x13d80" />
+		<Texture Name="gBongoTitleCardGERTex" OutName="bongo_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x15180" />
+		<Texture Name="gBongoTitleCardFRATex" OutName="bongo_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x16580" />
 	</File>
 	<File Name="object_tw" Segment="6">
-		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2e170" />
-		<Texture Name="gTwinrovaTitleCardGERTex" OutName="twinrova_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2f570" />
-		<Texture Name="gTwinrovaTitleCardFRATex" OutName="twinrova_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x30970" />
+		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2e170" />
+		<Texture Name="gTwinrovaTitleCardGERTex" OutName="twinrova_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2f570" />
+		<Texture Name="gTwinrovaTitleCardFRATex" OutName="twinrova_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x30970" />
 	</File>
 </Root>

--- a/soh/assets/xml/N64_NTSC_10/objects/object_bv.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1C7B0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1D2B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="80" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="ia8" Width="128" Height="80" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x14718"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16098"/>

--- a/soh/assets/xml/N64_NTSC_10/objects/object_fd.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="80" Offset="0xD700"/> -->
+        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="ia8" Width="128" Height="80" Offset="0xD700"/> -->
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x100E0"/>

--- a/soh/assets/xml/N64_NTSC_10/objects/object_fhg.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xAD80"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="80" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="ia8" Width="128" Height="80" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xE6A0"/>

--- a/soh/assets/xml/N64_NTSC_10/objects/object_ganon.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="80" Offset="0xCF00"/> -->
+        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="ia8" Width="128" Height="80" Offset="0xCF00"/> -->
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0xFF48"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/N64_NTSC_10/objects/object_goma.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="80" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="ia8" Width="128" Height="80" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1D820"/>

--- a/soh/assets/xml/N64_NTSC_10/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="80" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x19C10"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x19C1C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x19C28"/>

--- a/soh/assets/xml/N64_NTSC_10/objects/object_mo.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x4120" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x4920" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="80" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="ia8" Width="128" Height="80" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x7470"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/N64_NTSC_10/objects/object_sst.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x19330" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x193B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="80" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="ia8" Width="128" Height="80" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/N64_NTSC_10/objects/object_tw.xml
+++ b/soh/assets/xml/N64_NTSC_10/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="80" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x30970"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x3097C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x30988"/>

--- a/soh/assets/xml/N64_NTSC_10/textures/boss_title_cards.xml
+++ b/soh/assets/xml/N64_NTSC_10/textures/boss_title_cards.xml
@@ -1,42 +1,42 @@
 <Root>
 	<File Name="object_bv" Segment="6">
-		<Texture Name="gBarinadeTitleCardJPNTex" OutName="barinade_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x1230" />
-		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2630" />
+		<Texture Name="gBarinadeTitleCardJPNTex" OutName="barinade_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x1230" />
+		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2630" />
 	</File>
 	<File Name="object_fd" Segment="6">
-		<Texture Name="gVolvagiaBossTitleCardJPNTex" OutName="volvagia_boss_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0xd700" />
-		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xeb00" />
+		<Texture Name="gVolvagiaBossTitleCardJPNTex" OutName="volvagia_boss_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0xd700" />
+		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xeb00" />
 	</File>
 	<File Name="object_fhg" Segment="6">
-		<Texture Name="gPhantomGanonTitleCardJPNTex" OutName="phantom_ganon_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x59a0" />
-		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x6da0" />
+		<Texture Name="gPhantomGanonTitleCardJPNTex" OutName="phantom_ganon_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x59a0" />
+		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x6da0" />
 	</File>
 	<File Name="object_ganon" Segment="6">
-		<Texture Name="gGanondorfTitleCardJPNTex" OutName="ganondorf_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0xcf00" />
-		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xe300" />
+		<Texture Name="gGanondorfTitleCardJPNTex" OutName="ganondorf_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0xcf00" />
+		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xe300" />
 	</File>
 	<File Name="object_ganon2" Segment="6">
-		<Texture Name="gGanonTitleCardJPNTex" OutName="ganon_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x21a90" />
-		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x22e90" />
+		<Texture Name="gGanonTitleCardJPNTex" OutName="ganon_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x21a90" />
+		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x22e90" />
 	</File>
 	<File Name="object_goma" Segment="6">
-		<Texture Name="gGohmaTitleCardJPNTex" OutName="gohma_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x19ba8" />
-		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1afa8" />
+		<Texture Name="gGohmaTitleCardJPNTex" OutName="gohma_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x19ba8" />
+		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1afa8" />
 	</File>
 	<File Name="object_kingdodongo" Segment="6">
-		<Texture Name="gKingDodongoTitleCardJPNTex" OutName="king_dodongo_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x17410" />
-		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x18810" />
+		<Texture Name="gKingDodongoTitleCardJPNTex" OutName="king_dodongo_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x17410" />
+		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x18810" />
 	</File>
 	<File Name="object_mo" Segment="6">
-		<Texture Name="gMorphaTitleCardJPNTex" OutName="morpha_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x1010" />
-		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2410" />
+		<Texture Name="gMorphaTitleCardJPNTex" OutName="morpha_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x1010" />
+		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2410" />
 	</File>
 	<File Name="object_sst" Segment="6">
-		<Texture Name="gBongoTitleCardJPNTex" OutName="bongo_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x13d80" />
-		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x15180" />
+		<Texture Name="gBongoTitleCardJPNTex" OutName="bongo_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x13d80" />
+		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x15180" />
 	</File>
 	<File Name="object_tw" Segment="6">
-		<Texture Name="gTwinrovaTitleCardJPNTex" OutName="twinrova_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x2e170" />
-		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2f570" />
+		<Texture Name="gTwinrovaTitleCardJPNTex" OutName="twinrova_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x2e170" />
+		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2f570" />
 	</File>
 </Root>

--- a/soh/assets/xml/N64_NTSC_11/objects/object_bv.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1C7B0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1D2B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="80" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="ia8" Width="128" Height="80" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x14718"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16098"/>

--- a/soh/assets/xml/N64_NTSC_11/objects/object_fd.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="80" Offset="0xD700"/> -->
+        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="ia8" Width="128" Height="80" Offset="0xD700"/> -->
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x100E0"/>

--- a/soh/assets/xml/N64_NTSC_11/objects/object_fhg.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xAD80"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="80" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="ia8" Width="128" Height="80" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xE6A0"/>

--- a/soh/assets/xml/N64_NTSC_11/objects/object_ganon.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="80" Offset="0xCF00"/> -->
+        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="ia8" Width="128" Height="80" Offset="0xCF00"/> -->
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0xFF48"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/N64_NTSC_11/objects/object_goma.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="80" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="ia8" Width="128" Height="80" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1D820"/>

--- a/soh/assets/xml/N64_NTSC_11/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="80" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x19C10"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x19C1C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x19C28"/>

--- a/soh/assets/xml/N64_NTSC_11/objects/object_mo.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x4120" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x4920" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="80" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="ia8" Width="128" Height="80" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x7470"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/N64_NTSC_11/objects/object_sst.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x19330" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x193B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="80" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="ia8" Width="128" Height="80" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/N64_NTSC_11/objects/object_tw.xml
+++ b/soh/assets/xml/N64_NTSC_11/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="80" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x30970"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x3097C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x30988"/>

--- a/soh/assets/xml/N64_NTSC_11/textures/boss_title_cards.xml
+++ b/soh/assets/xml/N64_NTSC_11/textures/boss_title_cards.xml
@@ -1,42 +1,42 @@
 <Root>
 	<File Name="object_bv" Segment="6">
-		<Texture Name="gBarinadeTitleCardJPNTex" OutName="barinade_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x1230" />
-		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2630" />
+		<Texture Name="gBarinadeTitleCardJPNTex" OutName="barinade_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x1230" />
+		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2630" />
 	</File>
 	<File Name="object_fd" Segment="6">
-		<Texture Name="gVolvagiaBossTitleCardJPNTex" OutName="volvagia_boss_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0xd700" />
-		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xeb00" />
+		<Texture Name="gVolvagiaBossTitleCardJPNTex" OutName="volvagia_boss_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0xd700" />
+		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xeb00" />
 	</File>
 	<File Name="object_fhg" Segment="6">
-		<Texture Name="gPhantomGanonTitleCardJPNTex" OutName="phantom_ganon_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x59a0" />
-		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x6da0" />
+		<Texture Name="gPhantomGanonTitleCardJPNTex" OutName="phantom_ganon_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x59a0" />
+		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x6da0" />
 	</File>
 	<File Name="object_ganon" Segment="6">
-		<Texture Name="gGanondorfTitleCardJPNTex" OutName="ganondorf_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0xcf00" />
-		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xe300" />
+		<Texture Name="gGanondorfTitleCardJPNTex" OutName="ganondorf_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0xcf00" />
+		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xe300" />
 	</File>
 	<File Name="object_ganon2" Segment="6">
-		<Texture Name="gGanonTitleCardJPNTex" OutName="ganon_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x21a90" />
-		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x22e90" />
+		<Texture Name="gGanonTitleCardJPNTex" OutName="ganon_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x21a90" />
+		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x22e90" />
 	</File>
 	<File Name="object_goma" Segment="6">
-		<Texture Name="gGohmaTitleCardJPNTex" OutName="gohma_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x19ba8" />
-		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1afa8" />
+		<Texture Name="gGohmaTitleCardJPNTex" OutName="gohma_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x19ba8" />
+		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1afa8" />
 	</File>
 	<File Name="object_kingdodongo" Segment="6">
-		<Texture Name="gKingDodongoTitleCardJPNTex" OutName="king_dodongo_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x17410" />
-		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x18810" />
+		<Texture Name="gKingDodongoTitleCardJPNTex" OutName="king_dodongo_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x17410" />
+		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x18810" />
 	</File>
 	<File Name="object_mo" Segment="6">
-		<Texture Name="gMorphaTitleCardJPNTex" OutName="morpha_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x1010" />
-		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2410" />
+		<Texture Name="gMorphaTitleCardJPNTex" OutName="morpha_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x1010" />
+		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2410" />
 	</File>
 	<File Name="object_sst" Segment="6">
-		<Texture Name="gBongoTitleCardJPNTex" OutName="bongo_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x13d80" />
-		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x15180" />
+		<Texture Name="gBongoTitleCardJPNTex" OutName="bongo_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x13d80" />
+		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x15180" />
 	</File>
 	<File Name="object_tw" Segment="6">
-		<Texture Name="gTwinrovaTitleCardJPNTex" OutName="twinrova_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x2e170" />
-		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2f570" />
+		<Texture Name="gTwinrovaTitleCardJPNTex" OutName="twinrova_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x2e170" />
+		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2f570" />
 	</File>
 </Root>

--- a/soh/assets/xml/N64_NTSC_12/objects/object_bv.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1C7B0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1D2B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="80" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="ia8" Width="128" Height="80" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x14718"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16098"/>

--- a/soh/assets/xml/N64_NTSC_12/objects/object_fd.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="80" Offset="0xD700"/> -->
+        <!-- <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="ia8" Width="128" Height="80" Offset="0xD700"/> -->
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x100E0"/>

--- a/soh/assets/xml/N64_NTSC_12/objects/object_fhg.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xAD80"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="80" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="ia8" Width="128" Height="80" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xE6A0"/>

--- a/soh/assets/xml/N64_NTSC_12/objects/object_ganon.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="80" Offset="0xCF00"/> -->
+        <!-- <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="ia8" Width="128" Height="80" Offset="0xCF00"/> -->
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0xFF48"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/N64_NTSC_12/objects/object_goma.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="80" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="ia8" Width="128" Height="80" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1D820"/>

--- a/soh/assets/xml/N64_NTSC_12/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="80" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x19C10"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x19C1C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x19C28"/>

--- a/soh/assets/xml/N64_NTSC_12/objects/object_mo.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x4120" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x4920" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="80" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="ia8" Width="128" Height="80" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x7470"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/N64_NTSC_12/objects/object_sst.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x19330" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x193B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="80" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="ia8" Width="128" Height="80" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/N64_NTSC_12/objects/object_tw.xml
+++ b/soh/assets/xml/N64_NTSC_12/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="80" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="80" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x30970"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x3097C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x30988"/>

--- a/soh/assets/xml/N64_NTSC_12/textures/boss_title_cards.xml
+++ b/soh/assets/xml/N64_NTSC_12/textures/boss_title_cards.xml
@@ -1,42 +1,42 @@
 <Root>
 	<File Name="object_bv" Segment="6">
-		<Texture Name="gBarinadeTitleCardJPNTex" OutName="barinade_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x1230" />
-		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2630" />
+		<Texture Name="gBarinadeTitleCardJPNTex" OutName="barinade_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x1230" />
+		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2630" />
 	</File>
 	<File Name="object_fd" Segment="6">
-		<Texture Name="gVolvagiaBossTitleCardJPNTex" OutName="volvagia_boss_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0xd700" />
-		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xeb00" />
+		<Texture Name="gVolvagiaBossTitleCardJPNTex" OutName="volvagia_boss_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0xd700" />
+		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xeb00" />
 	</File>
 	<File Name="object_fhg" Segment="6">
-		<Texture Name="gPhantomGanonTitleCardJPNTex" OutName="phantom_ganon_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x59a0" />
-		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x6da0" />
+		<Texture Name="gPhantomGanonTitleCardJPNTex" OutName="phantom_ganon_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x59a0" />
+		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x6da0" />
 	</File>
 	<File Name="object_ganon" Segment="6">
-		<Texture Name="gGanondorfTitleCardJPNTex" OutName="ganondorf_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0xcf00" />
-		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xe300" />
+		<Texture Name="gGanondorfTitleCardJPNTex" OutName="ganondorf_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0xcf00" />
+		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xe300" />
 	</File>
 	<File Name="object_ganon2" Segment="6">
-		<Texture Name="gGanonTitleCardJPNTex" OutName="ganon_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x21a90" />
-		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x22e90" />
+		<Texture Name="gGanonTitleCardJPNTex" OutName="ganon_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x21a90" />
+		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x22e90" />
 	</File>
 	<File Name="object_goma" Segment="6">
-		<Texture Name="gGohmaTitleCardJPNTex" OutName="gohma_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x19ba8" />
-		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1afa8" />
+		<Texture Name="gGohmaTitleCardJPNTex" OutName="gohma_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x19ba8" />
+		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1afa8" />
 	</File>
 	<File Name="object_kingdodongo" Segment="6">
-		<Texture Name="gKingDodongoTitleCardJPNTex" OutName="king_dodongo_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x17410" />
-		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x18810" />
+		<Texture Name="gKingDodongoTitleCardJPNTex" OutName="king_dodongo_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x17410" />
+		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x18810" />
 	</File>
 	<File Name="object_mo" Segment="6">
-		<Texture Name="gMorphaTitleCardJPNTex" OutName="morpha_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x1010" />
-		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2410" />
+		<Texture Name="gMorphaTitleCardJPNTex" OutName="morpha_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x1010" />
+		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2410" />
 	</File>
 	<File Name="object_sst" Segment="6">
-		<Texture Name="gBongoTitleCardJPNTex" OutName="bongo_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x13d80" />
-		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x15180" />
+		<Texture Name="gBongoTitleCardJPNTex" OutName="bongo_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x13d80" />
+		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x15180" />
 	</File>
 	<File Name="object_tw" Segment="6">
-		<Texture Name="gTwinrovaTitleCardJPNTex" OutName="twinrova_jpn_title_card" Format="i8" Width="128" Height="40" Offset="0x2e170" />
-		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2f570" />
+		<Texture Name="gTwinrovaTitleCardJPNTex" OutName="twinrova_jpn_title_card" Format="ia8" Width="128" Height="40" Offset="0x2e170" />
+		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2f570" />
 	</File>
 </Root>

--- a/soh/assets/xml/N64_PAL_10/objects/object_bv.xml
+++ b/soh/assets/xml/N64_PAL_10/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1DBB0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1E6B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="ia8" Width="128" Height="120" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x15B18"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x17498"/>

--- a/soh/assets/xml/N64_PAL_10/objects/object_fd.xml
+++ b/soh/assets/xml/N64_PAL_10/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/>
+        <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="ia8" Width="128" Height="120" Offset="0xD700"/>
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x114E0"/>

--- a/soh/assets/xml/N64_PAL_10/objects/object_fhg.xml
+++ b/soh/assets/xml/N64_PAL_10/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xC180"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="120" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="ia8" Width="128" Height="120" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xFAA0"/>

--- a/soh/assets/xml/N64_PAL_10/objects/object_ganon.xml
+++ b/soh/assets/xml/N64_PAL_10/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="120" Offset="0xCF00"/>
+        <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="ia8" Width="128" Height="120" Offset="0xCF00"/>
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0x11348"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/N64_PAL_10/objects/object_goma.xml
+++ b/soh/assets/xml/N64_PAL_10/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="120" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="ia8" Width="128" Height="120" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1EC20"/>

--- a/soh/assets/xml/N64_PAL_10/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/N64_PAL_10/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="120" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x1B010"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x1B01C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x1B028"/>

--- a/soh/assets/xml/N64_PAL_10/objects/object_mo.xml
+++ b/soh/assets/xml/N64_PAL_10/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x5520" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x5D20" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="ia8" Width="128" Height="120" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x8870"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/N64_PAL_10/objects/object_sst.xml
+++ b/soh/assets/xml/N64_PAL_10/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x1A730" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x1A7B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="ia8" Width="128" Height="120" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/N64_PAL_10/objects/object_tw.xml
+++ b/soh/assets/xml/N64_PAL_10/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="120" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x31D70"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x31D7C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x31D88"/>

--- a/soh/assets/xml/N64_PAL_10/textures/boss_title_cards.xml
+++ b/soh/assets/xml/N64_PAL_10/textures/boss_title_cards.xml
@@ -1,52 +1,52 @@
 <Root>
 	<File Name="object_bv" Segment="6">
-		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1230" />
-		<Texture Name="gBarinadeTitleCardGERTex" OutName="barinade_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2630" />
-		<Texture Name="gBarinadeTitleCardFRATex" OutName="barinade_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x3a30" />
+		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1230" />
+		<Texture Name="gBarinadeTitleCardGERTex" OutName="barinade_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2630" />
+		<Texture Name="gBarinadeTitleCardFRATex" OutName="barinade_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x3a30" />
 	</File>
 	<File Name="object_fd" Segment="6">
-		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xd700" />
-		<Texture Name="gVolvagiaBossTitleCardGERTex" OutName="volvagia_boss_ger_title_card" Format="i8" Width="128" Height="40" Offset="0xeb00" />
-		<Texture Name="gVolvagiaBossTitleCardFRATex" OutName="volvagia_boss_fra_title_card" Format="i8" Width="128" Height="40" Offset="0xff00" />
+		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xd700" />
+		<Texture Name="gVolvagiaBossTitleCardGERTex" OutName="volvagia_boss_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0xeb00" />
+		<Texture Name="gVolvagiaBossTitleCardFRATex" OutName="volvagia_boss_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0xff00" />
 	</File>
 	<File Name="object_fhg" Segment="6">
-		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x59a0" />
-		<Texture Name="gPhantomGanonTitleCardGERTex" OutName="phantom_ganon_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x6da0" />
-		<Texture Name="gPhantomGanonTitleCardFRATex" OutName="phantom_ganon_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x81a0" />
+		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x59a0" />
+		<Texture Name="gPhantomGanonTitleCardGERTex" OutName="phantom_ganon_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x6da0" />
+		<Texture Name="gPhantomGanonTitleCardFRATex" OutName="phantom_ganon_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x81a0" />
 	</File>
 	<File Name="object_ganon" Segment="6">
-		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xcf00" />
-		<Texture Name="gGanondorfTitleCardGERTex" OutName="ganondorf_ger_title_card" Format="i8" Width="128" Height="40" Offset="0xe300" />
-		<Texture Name="gGanondorfTitleCardFRATex" OutName="ganondorf_fra_title_card" Format="i8" Width="128" Height="40" Offset="0xf700" />
+		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xcf00" />
+		<Texture Name="gGanondorfTitleCardGERTex" OutName="ganondorf_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0xe300" />
+		<Texture Name="gGanondorfTitleCardFRATex" OutName="ganondorf_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0xf700" />
 	</File>
 	<File Name="object_ganon2" Segment="6">
-		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x21a90" />
-		<Texture Name="gGanonTitleCardGERTex" OutName="ganon_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x22e90" />
-		<Texture Name="gGanonTitleCardFRATex" OutName="ganon_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x24290" />
+		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x21a90" />
+		<Texture Name="gGanonTitleCardGERTex" OutName="ganon_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x22e90" />
+		<Texture Name="gGanonTitleCardFRATex" OutName="ganon_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x24290" />
 	</File>
 	<File Name="object_goma" Segment="6">
-		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x19ba8" />
-		<Texture Name="gGohmaTitleCardGERTex" OutName="gohma_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x1afa8" />
-		<Texture Name="gGohmaTitleCardFRATex" OutName="gohma_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x1c3a8" />
+		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x19ba8" />
+		<Texture Name="gGohmaTitleCardGERTex" OutName="gohma_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x1afa8" />
+		<Texture Name="gGohmaTitleCardFRATex" OutName="gohma_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x1c3a8" />
 	</File>
 	<File Name="object_kingdodongo" Segment="6">
-		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x17410" />
-		<Texture Name="gKingDodongoTitleCardGERTex" OutName="king_dodongo_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x18810" />
-		<Texture Name="gKingDodongoTitleCardFRATex" OutName="king_dodongo_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x19c10" />
+		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x17410" />
+		<Texture Name="gKingDodongoTitleCardGERTex" OutName="king_dodongo_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x18810" />
+		<Texture Name="gKingDodongoTitleCardFRATex" OutName="king_dodongo_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x19c10" />
 	</File>
 	<File Name="object_mo" Segment="6">
-		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1010" />
-		<Texture Name="gMorphaTitleCardGERTex" OutName="morpha_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2410" />
-		<Texture Name="gMorphaTitleCardFRATex" OutName="morpha_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x3810" />
+		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1010" />
+		<Texture Name="gMorphaTitleCardGERTex" OutName="morpha_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2410" />
+		<Texture Name="gMorphaTitleCardFRATex" OutName="morpha_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x3810" />
 	</File>
 	<File Name="object_sst" Segment="6">
-		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x13d80" />
-		<Texture Name="gBongoTitleCardGERTex" OutName="bongo_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x15180" />
-		<Texture Name="gBongoTitleCardFRATex" OutName="bongo_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x16580" />
+		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x13d80" />
+		<Texture Name="gBongoTitleCardGERTex" OutName="bongo_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x15180" />
+		<Texture Name="gBongoTitleCardFRATex" OutName="bongo_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x16580" />
 	</File>
 	<File Name="object_tw" Segment="6">
-		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2e170" />
-		<Texture Name="gTwinrovaTitleCardGERTex" OutName="twinrova_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2f570" />
-		<Texture Name="gTwinrovaTitleCardFRATex" OutName="twinrova_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x30970" />
+		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2e170" />
+		<Texture Name="gTwinrovaTitleCardGERTex" OutName="twinrova_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2f570" />
+		<Texture Name="gTwinrovaTitleCardFRATex" OutName="twinrova_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x30970" />
 	</File>
 </Root>

--- a/soh/assets/xml/N64_PAL_11/objects/object_bv.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_bv.xml
@@ -38,7 +38,7 @@
         <Texture Name="object_bvTLUT_01DBB0" OutName="object_bvTLUT_01DBB0" Format="rgba16" Width="16" Height="16" Offset="0x1DBB0" AddedByScript="true"/>
         <Texture Name="object_bvTLUT_01E6B0" OutName="object_bvTLUT_01E6B0" Format="rgba16" Width="16" Height="16" Offset="0x1E6B0" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="ia8" Width="128" Height="120" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x15B18"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x17498"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_fd.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_fd.xml
@@ -28,7 +28,7 @@
         <Texture Name="object_fdTLUT_000A58" OutName="object_fdTLUT_000A58" Format="rgba16" Width="4" Height="4" Offset="0xA58" AddedByScript="true"/>
         <Texture Name="object_fdTLUT_0032A8" OutName="object_fdTLUT_0032A8" Format="rgba16" Width="16" Height="16" Offset="0x32A8" AddedByScript="true"/>
         <!-- Boss title card -->
-        <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/>
+        <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_boss_title_card" Format="ia8" Width="128" Height="120" Offset="0xD700"/>
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x114E0"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_fhg.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_fhg.xml
@@ -38,7 +38,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xC180"/>
         
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="120" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="ia8" Width="128" Height="120" Offset="0x59A0"/>
     
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xFAA0"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_ganon.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="120" Offset="0xCF00"/>
+        <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="ia8" Width="128" Height="120" Offset="0xCF00"/>
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0x11348"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/soh/assets/xml/N64_PAL_11/objects/object_goma.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="120" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="ia8" Width="128" Height="120" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1EC20"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_kingdodongo.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="120" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x1B010"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x1B01C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x1B028"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_mo.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_mo.xml
@@ -6,7 +6,7 @@
         <Texture Name="object_moTex_005520" OutName="object_moTex_005520" Format="ia16" Width="32" Height="32" Offset="0x5520" AddedByScript="true"/>
         <Texture Name="object_moTex_005D20" OutName="object_moTex_005D20" Format="ia16" Width="32" Height="32" Offset="0x5D20" AddedByScript="true"/>
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="ia8" Width="128" Height="120" Offset="0x1010"/>
         <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x8870"/>
 
         <!-- DLists for Morpha's Core -->

--- a/soh/assets/xml/N64_PAL_11/objects/object_sst.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_sst.xml
@@ -17,7 +17,7 @@
         <Texture Name="object_sstTex_01A730" OutName="object_sstTex_01A730" Format="rgba16" Width="4" Height="16" Offset="0x1A730" AddedByScript="true"/>
         <Texture Name="object_sstTex_01A7B0" OutName="object_sstTex_01A7B0" Format="rgba16" Width="16" Height="16" Offset="0x1A7B0" AddedByScript="true"/>
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="ia8" Width="128" Height="120" Offset="0x13D80"/>
         
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/soh/assets/xml/N64_PAL_11/objects/object_tw.xml
+++ b/soh/assets/xml/N64_PAL_11/objects/object_tw.xml
@@ -273,7 +273,7 @@
         <DList Name="gTwinrovaBroomIceTrailDL" Offset="0x2DEB0"/>
         <DList Name="gTwinrovaBroomFireJetDL" Offset="0x2DFB0"/>
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
-        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="i8" Width="128" Height="120" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="title_card" Format="ia8" Width="128" Height="120" Offset="0x2E170"/>
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x31D70"/>
         <Limb Name="gTwinrovaSash1Limb" LimbType="Standard" Offset="0x31D7C"/>
         <Limb Name="gTwinrovaSash2Limb" LimbType="Standard" Offset="0x31D88"/>

--- a/soh/assets/xml/N64_PAL_11/textures/boss_title_cards.xml
+++ b/soh/assets/xml/N64_PAL_11/textures/boss_title_cards.xml
@@ -1,52 +1,52 @@
 <Root>
 	<File Name="object_bv" Segment="6">
-		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1230" />
-		<Texture Name="gBarinadeTitleCardGERTex" OutName="barinade_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2630" />
-		<Texture Name="gBarinadeTitleCardFRATex" OutName="barinade_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x3a30" />
+		<Texture Name="gBarinadeTitleCardENGTex" OutName="barinade_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1230" />
+		<Texture Name="gBarinadeTitleCardGERTex" OutName="barinade_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2630" />
+		<Texture Name="gBarinadeTitleCardFRATex" OutName="barinade_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x3a30" />
 	</File>
 	<File Name="object_fd" Segment="6">
-		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xd700" />
-		<Texture Name="gVolvagiaBossTitleCardGERTex" OutName="volvagia_boss_ger_title_card" Format="i8" Width="128" Height="40" Offset="0xeb00" />
-		<Texture Name="gVolvagiaBossTitleCardFRATex" OutName="volvagia_boss_fra_title_card" Format="i8" Width="128" Height="40" Offset="0xff00" />
+		<Texture Name="gVolvagiaBossTitleCardENGTex" OutName="volvagia_boss_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xd700" />
+		<Texture Name="gVolvagiaBossTitleCardGERTex" OutName="volvagia_boss_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0xeb00" />
+		<Texture Name="gVolvagiaBossTitleCardFRATex" OutName="volvagia_boss_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0xff00" />
 	</File>
 	<File Name="object_fhg" Segment="6">
-		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x59a0" />
-		<Texture Name="gPhantomGanonTitleCardGERTex" OutName="phantom_ganon_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x6da0" />
-		<Texture Name="gPhantomGanonTitleCardFRATex" OutName="phantom_ganon_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x81a0" />
+		<Texture Name="gPhantomGanonTitleCardENGTex" OutName="phantom_ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x59a0" />
+		<Texture Name="gPhantomGanonTitleCardGERTex" OutName="phantom_ganon_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x6da0" />
+		<Texture Name="gPhantomGanonTitleCardFRATex" OutName="phantom_ganon_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x81a0" />
 	</File>
 	<File Name="object_ganon" Segment="6">
-		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="i8" Width="128" Height="40" Offset="0xcf00" />
-		<Texture Name="gGanondorfTitleCardGERTex" OutName="ganondorf_ger_title_card" Format="i8" Width="128" Height="40" Offset="0xe300" />
-		<Texture Name="gGanondorfTitleCardFRATex" OutName="ganondorf_fra_title_card" Format="i8" Width="128" Height="40" Offset="0xf700" />
+		<Texture Name="gGanondorfTitleCardENGTex" OutName="ganondorf_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0xcf00" />
+		<Texture Name="gGanondorfTitleCardGERTex" OutName="ganondorf_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0xe300" />
+		<Texture Name="gGanondorfTitleCardFRATex" OutName="ganondorf_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0xf700" />
 	</File>
 	<File Name="object_ganon2" Segment="6">
-		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x21a90" />
-		<Texture Name="gGanonTitleCardGERTex" OutName="ganon_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x22e90" />
-		<Texture Name="gGanonTitleCardFRATex" OutName="ganon_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x24290" />
+		<Texture Name="gGanonTitleCardENGTex" OutName="ganon_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x21a90" />
+		<Texture Name="gGanonTitleCardGERTex" OutName="ganon_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x22e90" />
+		<Texture Name="gGanonTitleCardFRATex" OutName="ganon_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x24290" />
 	</File>
 	<File Name="object_goma" Segment="6">
-		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x19ba8" />
-		<Texture Name="gGohmaTitleCardGERTex" OutName="gohma_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x1afa8" />
-		<Texture Name="gGohmaTitleCardFRATex" OutName="gohma_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x1c3a8" />
+		<Texture Name="gGohmaTitleCardENGTex" OutName="gohma_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x19ba8" />
+		<Texture Name="gGohmaTitleCardGERTex" OutName="gohma_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x1afa8" />
+		<Texture Name="gGohmaTitleCardFRATex" OutName="gohma_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x1c3a8" />
 	</File>
 	<File Name="object_kingdodongo" Segment="6">
-		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x17410" />
-		<Texture Name="gKingDodongoTitleCardGERTex" OutName="king_dodongo_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x18810" />
-		<Texture Name="gKingDodongoTitleCardFRATex" OutName="king_dodongo_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x19c10" />
+		<Texture Name="gKingDodongoTitleCardENGTex" OutName="king_dodongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x17410" />
+		<Texture Name="gKingDodongoTitleCardGERTex" OutName="king_dodongo_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x18810" />
+		<Texture Name="gKingDodongoTitleCardFRATex" OutName="king_dodongo_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x19c10" />
 	</File>
 	<File Name="object_mo" Segment="6">
-		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x1010" />
-		<Texture Name="gMorphaTitleCardGERTex" OutName="morpha_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2410" />
-		<Texture Name="gMorphaTitleCardFRATex" OutName="morpha_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x3810" />
+		<Texture Name="gMorphaTitleCardENGTex" OutName="morpha_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x1010" />
+		<Texture Name="gMorphaTitleCardGERTex" OutName="morpha_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2410" />
+		<Texture Name="gMorphaTitleCardFRATex" OutName="morpha_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x3810" />
 	</File>
 	<File Name="object_sst" Segment="6">
-		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x13d80" />
-		<Texture Name="gBongoTitleCardGERTex" OutName="bongo_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x15180" />
-		<Texture Name="gBongoTitleCardFRATex" OutName="bongo_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x16580" />
+		<Texture Name="gBongoTitleCardENGTex" OutName="bongo_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x13d80" />
+		<Texture Name="gBongoTitleCardGERTex" OutName="bongo_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x15180" />
+		<Texture Name="gBongoTitleCardFRATex" OutName="bongo_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x16580" />
 	</File>
 	<File Name="object_tw" Segment="6">
-		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="i8" Width="128" Height="40" Offset="0x2e170" />
-		<Texture Name="gTwinrovaTitleCardGERTex" OutName="twinrova_ger_title_card" Format="i8" Width="128" Height="40" Offset="0x2f570" />
-		<Texture Name="gTwinrovaTitleCardFRATex" OutName="twinrova_fra_title_card" Format="i8" Width="128" Height="40" Offset="0x30970" />
+		<Texture Name="gTwinrovaTitleCardENGTex" OutName="twinrova_eng_title_card" Format="ia8" Width="128" Height="40" Offset="0x2e170" />
+		<Texture Name="gTwinrovaTitleCardGERTex" OutName="twinrova_ger_title_card" Format="ia8" Width="128" Height="40" Offset="0x2f570" />
+		<Texture Name="gTwinrovaTitleCardFRATex" OutName="twinrova_fra_title_card" Format="ia8" Width="128" Height="40" Offset="0x30970" />
 	</File>
 </Root>


### PR DESCRIPTION
closes #6449

it appears the title card textures were incorrectly labeled as i8 in the asset xml's instead of ia8

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6199921940.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6199815981.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6199763242.zip)
<!--- section:artifacts:end -->