### PR TITLE
Fishing: don't say default 6/7 when minimum reduced by enhancement

### DIFF
--- a/soh/soh/Enhancements/Fishing.cpp
+++ b/soh/soh/Enhancements/Fishing.cpp
@@ -1,0 +1,21 @@
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/ShipInit.hpp"
+
+extern "C" {
+#include <variables.h>
+
+f32 Fishing_GetMinimumRequiredScore();
+}
+
+void BuildFishingMessage(uint16_t* textId, bool* loadFromMessageTable) {
+    if (gSaveContext.minigameScore == 0) {
+        gSaveContext.minigameScore = Fishing_GetMinimumRequiredScore();
+    }
+}
+
+void RegisterFishingMessages() {
+    COND_ID_HOOK(OnOpenText, 0x40AE, CVarGetInteger(CVAR_ENHANCEMENT("CustomizeFishing"), 0), BuildFishingMessage);
+    COND_ID_HOOK(OnOpenText, 0x4080, CVarGetInteger(CVAR_ENHANCEMENT("CustomizeFishing"), 0), BuildFishingMessage);
+}
+
+static RegisterShipInitFunc initFunc(RegisterFishingMessages, { CVAR_ENHANCEMENT("CustomizeFishing") });

--- a/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/soh/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -432,6 +432,8 @@ static FishingEffect sFishingEffects[FISHING_EFFECT_COUNT];
 static Vec3f sStreamSoundProjectedPos;
 static s16 sFishOnHandParams;
 
+f32 Fishing_GetMinimumRequiredScore();
+
 u8 AllHyruleLoaches() {
     return CVarGetInteger(CVAR_ENHANCEMENT("CustomizeFishing"), 0) &&
            CVarGetInteger(CVAR_ENHANCEMENT("AllHyruleLoaches"), 0);
@@ -904,12 +906,16 @@ void Fishing_Init(Actor* thisx, PlayState* play2) {
         if (sLinkAge == LINK_AGE_CHILD) {
             if ((HIGH_SCORE(HS_FISHING) & HS_FISH_LENGTH_CHILD) != 0) {
                 sFishingRecordLength = HIGH_SCORE(HS_FISHING) & HS_FISH_LENGTH_CHILD;
+            } else if (CVarGetInteger(CVAR_ENHANCEMENT("CustomizeFishing"), 0)) {
+                sFishingRecordLength = Fishing_GetMinimumRequiredScore();
             } else {
                 sFishingRecordLength = 40.0f; // 6 lbs
             }
         } else {
             if ((HIGH_SCORE(HS_FISHING) & HS_FISH_LENGTH_ADULT) != 0) {
                 sFishingRecordLength = (HIGH_SCORE(HS_FISHING) & HS_FISH_LENGTH_ADULT) >> 0x18;
+            } else if (CVarGetInteger(CVAR_ENHANCEMENT("CustomizeFishing"), 0)) {
+                sFishingRecordLength = Fishing_GetMinimumRequiredScore();
             } else {
                 sFishingRecordLength = 45.0f; // 7 lbs
             }


### PR DESCRIPTION
Fixes #1841

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6488738733.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6488728383.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6488723711.zip)
<!--- section:artifacts:end -->