### PR TITLE
Add missing Hint clarities back

### DIFF
--- a/soh/soh/Enhancements/randomizer/Messages/MerchantMessages.cpp
+++ b/soh/soh/Enhancements/randomizer/Messages/MerchantMessages.cpp
@@ -36,7 +36,8 @@ void BuildMerchantMessage(CustomMessage& msg, RandomizerCheck rc, bool mysteriou
         itemName = CustomMessage(RAND_GET_OVERRIDE(rc).GetTrickName());
         color = "%g";
     } else {
-        itemName = CustomMessage(Rando::StaticData::RetrieveItem(rgid).GetName());
+        const Rando::Item& item = Rando::StaticData::RetrieveItem(rgid);
+        itemName = item.GetHint().GetHintMessage().GetForCurrentLanguage();
     }
     msg.Replace("[[color]]", color);
     msg.InsertNames({ itemName, CustomMessage(std::to_string(price)) });

--- a/soh/soh/Enhancements/randomizer/Messages/StaticHints.cpp
+++ b/soh/soh/Enhancements/randomizer/Messages/StaticHints.cpp
@@ -155,7 +155,8 @@ void Build100SkullsHintMessage(uint16_t* textId, bool* loadFromMessageTable) {
                                       /*french*/
                                       "Yeaaarrgh! Je suis maudit!^Détruit encore %y100 Araignées de la Malédiction%w "
                                       "et j'aurai quelque chose à te donner! [[color]]([[1]])%w");
-    Rando::Item& item = Rando::StaticData::RetrieveItem(RAND_GET_ITEM_LOC(RC_KAK_100_GOLD_SKULLTULA_REWARD)->GetPlacedRandomizerGet());
+    Rando::Item& item =
+        Rando::StaticData::RetrieveItem(RAND_GET_ITEM_LOC(RC_KAK_100_GOLD_SKULLTULA_REWARD)->GetPlacedRandomizerGet());
     msg.Replace("[[color]]", item.GetColor());
     msg.InsertNames({ item.GetHint().GetHintMessage().GetForCurrentLanguage() });
     msg.AutoFormat();

--- a/soh/soh/Enhancements/randomizer/Messages/StaticHints.cpp
+++ b/soh/soh/Enhancements/randomizer/Messages/StaticHints.cpp
@@ -140,7 +140,7 @@ void BuildSkulltulaPeopleMessage(uint16_t* textId, bool* loadFromMessageTable) {
                                       "et j'aurai quelque chose à te donner! [[color]]([[1]])%w");
     msg.InsertNumber(count);
     msg.Replace("[[color]]", item.GetColor());
-    msg.InsertNames({ item.GetName() });
+    msg.InsertNames({ item.GetHint().GetHintMessage().GetForCurrentLanguage() });
     msg.AutoFormat();
     msg.LoadIntoFont();
     *loadFromMessageTable = false;
@@ -155,12 +155,9 @@ void Build100SkullsHintMessage(uint16_t* textId, bool* loadFromMessageTable) {
                                       /*french*/
                                       "Yeaaarrgh! Je suis maudit!^Détruit encore %y100 Araignées de la Malédiction%w "
                                       "et j'aurai quelque chose à te donner! [[color]]([[1]])%w");
-    msg.Replace("[[color]]", Rando::StaticData::RetrieveItem(
-                                 RAND_GET_ITEM_LOC(RC_KAK_100_GOLD_SKULLTULA_REWARD)->GetPlacedRandomizerGet())
-                                 .GetColor());
-    msg.InsertNames(
-        { Rando::StaticData::RetrieveItem(RAND_GET_ITEM_LOC(RC_KAK_100_GOLD_SKULLTULA_REWARD)->GetPlacedRandomizerGet())
-              .GetName() });
+    Rando::Item& item = Rando::StaticData::RetrieveItem(RAND_GET_ITEM_LOC(RC_KAK_100_GOLD_SKULLTULA_REWARD)->GetPlacedRandomizerGet());
+    msg.Replace("[[color]]", item.GetColor());
+    msg.InsertNames({ item.GetHint().GetHintMessage().GetForCurrentLanguage() });
     msg.AutoFormat();
     msg.LoadIntoFont();
     *loadFromMessageTable = false;

--- a/soh/soh/Enhancements/randomizer/hint.cpp
+++ b/soh/soh/Enhancements/randomizer/hint.cpp
@@ -520,9 +520,11 @@ const HintText Hint::GetItemHintText(uint8_t slot, bool mysterious) const {
         msg = CustomMessage({ ctx->overrides[hintedCheck].GetTrickName() });
     } else {
         const Rando::Item& item = ctx->GetItemLocation(hintedCheck)->GetPlacedItem();
-        msg = item.GetHint().GetHintMessage().GetForCurrentLanguage();
+        msg = item.GetHint().GetHintMessage().GetForCurrentLanguage(MF_RAW);
+        if (ctx->GetOption(RSK_HINT_CLARITY).Is(RO_HINT_CLARITY_CLEAR)) {
+            msg = CustomMessage(ctx->GetItemLocation(hintedCheck)->GetPlacedItem().GetArticle()) + msg;
+        }
     }
