### PR TITLE
Python script to compare source files with decomp

### DIFF
--- a/decomp_diff.py
+++ b/decomp_diff.py
@@ -53,7 +53,7 @@ def main():
     local_path = os.path.abspath(local_path)
     new_lines = read_file(local_path)
 
-    repo_path = os.path.join(os.path.dirname(__file__), "oot")
+    repo_path = os.path.join(os.path.dirname(__file__), "soh")
     relative_path = os.path.relpath(local_path, repo_path)
 
     if len(sys.argv) > 2:

--- a/decomp_diff.py
+++ b/decomp_diff.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Generate a git-style patch that shows changes in decompilation between SoH (new)
+and the official decomp repo (old).
+"""
+import difflib
+import os
+import sys
+
+ZELDARET_URL = "https://raw.githubusercontent.com/zeldaret/oot/master/"
+
+OLD_DISPLAY = "zeldaret/oot"
+NEW_DISPLAY = "SoH"
+
+try:
+    # Prefer requests if available for nicer error handling
+    import requests
+except Exception:
+    requests = None
+    import urllib.request
+
+def read_file(path):
+    with open(path, "r", encoding="utf-8", errors="surrogateescape") as f:
+        return f.read().splitlines(keepends=False)
+
+def fetch_url(url):
+    if requests:
+        r = requests.get(url)
+        r.raise_for_status()
+        return r.text.splitlines(keepends=False)
+    else:
+        with urllib.request.urlopen(url) as resp:
+            data = resp.read()
+            # decode with utf-8 fallback
+            text = data.decode("utf-8", errors="surrogateescape")
+            return text.splitlines(keepends=False)
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python decomp_diff.py <local_file> [decomp_relative_path]", file=sys.stderr)
+        sys.exit(2)
+
+    local_path = sys.argv[1]
+    if not os.path.exists(local_path):
+        print(f"Local file not found: {local_path}", file=sys.stderr)
+        sys.exit(2)
+
+    if not local_path.endswith((".c", ".h")):
+        print("Can only compare .c and .h files", file=sys.stderr)
+        sys.exit(2)
+
+    # Read local file (new)
+    local_path = os.path.abspath(local_path)
+    new_lines = read_file(local_path)
+
+    repo_path = os.path.join(os.path.dirname(__file__), "oot")
+    relative_path = os.path.relpath(local_path, repo_path)
+
+    if len(sys.argv) > 2:
+        decomp_url = sys.argv[2]
+    else:
+        decomp_url = None
+
+    print(f"Comparing '{relative_path}' to{f" '{decomp_url}' in" if decomp_url else ""} zeldaret's decomp...")
+
+    if not decomp_url:
+        decomp_url = relative_path.replace("\\", "/")
+
+    # Read zeldaret file (old)
+    try:
+        old_lines = fetch_url(ZELDARET_URL + decomp_url)
+    except Exception as e:
+        print(f"Failed to fetch URL {ZELDARET_URL + decomp_url}: {e}", file=sys.stderr)
+        sys.exit(3)
+
+    # produce unified diff (old -> new)
+    patch_lines = list(difflib.unified_diff(old_lines, new_lines,
+                                   fromfile=f"{OLD_DISPLAY} ({decomp_url})",
+                                   tofile=f"{NEW_DISPLAY} ({relative_path})",
+                                   lineterm=""))
+
+    # append --- and +++ lines are already present in unified diff output; but ensure they exist
+    # if unified_diff returned an empty list and files are identical, print nothing
+    if not patch_lines:
+        print("No differences found.")
+        return
+
+    out_text = "\n".join(patch_lines) + "\n"
+    sys.stdout.write(out_text)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Motivated by the desire to find incongruities between SoH's version of decomp and the "official" decomp. Some names might be different, especially as decomp receives more and more updates, but some things have also been renamed in SoH for convenience, in ways that don't align with the official decomp. Ideally, we want them to match as closely as possible. This script is also implemented for 2Ship in HarbourMasters/2ship2harkinian#1635.

```
Usage: python decomp_diff.py <local_file> [decomp_relative_path]
```

It can only compare one file at a time, because the number of changes that are specific to SoH's functionality (e.g. `GameInteractor` hooks) are too numerous, some files may have different names, and comparing each file all at once to its proper decomp counterpart while excluding SoH-specific code files would be way too complicated. The idea is to look at one file, look through the differences and identify which ones are differences come from decomp, like names of functions and constants. In case a file has been renamed, there's an optional argument to specify its path in decomp.

Sample output (now that zeldaret/oot#2688 has merged):
```
>python decomp_diff.py soh\src\overlays\actors\ovl_Bg_Spot18_Basket\z_bg_spot18_basket.h
Comparing 'src\overlays\actors\ovl_Bg_Spot18_Basket\z_bg_spot18_basket.h' to zeldaret's decomp...
--- zeldaret/oot (src/overlays/actors/ovl_Bg_Spot18_Basket/z_bg_spot18_basket.h)
+++ SoH (src\overlays\actors\ovl_Bg_Spot18_Basket\z_bg_spot18_basket.h)
@@ -1,28 +1,28 @@
 #ifndef Z_BG_SPOT18_BASKET_H
 #define Z_BG_SPOT18_BASKET_H

-#include "ultra64.h"
-#include "actor.h"
+#include <libultraship/libultra.h>
+#include "global.h"

 struct BgSpot18Basket;

-typedef void (*BgSpot18BasketActionFunc)(struct BgSpot18Basket*, struct PlayState*);
+typedef void (*BgSpot18BasketActionFunc)(struct BgSpot18Basket*, PlayState*);

 typedef struct BgSpot18Basket {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ ColliderJntSph colliderJntSph;
-    /* 0x0184 */ ColliderJntSphElement colliderJntSphElements[2];
+    /* 0x0184 */ ColliderJntSphElement ColliderJntSphElements[2];
     /* 0x0204 */ BgSpot18BasketActionFunc actionFunc;
-    /* 0x0208 */ f32 circleRadius;
-    /* 0x020C */ s16 circleRate;
-    /* 0x020E */ s16 circleMoveAngle;
-    /* 0x0210 */ s16 spinRate;
-    /* 0x0212 */ s16 pivotAzimuth;
-    /* 0x0214 */ s16 pivotAltitude;
-    /* 0x0216 */ s16 timer;
-    /* 0x0218 */ s16 prize;
-    /* 0x021A */ u8 isHeartPieceGiven;
-    /* 0x021B */ u8 pad;
+    /* 0x0208 */ f32 unk_208;
+    /* 0x020C */ s16 unk_20C;
+    /* 0x020E */ s16 unk_20E;
+    /* 0x0210 */ s16 unk_210;
+    /* 0x0212 */ s16 unk_212;
+    /* 0x0214 */ s16 unk_214;
+    /* 0x0216 */ s16 unk_216;
+    /* 0x0218 */ s16 unk_218;
+    /* 0x021A */ u8 unk_21A;
+    /* 0x021B */ u8 unk_21B;
 } BgSpot18Basket; // size = 0x021C

 #endif
```

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6329632542.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6329479285.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6329441356.zip)
<!--- section:artifacts:end -->