### PR TITLE
Small patch for Disable Fixed Camera in Hyrule Castle Market

### DIFF
--- a/soh/soh/Enhancements/Graphics/DisableFixedCamera.cpp
+++ b/soh/soh/Enhancements/Graphics/DisableFixedCamera.cpp
@@ -84,7 +84,8 @@ static void DisableFixedCamera_RestoreAllCameraData() {
 
 // Helper to check if a camera type is a fixed camera
 static bool IsFixedCameraType(s16 type) {
-    return type == CAM_SET_PREREND_FIXED || type == CAM_SET_PREREND_PIVOT || type == CAM_SET_PIVOT_FROM_SIDE;
+    return type == CAM_SET_PREREND_FIXED || type == CAM_SET_PREREND_PIVOT || type == CAM_SET_PIVOT_FROM_SIDE ||
+           type == CAM_SET_MARKET_BALCONY;
 }
 
 static void RegisterDisableFixedCamera() {


### PR DESCRIPTION
Adds a check for a special camera type used only on the balcony in Hyrule Castle Market, seemingly resetting the fixed camera when it was reached

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6281173473.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6281170725.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6281146888.zip)
<!--- section:artifacts:end -->