### PR TITLE
[docs] apply corrections to 

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -120,13 +120,15 @@ You can use a `flake.nix` file to instantly setup a development environment usin
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    pinned.url = "github:NixOS/nixpkgs/e6f23dc08d3624daab7094b701aa3954923c6bbb";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, pinned, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        pinned-pkgs = pinned.legacyPackages.${system};
       in
       {
         devShells.default = pkgs.mkShell {
@@ -144,6 +146,10 @@ You can use a `flake.nix` file to instantly setup a development environment usin
             SDL2.dev
             SDL2_net
 
+            # Assets pipeline
+            python3
+            imagemagick
+
             # Other libraries
             libpng
             libzip
@@ -155,7 +161,7 @@ You can use a `flake.nix` file to instantly setup a development environment usin
             bzip2
 
             # X11 libraries
-            xorg.libX11
+            libx11
 
             # Audio libraries
             libogg
@@ -166,10 +172,16 @@ You can use a `flake.nix` file to instantly setup a development environment usin
             libopus.dev
             opusfile
             opusfile.dev
+
+            # Runtime dependencies
+            zenity
+          ] ++ [
+            # HM64 projects use an older clang-format than the main 'clang' package
+            pinned-pkgs.clang_14
           ];
           shellHook = ''
             echo "Shipwright development environment loaded"
-            echo "Available tools: clang, git, cmake, ninja"
+            echo "Available tools: clang, git, cmake, ninja, python3"
           '';
         };
       });


### PR DESCRIPTION
`Python3`, used for several CMake targets.
`Zenity`, a still used runtime dependency.
`xorg.libX11` -> `libx11`, packageset deprecated.
`imagemagick`, included as per @IQubic's research.