### PR TITLE
Fix Duplicate Reticles in Anchor

### DIFF
--- a/soh/soh/Enhancements/Items/AdditionalReticles.cpp
+++ b/soh/soh/Enhancements/Items/AdditionalReticles.cpp
@@ -16,6 +16,8 @@ extern SaveContext gSaveContext;
 #define CVAR_BOOMERANG_RETICLE_DEFAULT 0
 #define CVAR_BOOMERANG_RETICLE_VALUE CVarGetInteger(CVAR_BOOMERANG_RETICLE_NAME, CVAR_BOOMERANG_RETICLE_DEFAULT)
 
+Vec3f D_80126184 = { 100.0f, 1500.0f, 0.0f };
+
 // OTRTODO: Figure out why this value works/what this value should be
 // This was originally obtained by working down from FLT_MAX until the math
 // started working out properly
@@ -36,7 +38,7 @@ void RegisterAdditionalReticles() {
     bool shouldRegister = CVAR_BOW_RETICLE_VALUE || CVAR_BOOMERANG_RETICLE_VALUE;
 
     COND_VB_SHOULD(VB_DRAW_ADDITIONAL_RETICLES, shouldRegister, {
-        Player* player = GET_PLAYER(gPlayState);
+        Player* player = va_arg(args, Player*);
         Actor* heldActor = player->heldActor;
         if (CVAR_BOW_RETICLE_VALUE &&
             ((player->heldItemAction >= PLAYER_IA_BOW && player->heldItemAction <= PLAYER_IA_BOW_LIGHT) ||

--- a/soh/soh/Enhancements/Items/AdditionalReticles.cpp
+++ b/soh/soh/Enhancements/Items/AdditionalReticles.cpp
@@ -16,8 +16,6 @@ extern SaveContext gSaveContext;
 #define CVAR_BOOMERANG_RETICLE_DEFAULT 0
 #define CVAR_BOOMERANG_RETICLE_VALUE CVarGetInteger(CVAR_BOOMERANG_RETICLE_NAME, CVAR_BOOMERANG_RETICLE_DEFAULT)
 
-Vec3f D_80126184 = { 100.0f, 1500.0f, 0.0f };
-
 // OTRTODO: Figure out why this value works/what this value should be
 // This was originally obtained by working down from FLT_MAX until the math
 // started working out properly

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -540,10 +540,11 @@ typedef enum {
 
     // #### `result`
     // ```c
-    // true
+    // (this->heldItemAction == PLAYER_IA_HOOKSHOT) ||
+    // (this->heldItemAction == PLAYER_IA_LONGSHOT)
     // ```
     // #### `args`
-    // - None
+    // - '*Player'
     VB_DRAW_ADDITIONAL_RETICLES,
 
     // #### `result`

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -1906,8 +1906,10 @@ void Player_PostLimbDrawGameplay(PlayState* play, s32 limbIndex, Gfx** dList, Ve
         }
 
         if (this->actor.scale.y >= 0.0f) {
-            if (GameInteractor_Should(VB_DRAW_ADDITIONAL_RETICLES, (this->heldItemAction == PLAYER_IA_HOOKSHOT) ||
-                                                                       (this->heldItemAction == PLAYER_IA_LONGSHOT))) {
+            if (GameInteractor_Should(VB_DRAW_ADDITIONAL_RETICLES,
+                                      (this->heldItemAction == PLAYER_IA_HOOKSHOT) ||
+                                          (this->heldItemAction == PLAYER_IA_LONGSHOT),
+                                      this)) {
                 Matrix_MultVec3f(&D_80126184, &this->unk_3C8);
 
                 if (heldActor != NULL) {


### PR DESCRIPTION
Bow and Boomerang were using the global playstate to get player, leading to an additional reticle being drawn for every other anchor player in the scene