### PR TITLE
Arrow cycle should check for sufficient magic

### DIFF
--- a/soh/soh/Enhancements/ArrowCycle.cpp
+++ b/soh/soh/Enhancements/ArrowCycle.cpp
@@ -43,11 +43,11 @@ static bool HasArrowType(PlayerItemAction itemAction) {
         case PLAYER_IA_BOW:
             return true;
         case PLAYER_IA_BOW_FIRE:
-            return INV_CONTENT(ITEM_ARROW_FIRE) == ITEM_ARROW_FIRE;
+            return INV_CONTENT(ITEM_ARROW_FIRE) == ITEM_ARROW_FIRE && gSaveContext.magic >= sMagicArrowCosts[0];
         case PLAYER_IA_BOW_ICE:
-            return INV_CONTENT(ITEM_ARROW_ICE) == ITEM_ARROW_ICE;
+            return INV_CONTENT(ITEM_ARROW_ICE) == ITEM_ARROW_ICE && gSaveContext.magic >= sMagicArrowCosts[1];
         case PLAYER_IA_BOW_LIGHT:
-            return INV_CONTENT(ITEM_ARROW_LIGHT) == ITEM_ARROW_LIGHT;
+            return INV_CONTENT(ITEM_ARROW_LIGHT) == ITEM_ARROW_LIGHT && gSaveContext.magic >= sMagicArrowCosts[2];
         default:
             return false;
     }


### PR DESCRIPTION
It was reported that a player can shoot a free magic arrow with arrow cycle enabled, even without any magic.
Based upon the tooltip for the setting, we should only cycle arrows if we have enough magic.
This seemed like the appropriate place, but let me know if there is a better solution.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6519022377.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6518884874.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6518869177.zip)
<!--- section:artifacts:end -->