-    msg = CustomMessage(ctx->GetItemLocation(hintedCheck)->GetPlacedItem().GetArticle()) + msg;
     return HintText(msg);
 }
 

--- a/soh/soh/Enhancements/randomizer/hint.cpp
+++ b/soh/soh/Enhancements/randomizer/hint.cpp
@@ -520,7 +520,8 @@ const HintText Hint::GetItemHintText(uint8_t slot, bool mysterious) const {
                targetRG == RG_ICE_TRAP) { // RANDOTODO store in item hint instead of item
         msg = CustomMessage({ ctx->overrides[hintedCheck].GetTrickName() });
     } else {
-        msg = ctx->GetItemLocation(hintedCheck)->GetPlacedItem().GetName();
+        const Rando::Item& item = ctx->GetItemLocation(hintedCheck)->GetPlacedItem();
+        msg = item.GetHint().GetHintMessage().GetForCurrentLanguage();
     }
     msg = CustomMessage(ctx->GetItemLocation(hintedCheck)->GetPlacedItem().GetArticle()) + msg;
     return HintText(msg);

--- a/soh/soh/Enhancements/randomizer/hint.cpp
+++ b/soh/soh/Enhancements/randomizer/hint.cpp
@@ -516,8 +516,7 @@ const HintText Hint::GetItemHintText(uint8_t slot, bool mysterious) const {
     CustomMessage msg;
     if (mysterious) {
         return StaticData::hintTextTable[RHT_MYSTERIOUS_ITEM];
-    } else if (!ctx->GetOption(RSK_HINT_CLARITY).Is(RO_HINT_CLARITY_AMBIGUOUS) &&
-               targetRG == RG_ICE_TRAP) { // RANDOTODO store in item hint instead of item
+    } else if (targetRG == RG_ICE_TRAP) { // RANDOTODO store in item hint instead of item
         msg = CustomMessage({ ctx->overrides[hintedCheck].GetTrickName() });
     } else {
         const Rando::Item& item = ctx->GetItemLocation(hintedCheck)->GetPlacedItem();

--- a/soh/soh/Enhancements/randomizer/hint.cpp
+++ b/soh/soh/Enhancements/randomizer/hint.cpp
@@ -513,19 +513,13 @@ const HintText Hint::GetItemHintText(uint8_t slot, bool mysterious) const {
     auto ctx = Rando::Context::GetInstance();
     RandomizerCheck hintedCheck = locations[slot];
     RandomizerGet targetRG = ctx->GetItemLocation(hintedCheck)->GetPlacedRandomizerGet();
-    CustomMessage msg;
     if (mysterious) {
         return StaticData::hintTextTable[RHT_MYSTERIOUS_ITEM];
     } else if (targetRG == RG_ICE_TRAP) { // RANDOTODO store in item hint instead of item
-        msg = CustomMessage({ ctx->overrides[hintedCheck].GetTrickName() });
+        return HintText(CustomMessage({ ctx->overrides[hintedCheck].GetTrickName() }));
     } else {
-        const Rando::Item& item = ctx->GetItemLocation(hintedCheck)->GetPlacedItem();
-        msg = item.GetHint().GetHintMessage().GetForCurrentLanguage(MF_RAW);
-        if (ctx->GetOption(RSK_HINT_CLARITY).Is(RO_HINT_CLARITY_CLEAR)) {
-            msg = CustomMessage(ctx->GetItemLocation(hintedCheck)->GetPlacedItem().GetArticle()) + msg;
-        }
+        return ctx->GetItemLocation(hintedCheck)->GetPlacedItem().GetHint();
     }
-    return HintText(msg);
 }
 
 const HintText Hint::GetAreaHintText(uint8_t slot) const {

--- a/soh/soh/Enhancements/randomizer/item_list.cpp
+++ b/soh/soh/Enhancements/randomizer/item_list.cpp
@@ -1,7 +1,6 @@
 #include "soh_assets.h"
 #include "static_data.h"
 #include "SeedContext.h"
-#include "logic.h"
 #include "textures/icon_item_24_static/icon_item_24_static.h"
 #include "textures/icon_item_static/icon_item_static.h"
 #include "z64object.h"


### PR DESCRIPTION
With all of the hint texts moved to separate files it looks like the Ambiguous and Obscure hints both got broken and always display as clear hints.

This change attempts to rectify this by getting the hint text for the item instead of the item name.

The article for the name doesn't always work with the ambiguous text (Iron boots -> "The some boots"). If hint clarity wasn't ported over because of this new system. free to kick this PR to the curb.

The different Obscure and Ambiguous names that can be picked for items also seem to always be the same, but I haven't looked at that too hard yet.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6393530132.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6393490019.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6393485354.zip)
<!--- section:artifacts:end -->