### PR TITLE
Fix kak bazaar items having articles

### DIFF
--- a/soh/soh/Enhancements/randomizer/location.cpp
+++ b/soh/soh/Enhancements/randomizer/location.cpp
@@ -64,7 +64,7 @@ bool Rando::Location::IsOverworld() const {
 }
 
 bool Rando::Location::IsShop() const {
-    return scene >= SCENE_BAZAAR && scene <= SCENE_BOMBCHU_SHOP;
+    return (scene >= SCENE_BAZAAR && scene <= SCENE_BOMBCHU_SHOP) || scene == SCENE_TEST01;
 }
 
 bool Rando::Location::IsVanillaCompletion() const {


### PR DESCRIPTION
IsShop didn't include SCENE_TEST01, but that's used as placeholder for kak bazaar vs market bazaar

Fixes #6514

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6487567536.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6487522501.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6487487608.zip)
<!--- section:artifacts:end -->