### PR TITLE
Added slider for Rupee Diving Game's time limit

### DIFF
--- a/soh/soh/Enhancements/Difficulty/DivingGameTimer.cpp
+++ b/soh/soh/Enhancements/Difficulty/DivingGameTimer.cpp
@@ -1,0 +1,21 @@
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+
+extern "C" {
+#include "functions.h"
+extern GameInfo* gGameInfo;
+}
+
+static constexpr int32_t CVAR_DIVING_GAME_TIME_DEFAULT = 50;
+#define CVAR_DIVING_GAME_TIME_NAME CVAR_ENHANCEMENT("DivingGame.TimeLimit")
+#define CVAR_DIVING_GAME_TIME_VALUE CVarGetInteger(CVAR_DIVING_GAME_TIME_NAME, CVAR_DIVING_GAME_TIME_DEFAULT)
+#define CVAR_DIVING_GAME_TIME_SET (CVAR_DIVING_GAME_TIME_VALUE != CVAR_DIVING_GAME_TIME_DEFAULT)
+
+static void RegisterDIvingGameTimeLimit() {
+    COND_VB_SHOULD(VB_SET_DIVING_GAME_TIME_LIMIT, CVAR_DIVING_GAME_TIME_SET, {
+        Interface_SetTimer(BREG(2) + CVAR_DIVING_GAME_TIME_VALUE);
+        *should = false;
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterDIvingGameTimeLimit, { CVAR_DIVING_GAME_TIME_NAME });

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -2054,6 +2054,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // true
+    // ```
+    // #### `args`
+    // - None
+    VB_SET_DIVING_GAME_TIME_LIMIT,
+
+    // #### `result`
+    // ```c
     // SurfaceType_GetSlope(&play->colCtx, poly, bgId) == 2
     // ```
     // #### `args`

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1526,11 +1526,7 @@ void SohMenu::AddMenuEnhancements() {
     AddWidget(path, "Rupee Diving Game", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Time Limit: %d seconds", WIDGET_CVAR_SLIDER_INT)
         .CVar(CVAR_ENHANCEMENT("DivingGame.TimeLimit"))
-        .Options(IntSliderOptions()
-                     .Min(30)
-                     .Max(120)
-                     .DefaultValue(50)
-                     .Format("%d seconds"));
+        .Options(IntSliderOptions().Min(30).Max(120).DefaultValue(50).Format("%d seconds"));
 
     AddWidget(path, "Fishing", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Customize Behavior##Fishing", WIDGET_CVAR_CHECKBOX)

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1523,6 +1523,15 @@ void SohMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip("Amy's block pushing puzzle instantly solved."));
 
     path.column = SECTION_COLUMN_3;
+    AddWidget(path, "Rupee Diving Game", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Time Limit: %d seconds", WIDGET_CVAR_SLIDER_INT)
+        .CVar(CVAR_ENHANCEMENT("DivingGame.TimeLimit"))
+        .Options(IntSliderOptions()
+                     .Min(30)
+                     .Max(120)
+                     .DefaultValue(50)
+                     .Format("%d seconds"));
+
     AddWidget(path, "Fishing", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Customize Behavior##Fishing", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("CustomizeFishing"))

--- a/soh/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
+++ b/soh/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
@@ -416,10 +416,12 @@ void func_809EE800(EnDivingGame* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     if (this->unk_292 == Message_GetState(&play->msgCtx) && Message_ShouldAdvance(play)) {
         Message_CloseTextbox(play);
-        if (!Flags_GetEventChkInf(EVENTCHKINF_OBTAINED_SILVER_SCALE)) {
-            Interface_SetTimer(BREG(2) + 50);
-        } else {
-            Interface_SetTimer(BREG(2) + 50);
+        if (GameInteractor_Should(VB_SET_DIVING_GAME_TIME_LIMIT, true)) {
+            if (!Flags_GetEventChkInf(EVENTCHKINF_OBTAINED_SILVER_SCALE)) {
+                Interface_SetTimer(BREG(2) + 50);
+            } else {
+                Interface_SetTimer(BREG(2) + 50);
+            }
         }
         func_800F5ACC(NA_BGM_TIMED_MINI_GAME);
         Player_SetCsActionWithHaltedActors(play, NULL, 7);


### PR DESCRIPTION
Closes #4317

The default time limit is 50 seconds; the slider can go down as far as 30 seconds to make it harder, or up to 2 minutes to make it easier.

<img width="475" height="181" alt="2026-04-09" src="https://github.com/user-attachments/assets/d4e2ded6-aa19-4523-be85-13eb8b845751" />
<img width="473" height="176" alt="2026-04-09 (1)" src="https://github.com/user-attachments/assets/d32eae07-8cad-4b07-b67b-361ba251a058" />

https://github.com/user-attachments/assets/18d6ceea-68a3-4b29-a9e7-c8cc99a31f74

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6349803716.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6349192056.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6349145242.zip)
<!--- section:artifacts:end -->