### PR TITLE
Fix Skip Planting Beans crash

### DIFF
--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -446,6 +446,54 @@ void RandomizerOnItemReceiveHandler(GetItemEntry receivedItemEntry) {
         randomizerQueuedItemEntry = GET_ITEM_NONE;
     }
 
+    if (receivedItemEntry.modIndex == 1 && receivedItemEntry.getItemId == RG_MAGIC_BEAN_PACK) {
+        if (OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_SKIP_PLANTING_BEANS)) {
+            gSaveContext.sceneFlags[SCENE_DEATH_MOUNTAIN_CRATER].swch |= (1 << 3);
+            if (gPlayState->sceneNum == SCENE_DEATH_MOUNTAIN_CRATER) {
+                Flags_SetSwitch(gPlayState, 3);
+            }
+            gSaveContext.sceneFlags[SCENE_DEATH_MOUNTAIN_TRAIL].swch |= (1 << 6);
+            if (gPlayState->sceneNum == SCENE_DEATH_MOUNTAIN_TRAIL) {
+                Flags_SetSwitch(gPlayState, 6);
+            }
+            gSaveContext.sceneFlags[SCENE_DESERT_COLOSSUS].swch |= (1 << 24);
+            if (gPlayState->sceneNum == SCENE_DESERT_COLOSSUS) {
+                Flags_SetSwitch(gPlayState, 24);
+            }
+            gSaveContext.sceneFlags[SCENE_GERUDO_VALLEY].swch |= (1 << 3);
+            if (gPlayState->sceneNum == SCENE_GERUDO_VALLEY) {
+                Flags_SetSwitch(gPlayState, 3);
+            }
+            gSaveContext.sceneFlags[SCENE_GRAVEYARD].swch |= (1 << 3);
+            if (gPlayState->sceneNum == SCENE_GRAVEYARD) {
+                Flags_SetSwitch(gPlayState, 3);
+            }
+            gSaveContext.sceneFlags[SCENE_KOKIRI_FOREST].swch |= (1 << 9);
+            if (gPlayState->sceneNum == SCENE_KOKIRI_FOREST) {
+                Flags_SetSwitch(gPlayState, 9);
+            }
+            gSaveContext.sceneFlags[SCENE_LAKE_HYLIA].swch |= (1 << 1);
+            if (gPlayState->sceneNum == SCENE_LAKE_HYLIA) {
+                Flags_SetSwitch(gPlayState, 1);
+            }
+            gSaveContext.sceneFlags[SCENE_LOST_WOODS].swch |= (1 << 4) | (1 << 18);
+            if (gPlayState->sceneNum == SCENE_LOST_WOODS) {
+                Flags_SetSwitch(gPlayState, 4);
+                Flags_SetSwitch(gPlayState, 18);
+            }
+            gSaveContext.sceneFlags[SCENE_ZORAS_RIVER].swch |= (1 << 3);
+            if (gPlayState->sceneNum == SCENE_ZORAS_RIVER) {
+                Flags_SetSwitch(gPlayState, 3);
+            }
+            ObjBean* bean = (ObjBean*)Actor_Find(&gPlayState->actorCtx, ACTOR_OBJ_BEAN, ACTORCAT_BG);
+            if (bean != nullptr) {
+                Flags_SetSwitch(gPlayState, bean->dyna.actor.params & 0x3F);
+                func_80B8FE00(bean);
+            }
+            AMMO(ITEM_BEAN) = 0;
+        }
+    }
+
     if (receivedItemEntry.modIndex == MOD_NONE &&
         (receivedItemEntry.itemId == ITEM_HEART_PIECE || receivedItemEntry.itemId == ITEM_HEART_PIECE_2 ||
          receivedItemEntry.itemId == ITEM_HEART_CONTAINER)) {

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -446,7 +446,7 @@ void RandomizerOnItemReceiveHandler(GetItemEntry receivedItemEntry) {
         randomizerQueuedItemEntry = GET_ITEM_NONE;
     }
 
-    if (receivedItemEntry.modIndex == 1 && receivedItemEntry.getItemId == RG_MAGIC_BEAN_PACK) {
+    if (receivedItemEntry.modIndex == MOD_RANDOMIZER && receivedItemEntry.getItemId == RG_MAGIC_BEAN_PACK) {
         if (OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_SKIP_PLANTING_BEANS)) {
             gSaveContext.sceneFlags[SCENE_DEATH_MOUNTAIN_CRATER].swch |= (1 << 3);
             if (gPlayState->sceneNum == SCENE_DEATH_MOUNTAIN_CRATER) {

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3867,51 +3867,6 @@ extern "C" u16 Randomizer_Item_Give(PlayState* play, GetItemEntry giEntry) {
             if (INV_CONTENT(ITEM_BEAN) == ITEM_NONE) {
                 INV_CONTENT(ITEM_BEAN) = ITEM_BEAN;
                 AMMO(ITEM_BEAN) = 10;
-                if (OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_SKIP_PLANTING_BEANS)) {
-                    gSaveContext.sceneFlags[SCENE_DEATH_MOUNTAIN_CRATER].swch |= (1 << 3);
-                    if (gPlayState->sceneNum == SCENE_DEATH_MOUNTAIN_CRATER) {
-                        Flags_SetSwitch(gPlayState, 3);
-                    }
-                    gSaveContext.sceneFlags[SCENE_DEATH_MOUNTAIN_TRAIL].swch |= (1 << 6);
-                    if (gPlayState->sceneNum == SCENE_DEATH_MOUNTAIN_TRAIL) {
-                        Flags_SetSwitch(gPlayState, 6);
-                    }
-                    gSaveContext.sceneFlags[SCENE_DESERT_COLOSSUS].swch |= (1 << 24);
-                    if (gPlayState->sceneNum == SCENE_DESERT_COLOSSUS) {
-                        Flags_SetSwitch(gPlayState, 24);
-                    }
-                    gSaveContext.sceneFlags[SCENE_GERUDO_VALLEY].swch |= (1 << 3);
-                    if (gPlayState->sceneNum == SCENE_GERUDO_VALLEY) {
-                        Flags_SetSwitch(gPlayState, 3);
-                    }
-                    gSaveContext.sceneFlags[SCENE_GRAVEYARD].swch |= (1 << 3);
-                    if (gPlayState->sceneNum == SCENE_GRAVEYARD) {
-                        Flags_SetSwitch(gPlayState, 3);
-                    }
-                    gSaveContext.sceneFlags[SCENE_KOKIRI_FOREST].swch |= (1 << 9);
-                    if (gPlayState->sceneNum == SCENE_KOKIRI_FOREST) {
-                        Flags_SetSwitch(gPlayState, 9);
-                    }
-                    gSaveContext.sceneFlags[SCENE_LAKE_HYLIA].swch |= (1 << 1);
-                    if (gPlayState->sceneNum == SCENE_LAKE_HYLIA) {
-                        Flags_SetSwitch(gPlayState, 1);
-                    }
-                    gSaveContext.sceneFlags[SCENE_LOST_WOODS].swch |= (1 << 4) | (1 << 18);
-                    if (gPlayState->sceneNum == SCENE_LOST_WOODS) {
-                        Flags_SetSwitch(gPlayState, 4);
-                        Flags_SetSwitch(gPlayState, 18);
-                    }
-                    gSaveContext.sceneFlags[SCENE_ZORAS_RIVER].swch |= (1 << 3);
-                    if (gPlayState->sceneNum == SCENE_ZORAS_RIVER) {
-                        Flags_SetSwitch(gPlayState, 3);
-                    }
-                    ObjBean* bean = (ObjBean*)Actor_Find(&gPlayState->actorCtx, ACTOR_OBJ_BEAN, ACTORCAT_BG);
-                    if (bean != nullptr) {
-                        Flags_SetSwitch(gPlayState, bean->dyna.actor.params & 0x3F);
-                        func_80B8FE00(bean);
-                    }
-                    AMMO(ITEM_BEAN) = 0;
-                }
             }
             break;
         case RG_DOUBLE_DEFENSE:


### PR DESCRIPTION
The code for giving the magic bean pack in `Randomizer_Item_Give` included the code for setting the beans as planted when Skip Planting Beans is enabled. However, this had no safety check for `gPlayState` being NULL, so if you happened to get the bean pack in one of the starting items, it would crash trying to check the scene ID. This moves that block of code to the rando item receive handler in hook_handlers.cpp instead.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6281087698.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6281078153.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6281043522.zip)
<!--- section:artifacts:end -->