### PR TITLE
Fix Rate Limited Success Chime

### DIFF
--- a/soh/soh/Enhancements/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/timesaver_hook_handlers.cpp
@@ -1415,12 +1415,10 @@ static void TimeSaverRegisterHooks() {
               TimeSaverOnSceneInitHandler);
     COND_HOOK(OnVanillaBehavior, true, TimeSaverOnVanillaBehaviorHandler);
     COND_HOOK(OnActorInit, true, TimeSaverOnActorInitHandler);
+    COND_HOOK(OnSceneInit, true, [](int16_t sceneNum) { successChimeCooldown = 0; });
 
     // item queue for use outside rando, rando has its own queue
-    COND_HOOK(OnLoadGame, !IS_RANDO, [](int32_t fileNum) {
-        vanillaQueuedItemEntry = GET_ITEM_NONE;
-        successChimeCooldown = 0;
-    });
+    COND_HOOK(OnLoadGame, !IS_RANDO, [](int32_t fileNum) { vanillaQueuedItemEntry = GET_ITEM_NONE; });
     COND_HOOK(OnItemReceive, !IS_RANDO, TimeSaverOnItemReceiveHandler);
     COND_HOOK(OnPlayerUpdate, !IS_RANDO, TimeSaverOnPlayerUpdateHandler);
     COND_HOOK(OnFlagSet,


### PR DESCRIPTION
Gorodine reported to me that switches in Jabu were not chiming with the One Point setting enabled
I looked at the code and it seemed like it was set up correctly
I hit all of the switches in Jabu, then reset to see if glitch useful would make a difference.  I then found that the first switch did not chime.

Root cause is (and maybe always was) that gameplayFrames is set to 0 on respawn.  Currently, the chime will eventually work when gameplayFrames catches up, but you'll obviously have a period in which it does not.
This now checks to see if the cooldown value is more than 120 frames in the future.  If so, it's from a respawn and we should safely be able to play again.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6482476248.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6482320927.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6482253314.zip)
<!--- section:artifacts:end -->