### PR TITLE
entrance rando savewarping

### DIFF
--- a/soh/include/z64save.h
+++ b/soh/include/z64save.h
@@ -205,6 +205,7 @@ typedef struct {
 typedef struct ShipRandomizerSaveContextData {
     u8 triforcePiecesCollected;
     u8 bombchuUpgradeLevel;
+    s16 dungeonEntranceIndex;
 } ShipRandomizerSaveContextData;
 
 typedef struct ShipBossRushSaveContextData {

--- a/soh/soh/Enhancements/randomizer/entrance.cpp
+++ b/soh/soh/Enhancements/randomizer/entrance.cpp
@@ -1737,6 +1737,49 @@ extern "C" EntranceOverride* Randomizer_GetEntranceOverrides() {
     return Rando::Context::GetInstance()->GetEntranceShuffler()->entranceOverrides.data();
 }
 
+// Resolve which entrance savewarp should use after player leaves overworld.
+// In decoupled player should respawn in overworld,
+// whereas in non-decoupled player should respawn in front of exit to overworld.
+extern "C" int16_t Entrance_GetLastDungeonEntranceIndex(int16_t currentEntranceIndex) {
+    auto ctx = Rando::Context::GetInstance();
+
+    // in non-decoupled spawn at entrance, instead of outside entrance, except for boss arenas
+    if (!ctx->GetOption(RSK_DECOUPLED_ENTRANCES) && currentEntranceIndex != ENTR_DEKU_TREE_BOSS_ENTRANCE &&
+        currentEntranceIndex != ENTR_DODONGOS_CAVERN_BOSS_ENTRANCE &&
+        currentEntranceIndex != ENTR_JABU_JABU_BOSS_ENTRANCE &&
+        currentEntranceIndex != ENTR_FOREST_TEMPLE_BOSS_ENTRANCE &&
+        currentEntranceIndex != ENTR_FIRE_TEMPLE_BOSS_ENTRANCE &&
+        currentEntranceIndex != ENTR_WATER_TEMPLE_BOSS_ENTRANCE &&
+        currentEntranceIndex != ENTR_SPIRIT_TEMPLE_BOSS_ENTRANCE &&
+        currentEntranceIndex != ENTR_SHADOW_TEMPLE_BOSS_ENTRANCE &&
+        currentEntranceIndex != ENTR_SHADOW_TEMPLE_BOSS_ENTRANCE && currentEntranceIndex != ENTR_GANONDORF_BOSS_0) {
+        return currentEntranceIndex;
+    }
+
+    // Map currentEntranceIndex (which is the override after crossing) back to the logical
+    // forward entrance the player took, then return that forward's bound reverse index.
+    int16_t logicalIndex = currentEntranceIndex;
+    for (const auto& o : ctx->GetEntranceShuffler()->entranceOverrides) {
+        if (o.index == 0 && o.destination == 0 && o.override == 0 && o.overrideDestination == 0) {
+            continue;
+        }
+        if (o.override == currentEntranceIndex) {
+            logicalIndex = o.index;
+            break;
+        }
+    }
+
+    auto it = Rando::entranceMap.find(logicalIndex);
+    if (it == Rando::entranceMap.end()) {
+        return currentEntranceIndex;
+    }
+    Rando::Entrance* reverse = it->second->GetReverse();
+    if (reverse == nullptr) {
+        return currentEntranceIndex;
+    }
+    return reverse->GetIndex();
+}
+
 static SceneID backedUpScene = (SceneID)0xFF;
 static Camera backupCamera;
 

--- a/soh/soh/Enhancements/randomizer/entrance.cpp
+++ b/soh/soh/Enhancements/randomizer/entrance.cpp
@@ -1731,37 +1731,19 @@ const Entrance* EntranceShuffler::GetEntranceByIndex(int16_t index) {
     auto iter = entranceMap.find(index);
     return iter != entranceMap.end() ? iter->second : nullptr;
 }
-} // namespace Rando
-
-extern "C" EntranceOverride* Randomizer_GetEntranceOverrides() {
-    return Rando::Context::GetInstance()->GetEntranceShuffler()->entranceOverrides.data();
-}
 
 // Resolve which entrance savewarp should use after player leaves overworld.
-// In decoupled player should respawn in overworld,
-// whereas in non-decoupled player should respawn in front of exit to overworld.
-extern "C" int16_t Entrance_GetLastDungeonEntranceIndex(int16_t currentEntranceIndex) {
+// Should only be used for decoupled & boss scenes,
+// remaining scenarios should just use currentEntranceIndex.
+int16_t GetReverseEntranceIndex(int16_t currentEntranceIndex) {
     auto ctx = Rando::Context::GetInstance();
-
-    // in non-decoupled spawn at entrance, instead of outside entrance, except for boss arenas
-    if (!ctx->GetOption(RSK_DECOUPLED_ENTRANCES) && currentEntranceIndex != ENTR_DEKU_TREE_BOSS_ENTRANCE &&
-        currentEntranceIndex != ENTR_DODONGOS_CAVERN_BOSS_ENTRANCE &&
-        currentEntranceIndex != ENTR_JABU_JABU_BOSS_ENTRANCE &&
-        currentEntranceIndex != ENTR_FOREST_TEMPLE_BOSS_ENTRANCE &&
-        currentEntranceIndex != ENTR_FIRE_TEMPLE_BOSS_ENTRANCE &&
-        currentEntranceIndex != ENTR_WATER_TEMPLE_BOSS_ENTRANCE &&
-        currentEntranceIndex != ENTR_SPIRIT_TEMPLE_BOSS_ENTRANCE &&
-        currentEntranceIndex != ENTR_SHADOW_TEMPLE_BOSS_ENTRANCE &&
-        currentEntranceIndex != ENTR_SHADOW_TEMPLE_BOSS_ENTRANCE && currentEntranceIndex != ENTR_GANONDORF_BOSS_0) {
-        return currentEntranceIndex;
-    }
 
     // Map currentEntranceIndex (which is the override after crossing) back to the logical
     // forward entrance the player took, then return that forward's bound reverse index.
     int16_t logicalIndex = currentEntranceIndex;
     for (const auto& o : ctx->GetEntranceShuffler()->entranceOverrides) {
-        if (o.index == 0 && o.destination == 0 && o.override == 0 && o.overrideDestination == 0) {
-            continue;
+        if (Entrance_EntranceIsNull(&o)) {
+            break;
         }
         if (o.override == currentEntranceIndex) {
             logicalIndex = o.index;
@@ -1778,6 +1760,12 @@ extern "C" int16_t Entrance_GetLastDungeonEntranceIndex(int16_t currentEntranceI
         return currentEntranceIndex;
     }
     return reverse->GetIndex();
+}
+
+} // namespace Rando
+
+extern "C" EntranceOverride* Randomizer_GetEntranceOverrides() {
+    return Rando::Context::GetInstance()->GetEntranceShuffler()->entranceOverrides.data();
 }
 
 static SceneID backedUpScene = (SceneID)0xFF;

--- a/soh/soh/Enhancements/randomizer/entrance.h
+++ b/soh/soh/Enhancements/randomizer/entrance.h
@@ -159,12 +159,13 @@ class EntranceShuffler {
     int mCurNumRandomizedEntrances = 0;
     bool mEntranceShuffleFailure = false;
 };
+
+int16_t GetReverseEntranceIndex(int16_t currentEntranceIndex);
 } // namespace Rando
 
 extern "C" {
 #endif
 EntranceOverride* Randomizer_GetEntranceOverrides();
-int16_t Entrance_GetLastDungeonEntranceIndex(int16_t currentEntranceIndex);
 #ifdef __cplusplus
 }
 #endif

--- a/soh/soh/Enhancements/randomizer/entrance.h
+++ b/soh/soh/Enhancements/randomizer/entrance.h
@@ -164,6 +164,7 @@ class EntranceShuffler {
 extern "C" {
 #endif
 EntranceOverride* Randomizer_GetEntranceOverrides();
+int16_t Entrance_GetLastDungeonEntranceIndex(int16_t currentEntranceIndex);
 #ifdef __cplusplus
 }
 #endif

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -3,8 +3,9 @@
 #include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/enhancementTypes.h"
 #include "soh/Enhancements/custom-message/CustomMessageTypes.h"
-#include "soh/Enhancements/randomizer/randomizerTypes.h"
 #include "soh/Enhancements/randomizer/dungeon.h"
+#include "soh/Enhancements/randomizer/entrance.h"
+#include "soh/Enhancements/randomizer/randomizerTypes.h"
 #include "soh/Enhancements/randomizer/static_data.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
@@ -2709,7 +2710,51 @@ void RandomizerOnCuccoOrChickenHatch() {
     }
 }
 
-static void RandomizerRegisterHooks() {
+extern "C" bool IsDungeonScene(s16 scene) {
+    switch (scene) {
+        case SCENE_DEKU_TREE:
+        case SCENE_DEKU_TREE_BOSS:
+        case SCENE_DODONGOS_CAVERN:
+        case SCENE_DODONGOS_CAVERN_BOSS:
+        case SCENE_JABU_JABU:
+        case SCENE_JABU_JABU_BOSS:
+        case SCENE_FOREST_TEMPLE:
+        case SCENE_FOREST_TEMPLE_BOSS:
+        case SCENE_FIRE_TEMPLE:
+        case SCENE_FIRE_TEMPLE_BOSS:
+        case SCENE_WATER_TEMPLE:
+        case SCENE_WATER_TEMPLE_BOSS:
+        case SCENE_SPIRIT_TEMPLE:
+        case SCENE_SPIRIT_TEMPLE_BOSS:
+        case SCENE_SHADOW_TEMPLE:
+        case SCENE_SHADOW_TEMPLE_BOSS:
+        case SCENE_BOTTOM_OF_THE_WELL:
+        case SCENE_GERUDO_TRAINING_GROUND:
+        case SCENE_ICE_CAVERN:
+        case SCENE_INSIDE_GANONS_CASTLE:
+        case SCENE_GANONS_TOWER:
+        case SCENE_GANONDORF_BOSS:
+        case SCENE_INSIDE_GANONS_CASTLE_COLLAPSE:
+        case SCENE_GANONS_TOWER_COLLAPSE_INTERIOR:
+        case SCENE_GANON_BOSS:
+        case SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// bookkeeping for entrance rando, where savewarp needs to replace returning to start of dungeon
+// with returning to last overworld->dungeon entrance taken (or just before, for decoupled)
+static void Randomizer_OnTransitionEnd(s16 sceneNum) {
+    static s16 prevSceneNum = -1;
+    if (!IsDungeonScene(prevSceneNum) && IsDungeonScene(sceneNum)) {
+        lastDungeonEntranceIndex = Entrance_GetLastDungeonEntranceIndex(gSaveContext.entranceIndex);
+    }
+    prevSceneNum = sceneNum;
+}
+
+static void RandomizerRegisterIsRando() {
     static uint32_t onFlagSetHook = 0;
     static uint32_t onSceneFlagSetHook = 0;
     static uint32_t onPlayerUpdateForRCQueueHook = 0;
@@ -2728,6 +2773,17 @@ static void RandomizerRegisterHooks() {
     static uint32_t onExitGameHook = 0;
     static uint32_t onKaleidoUpdateHook = 0;
     static uint32_t onCuccoOrChickenHatchHook = 0;
+
+    SaveManager::Instance->AddInitFunction([](bool isDebug) { lastDungeonEntranceIndex = -1; });
+    SaveManager::Instance->AddSaveFunction(
+        "lastDungeonEntrance", 1,
+        [](SaveContext* saveContext, int sectionID, bool fullSave) {
+            SaveManager::Instance->SaveData("lastDungeonEntranceIndex", lastDungeonEntranceIndex);
+        },
+        true, SECTION_PARENT_NONE);
+    SaveManager::Instance->AddLoadFunction("lastDungeonEntrance", 1, []() {
+        SaveManager::Instance->LoadData("lastDungeonEntranceIndex", lastDungeonEntranceIndex, (int16_t)-1);
+    });
 
     // register this outside OnLoadGame as VB is invoked before OnLoadGame
     COND_VB_SHOULD(VB_REVERT_SPOILING_ITEMS, true, {
@@ -2836,4 +2892,9 @@ static void RandomizerRegisterHooks() {
     });
 }
 
-static RegisterShipInitFunc initFunc_RegisterHooks(RandomizerRegisterHooks);
+static void RandomizerRegisterHooks() {
+    COND_HOOK(OnTransitionEnd, IS_RANDO, Randomizer_OnTransitionEnd)
+}
+
+static RegisterShipInitFunc initFunc_RegisterIsRando(RandomizerRegisterIsRando);
+static RegisterShipInitFunc initFunc_RegisterHooks(RandomizerRegisterHooks, { "IS_RANDO" });

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -2725,7 +2725,8 @@ static void Randomizer_OnTransitionEnd(s16 sceneNum) {
             gSaveContext.entranceIndex == ENTR_WATER_TEMPLE_BOSS_DOOR ||
             gSaveContext.entranceIndex == ENTR_SPIRIT_TEMPLE_BOSS_DOOR ||
             gSaveContext.entranceIndex == ENTR_SHADOW_TEMPLE_BOSS_DOOR) {
-            gSaveContext.ship.quest.data.randomizer.dungeonEntranceIndex = Rando::GetReverseEntranceIndex(gSaveContext.entranceIndex);
+            gSaveContext.ship.quest.data.randomizer.dungeonEntranceIndex =
+                Rando::GetReverseEntranceIndex(gSaveContext.entranceIndex);
         } else {
             gSaveContext.ship.quest.data.randomizer.dungeonEntranceIndex = gSaveContext.entranceIndex;
         }

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -2725,9 +2725,9 @@ static void Randomizer_OnTransitionEnd(s16 sceneNum) {
             gSaveContext.entranceIndex == ENTR_WATER_TEMPLE_BOSS_DOOR ||
             gSaveContext.entranceIndex == ENTR_SPIRIT_TEMPLE_BOSS_DOOR ||
             gSaveContext.entranceIndex == ENTR_SHADOW_TEMPLE_BOSS_DOOR) {
-            lastDungeonEntranceIndex = Rando::GetReverseEntranceIndex(gSaveContext.entranceIndex);
+            gSaveContext.ship.quest.data.randomizer.dungeonEntranceIndex = Rando::GetReverseEntranceIndex(gSaveContext.entranceIndex);
         } else {
-            lastDungeonEntranceIndex = gSaveContext.entranceIndex;
+            gSaveContext.ship.quest.data.randomizer.dungeonEntranceIndex = gSaveContext.entranceIndex;
         }
     }
     prevSceneNum = sceneNum;
@@ -2752,17 +2752,6 @@ static void RandomizerRegisterIsRando() {
     static uint32_t onExitGameHook = 0;
     static uint32_t onKaleidoUpdateHook = 0;
     static uint32_t onCuccoOrChickenHatchHook = 0;
-
-    SaveManager::Instance->AddInitFunction([](bool isDebug) { lastDungeonEntranceIndex = -1; });
-    SaveManager::Instance->AddSaveFunction(
-        "lastDungeonEntrance", 1,
-        [](SaveContext* saveContext, int sectionID, bool fullSave) {
-            SaveManager::Instance->SaveData("lastDungeonEntranceIndex", lastDungeonEntranceIndex);
-        },
-        true, SECTION_PARENT_NONE);
-    SaveManager::Instance->AddLoadFunction("lastDungeonEntrance", 1, []() {
-        SaveManager::Instance->LoadData("lastDungeonEntranceIndex", lastDungeonEntranceIndex, (int16_t)-1);
-    });
 
     // register this outside OnLoadGame as VB is invoked before OnLoadGame
     COND_VB_SHOULD(VB_REVERT_SPOILING_ITEMS, true, {

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -2710,46 +2710,17 @@ void RandomizerOnCuccoOrChickenHatch() {
     }
 }
 
-extern "C" bool IsDungeonScene(s16 scene) {
-    switch (scene) {
-        case SCENE_DEKU_TREE:
-        case SCENE_DEKU_TREE_BOSS:
-        case SCENE_DODONGOS_CAVERN:
-        case SCENE_DODONGOS_CAVERN_BOSS:
-        case SCENE_JABU_JABU:
-        case SCENE_JABU_JABU_BOSS:
-        case SCENE_FOREST_TEMPLE:
-        case SCENE_FOREST_TEMPLE_BOSS:
-        case SCENE_FIRE_TEMPLE:
-        case SCENE_FIRE_TEMPLE_BOSS:
-        case SCENE_WATER_TEMPLE:
-        case SCENE_WATER_TEMPLE_BOSS:
-        case SCENE_SPIRIT_TEMPLE:
-        case SCENE_SPIRIT_TEMPLE_BOSS:
-        case SCENE_SHADOW_TEMPLE:
-        case SCENE_SHADOW_TEMPLE_BOSS:
-        case SCENE_BOTTOM_OF_THE_WELL:
-        case SCENE_GERUDO_TRAINING_GROUND:
-        case SCENE_ICE_CAVERN:
-        case SCENE_INSIDE_GANONS_CASTLE:
-        case SCENE_GANONS_TOWER:
-        case SCENE_GANONDORF_BOSS:
-        case SCENE_INSIDE_GANONS_CASTLE_COLLAPSE:
-        case SCENE_GANONS_TOWER_COLLAPSE_INTERIOR:
-        case SCENE_GANON_BOSS:
-        case SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR:
-            return true;
-        default:
-            return false;
-    }
-}
-
 // bookkeeping for entrance rando, where savewarp needs to replace returning to start of dungeon
 // with returning to last overworld->dungeon entrance taken (or just before, for decoupled)
 static void Randomizer_OnTransitionEnd(s16 sceneNum) {
     static s16 prevSceneNum = -1;
-    if (!IsDungeonScene(prevSceneNum) && IsDungeonScene(sceneNum)) {
-        lastDungeonEntranceIndex = Entrance_GetLastDungeonEntranceIndex(gSaveContext.entranceIndex);
+    int8_t dungeonSceneKind = DungeonSceneKind(sceneNum);
+    if (dungeonSceneKind != 0 && DungeonSceneKind(prevSceneNum) == 0) {
+        if (RAND_GET_OPTION(RSK_DECOUPLED_ENTRANCES) || dungeonSceneKind == 2) {
+            lastDungeonEntranceIndex = Rando::GetReverseEntranceIndex(gSaveContext.entranceIndex);
+        } else {
+            lastDungeonEntranceIndex = gSaveContext.entranceIndex;
+        }
     }
     prevSceneNum = sceneNum;
 }

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -2716,7 +2716,15 @@ static void Randomizer_OnTransitionEnd(s16 sceneNum) {
     static s16 prevSceneNum = -1;
     int8_t dungeonSceneKind = DungeonSceneKind(sceneNum);
     if (dungeonSceneKind != 0 && DungeonSceneKind(prevSceneNum) == 0) {
-        if (RAND_GET_OPTION(RSK_DECOUPLED_ENTRANCES) || dungeonSceneKind == 2) {
+        if (RAND_GET_OPTION(RSK_DECOUPLED_ENTRANCES) || dungeonSceneKind == 2 ||
+            gSaveContext.entranceIndex == ENTR_DEKU_TREE_BOSS_DOOR ||
+            gSaveContext.entranceIndex == ENTR_DODONGOS_CAVERN_BOSS_DOOR ||
+            gSaveContext.entranceIndex == ENTR_JABU_JABU_BOSS_DOOR ||
+            gSaveContext.entranceIndex == ENTR_FOREST_TEMPLE_BOSS_DOOR ||
+            gSaveContext.entranceIndex == ENTR_FIRE_TEMPLE_BOSS_DOOR ||
+            gSaveContext.entranceIndex == ENTR_WATER_TEMPLE_BOSS_DOOR ||
+            gSaveContext.entranceIndex == ENTR_SPIRIT_TEMPLE_BOSS_DOOR ||
+            gSaveContext.entranceIndex == ENTR_SHADOW_TEMPLE_BOSS_DOOR) {
             lastDungeonEntranceIndex = Rando::GetReverseEntranceIndex(gSaveContext.entranceIndex);
         } else {
             lastDungeonEntranceIndex = gSaveContext.entranceIndex;

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -20,8 +20,6 @@
 
 extern PlayState* gPlayState;
 
-s16 lastDungeonEntranceIndex = -1;
-
 // Overwrite the dynamic exit for the OGC Fairy Fountain to be 0x3E8 instead
 // of 0x340 (0x340 will stay as the exit for the HC Fairy Fountain -> Castle Grounds)
 s16 dynamicExitList[] = {
@@ -339,8 +337,8 @@ u32 Entrance_SceneAndSpawnAre(u8 scene, u8 spawn) {
 // Properly respawn the player after a game over, accounting for dungeon entrance randomizer
 void Entrance_SetGameOverEntrance(void) {
     s16 scene = gPlayState->sceneNum;
-    if (lastDungeonEntranceIndex != -1 && DungeonSceneKind(scene) != 0) {
-        gSaveContext.entranceIndex = lastDungeonEntranceIndex;
+    if (gSaveContext.ship.quest.data.randomizer.dungeonEntranceIndex != -1 && DungeonSceneKind(scene) != 0) {
+        gSaveContext.entranceIndex = gSaveContext.ship.quest.data.randomizer.dungeonEntranceIndex;
     }
 }
 
@@ -348,8 +346,8 @@ void Entrance_SetGameOverEntrance(void) {
 void Entrance_SetSavewarpEntrance(void) {
     s16 scene = gSaveContext.savedSceneNum;
 
-    if (lastDungeonEntranceIndex != -1 && DungeonSceneKind(scene) != 0) {
-        gSaveContext.entranceIndex = lastDungeonEntranceIndex;
+    if (gSaveContext.ship.quest.data.randomizer.dungeonEntranceIndex != -1 && DungeonSceneKind(scene) != 0) {
+        gSaveContext.entranceIndex = gSaveContext.ship.quest.data.randomizer.dungeonEntranceIndex;
     } else if (scene == SCENE_LINKS_HOUSE &&
                Randomizer_GetSettingValue(RSK_SHUFFLE_INTERIOR_ENTRANCES) != RO_INTERIOR_ENTRANCE_SHUFFLE_ALL) {
         // Save warping in Link's house keeps the player there if Link's house not shuffled,

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -20,6 +20,8 @@
 
 extern PlayState* gPlayState;
 
+s16 lastDungeonEntranceIndex = -1;
+
 // Overwrite the dynamic exit for the OGC Fairy Fountain to be 0x3E8 instead
 // of 0x340 (0x340 will stay as the exit for the HC Fairy Fountain -> Castle Grounds)
 s16 dynamicExitList[] = {
@@ -48,8 +50,6 @@ s16 dynamicExitList[] = {
 // Owl Flights : 0x492064 and 0x492080
 
 static s16 entranceOverrideTable[ENTRANCE_TABLE_SIZE] = { 0 };
-// Boss scenes (normalize boss scene range to 0 on lookup) mapped to save/death warp entrance
-static s16 bossSceneSaveDeathWarps[SHUFFLEABLE_BOSS_COUNT] = { 0 };
 static ActorEntry modifiedLinkActorEntry = { 0 };
 
 EntranceInfo originalEntranceTable[ENTRANCE_TABLE_SIZE] = { 0 };
@@ -81,6 +81,7 @@ static s8 hasCopiedEntranceTable = 0;
 static s8 hasModifiedEntranceTable = 0;
 
 void Entrance_SetEntranceDiscovered(u16 entranceIndex, u8 isReversedEntrance);
+bool IsDungeonScene(s16 scene);
 
 u8 Entrance_EntranceIsNull(EntranceOverride* entranceOverride) {
     return entranceOverride->index == 0 && entranceOverride->destination == 0 && entranceOverride->override == 0 &&
@@ -170,11 +171,6 @@ void Entrance_Init(void) {
         entranceOverrideTable[i] = i;
     }
 
-    // Initialize all boss room save/death warps with their vanilla dungeon entryway
-    for (s16 i = 0; i < SHUFFLEABLE_BOSS_COUNT; i++) {
-        bossSceneSaveDeathWarps[i] = dungeons[i].entryway;
-    }
-
     // Initialize the grotto exit and load lists
     Grotto_InitExitAndLoadLists();
 
@@ -188,26 +184,7 @@ void Entrance_Init(void) {
         s16 originalDestination = entranceOverrides[i].destination;
         s16 overrideIndex = entranceOverrides[i].override;
 
-        int16_t bossScene = -1;
         int16_t saveWarpEntrance = originalDestination; // Default save warp to the original return entrance
-
-        // Search for boss room overrides and look for the matching save/death warp value to use
-        // If the boss room is in a dungeon, use the dungeons entryway as the save warp
-        // Otherwise use the "exit" value for the entrance that lead to the boss room
-        for (int j = 0; j < SHUFFLEABLE_BOSS_COUNT; j++) {
-            if (overrideIndex == dungeons[j].bossDoor) {
-                bossScene = dungeons[j].bossScene;
-            }
-
-            if (index == dungeons[j].bossDoor) {
-                saveWarpEntrance = dungeons[j].entryway;
-            }
-        }
-
-        // Found a boss scene and a valid save/death warp value
-        if (bossScene != -1 && saveWarpEntrance != -1) {
-            bossSceneSaveDeathWarps[bossScene - SCENE_DEKU_TREE_BOSS] = saveWarpEntrance;
-        }
 
         // Overwrite grotto related indices
         if (originalIndex >= ENTRANCE_GROTTO_EXIT_START && originalIndex < ENTRANCE_GROTTO_EXIT_START + NUM_GROTTOS) {
@@ -327,13 +304,8 @@ u32 Entrance_SceneAndSpawnAre(u8 scene, u8 spawn) {
 // Properly respawn the player after a game over, accounting for dungeon entrance randomizer
 void Entrance_SetGameOverEntrance(void) {
     s16 scene = gPlayState->sceneNum;
-
-    // When in a boss room and boss shuffle is on, use the boss scene to find the death warp entrance
-    if (Randomizer_GetSettingValue(RSK_SHUFFLE_BOSS_ENTRANCES) != RO_BOSS_ROOM_ENTRANCE_SHUFFLE_OFF &&
-        scene >= SCENE_DEKU_TREE_BOSS && scene <= SCENE_SHADOW_TEMPLE_BOSS) {
-        // Normalize boss scene range to 0 on lookup and handle for grotto entrances
-        gSaveContext.entranceIndex =
-            Grotto_OverrideSpecialEntrance(bossSceneSaveDeathWarps[scene - SCENE_DEKU_TREE_BOSS]);
+    if (lastDungeonEntranceIndex != -1 && IsDungeonScene(scene)) {
+        gSaveContext.entranceIndex = lastDungeonEntranceIndex;
         return;
     }
 
@@ -373,16 +345,9 @@ void Entrance_SetGameOverEntrance(void) {
 void Entrance_SetSavewarpEntrance(void) {
     s16 scene = gSaveContext.savedSceneNum;
 
-    // When in a boss room and boss shuffle is on, use the boss scene to find the savewarp entrance
-    if (Randomizer_GetSettingValue(RSK_SHUFFLE_BOSS_ENTRANCES) != RO_BOSS_ROOM_ENTRANCE_SHUFFLE_OFF &&
-        scene >= SCENE_DEKU_TREE_BOSS && scene <= SCENE_SHADOW_TEMPLE_BOSS) {
-        // Normalize boss scene range to 0 on lookup and handle for grotto entrances
-        gSaveContext.entranceIndex =
-            Grotto_OverrideSpecialEntrance(bossSceneSaveDeathWarps[scene - SCENE_DEKU_TREE_BOSS]);
-        return;
-    }
-
-    if (scene == SCENE_DEKU_TREE || scene == SCENE_DEKU_TREE_BOSS) {
+    if (lastDungeonEntranceIndex != -1 && IsDungeonScene(scene)) {
+        gSaveContext.entranceIndex = lastDungeonEntranceIndex;
+    } else if (scene == SCENE_DEKU_TREE || scene == SCENE_DEKU_TREE_BOSS) {
         gSaveContext.entranceIndex = ENTR_DEKU_TREE_ENTRANCE;
     } else if (scene == SCENE_DODONGOS_CAVERN || scene == SCENE_DODONGOS_CAVERN_BOSS) {
         gSaveContext.entranceIndex = ENTR_DODONGOS_CAVERN_ENTRANCE;

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -81,9 +81,44 @@ static s8 hasCopiedEntranceTable = 0;
 static s8 hasModifiedEntranceTable = 0;
 
 void Entrance_SetEntranceDiscovered(u16 entranceIndex, u8 isReversedEntrance);
-bool IsDungeonScene(s16 scene);
 
-u8 Entrance_EntranceIsNull(EntranceOverride* entranceOverride) {
+int8_t DungeonSceneKind(int scene) {
+    switch (scene) {
+        case SCENE_DEKU_TREE:
+        case SCENE_DODONGOS_CAVERN:
+        case SCENE_JABU_JABU:
+        case SCENE_FOREST_TEMPLE:
+        case SCENE_FIRE_TEMPLE:
+        case SCENE_WATER_TEMPLE:
+        case SCENE_SPIRIT_TEMPLE:
+        case SCENE_SHADOW_TEMPLE:
+        case SCENE_BOTTOM_OF_THE_WELL:
+        case SCENE_GERUDO_TRAINING_GROUND:
+        case SCENE_ICE_CAVERN:
+        case SCENE_INSIDE_GANONS_CASTLE:
+        case SCENE_GANONS_TOWER:
+        case SCENE_THIEVES_HIDEOUT:
+            return 1;
+        case SCENE_DEKU_TREE_BOSS:
+        case SCENE_DODONGOS_CAVERN_BOSS:
+        case SCENE_JABU_JABU_BOSS:
+        case SCENE_FOREST_TEMPLE_BOSS:
+        case SCENE_FIRE_TEMPLE_BOSS:
+        case SCENE_WATER_TEMPLE_BOSS:
+        case SCENE_SPIRIT_TEMPLE_BOSS:
+        case SCENE_SHADOW_TEMPLE_BOSS:
+        case SCENE_GANONDORF_BOSS:
+        case SCENE_GANONS_TOWER_COLLAPSE_INTERIOR:
+        case SCENE_INSIDE_GANONS_CASTLE_COLLAPSE:
+        case SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR:
+        case SCENE_GANON_BOSS:
+            return 2;
+        default:
+            return 0;
+    }
+}
+
+u8 Entrance_EntranceIsNull(const EntranceOverride* entranceOverride) {
     return entranceOverride->index == 0 && entranceOverride->destination == 0 && entranceOverride->override == 0 &&
            entranceOverride->overrideDestination == 0;
 }
@@ -304,40 +339,8 @@ u32 Entrance_SceneAndSpawnAre(u8 scene, u8 spawn) {
 // Properly respawn the player after a game over, accounting for dungeon entrance randomizer
 void Entrance_SetGameOverEntrance(void) {
     s16 scene = gPlayState->sceneNum;
-    if (lastDungeonEntranceIndex != -1 && IsDungeonScene(scene)) {
+    if (lastDungeonEntranceIndex != -1 && DungeonSceneKind(scene) != 0) {
         gSaveContext.entranceIndex = lastDungeonEntranceIndex;
-        return;
-    }
-
-    // Set the current entrance depending on which entrance the player last came through
-    switch (gSaveContext.entranceIndex) {
-        case ENTR_DEKU_TREE_BOSS_ENTRANCE: // Deku Tree Boss Room
-            gSaveContext.entranceIndex = ENTR_DEKU_TREE_ENTRANCE;
-            return;
-        case ENTR_DODONGOS_CAVERN_BOSS_ENTRANCE: // Dodongos Cavern Boss Room
-            gSaveContext.entranceIndex = ENTR_DODONGOS_CAVERN_ENTRANCE;
-            return;
-        case ENTR_JABU_JABU_BOSS_ENTRANCE: // Jabu Jabus Belly Boss Room
-            gSaveContext.entranceIndex = ENTR_JABU_JABU_ENTRANCE;
-            return;
-        case ENTR_FOREST_TEMPLE_BOSS_ENTRANCE: // Forest Temple Boss Room
-            gSaveContext.entranceIndex = ENTR_FOREST_TEMPLE_ENTRANCE;
-            return;
-        case ENTR_FIRE_TEMPLE_BOSS_ENTRANCE: // Fire Temple Boss Room
-            gSaveContext.entranceIndex = ENTR_FIRE_TEMPLE_ENTRANCE;
-            return;
-        case ENTR_WATER_TEMPLE_BOSS_ENTRANCE: // Water Temple Boss Room
-            gSaveContext.entranceIndex = ENTR_WATER_TEMPLE_ENTRANCE;
-            return;
-        case ENTR_SPIRIT_TEMPLE_BOSS_ENTRANCE: // Spirit Temple Boss Room
-            gSaveContext.entranceIndex = ENTR_SPIRIT_TEMPLE_ENTRANCE;
-            return;
-        case ENTR_SHADOW_TEMPLE_BOSS_ENTRANCE: // Shadow Temple Boss Room
-            gSaveContext.entranceIndex = ENTR_SHADOW_TEMPLE_ENTRANCE;
-            return;
-        case ENTR_GANONDORF_BOSS_0: // Ganondorf Boss Room
-            gSaveContext.entranceIndex = ENTR_INSIDE_GANONS_CASTLE_ENTRANCE;
-            return;
     }
 }
 
@@ -345,39 +348,8 @@ void Entrance_SetGameOverEntrance(void) {
 void Entrance_SetSavewarpEntrance(void) {
     s16 scene = gSaveContext.savedSceneNum;
 
-    if (lastDungeonEntranceIndex != -1 && IsDungeonScene(scene)) {
+    if (lastDungeonEntranceIndex != -1 && DungeonSceneKind(scene) != 0) {
         gSaveContext.entranceIndex = lastDungeonEntranceIndex;
-    } else if (scene == SCENE_DEKU_TREE || scene == SCENE_DEKU_TREE_BOSS) {
-        gSaveContext.entranceIndex = ENTR_DEKU_TREE_ENTRANCE;
-    } else if (scene == SCENE_DODONGOS_CAVERN || scene == SCENE_DODONGOS_CAVERN_BOSS) {
-        gSaveContext.entranceIndex = ENTR_DODONGOS_CAVERN_ENTRANCE;
-    } else if (scene == SCENE_JABU_JABU || scene == SCENE_JABU_JABU_BOSS) {
-        gSaveContext.entranceIndex = ENTR_JABU_JABU_ENTRANCE;
-    } else if (scene == SCENE_FOREST_TEMPLE || scene == SCENE_FOREST_TEMPLE_BOSS) { // Forest Temple Boss Room
-        gSaveContext.entranceIndex = ENTR_FOREST_TEMPLE_ENTRANCE;
-    } else if (scene == SCENE_FIRE_TEMPLE || scene == SCENE_FIRE_TEMPLE_BOSS) { // Fire Temple Boss Room
-        gSaveContext.entranceIndex = ENTR_FIRE_TEMPLE_ENTRANCE;
-    } else if (scene == SCENE_WATER_TEMPLE || scene == SCENE_WATER_TEMPLE_BOSS) { // Water Temple Boss Room
-        gSaveContext.entranceIndex = ENTR_WATER_TEMPLE_ENTRANCE;
-    } else if (scene == SCENE_SPIRIT_TEMPLE || scene == SCENE_SPIRIT_TEMPLE_BOSS) { // Spirit Temple Boss Room
-        gSaveContext.entranceIndex = ENTR_SPIRIT_TEMPLE_ENTRANCE;
-    } else if (scene == SCENE_SHADOW_TEMPLE || scene == SCENE_SHADOW_TEMPLE_BOSS) { // Shadow Temple Boss Room
-        gSaveContext.entranceIndex = ENTR_SHADOW_TEMPLE_ENTRANCE;
-    } else if (scene == SCENE_BOTTOM_OF_THE_WELL) { // BOTW
-        gSaveContext.entranceIndex = ENTR_BOTTOM_OF_THE_WELL_ENTRANCE;
-    } else if (scene == SCENE_GERUDO_TRAINING_GROUND) { // GTG
-        gSaveContext.entranceIndex = ENTR_GERUDO_TRAINING_GROUND_ENTRANCE;
-    } else if (scene == SCENE_ICE_CAVERN) { // Ice cavern
-        gSaveContext.entranceIndex = ENTR_ICE_CAVERN_ENTRANCE;
-    } else if (scene == SCENE_INSIDE_GANONS_CASTLE) {
-        gSaveContext.entranceIndex = ENTR_INSIDE_GANONS_CASTLE_ENTRANCE;
-    } else if (scene == SCENE_GANONS_TOWER || scene == SCENE_GANONDORF_BOSS ||
-               scene == SCENE_INSIDE_GANONS_CASTLE_COLLAPSE || scene == SCENE_GANONS_TOWER_COLLAPSE_INTERIOR ||
-               scene == SCENE_GANON_BOSS || scene == SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR) {
-        gSaveContext.entranceIndex = ENTR_GANONS_TOWER_0; // Inside Ganon's Castle -> Ganon's Tower Climb
-    } else if (scene == SCENE_THIEVES_HIDEOUT &&
-               !Randomizer_GetSettingValue(RSK_SHUFFLE_THIEVES_HIDEOUT_ENTRANCES)) { // Thieves' Hideout
-        gSaveContext.entranceIndex = ENTR_THIEVES_HIDEOUT_0; // Gerudo Fortress -> Thieves' Hideout spawn 0
     } else if (scene == SCENE_LINKS_HOUSE &&
                Randomizer_GetSettingValue(RSK_SHUFFLE_INTERIOR_ENTRANCES) != RO_INTERIOR_ENTRANCE_SHUFFLE_ALL) {
         // Save warping in Link's house keeps the player there if Link's house not shuffled,

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -339,6 +339,10 @@ void Entrance_SetGameOverEntrance(void) {
     s16 scene = gPlayState->sceneNum;
     if (gSaveContext.ship.quest.data.randomizer.dungeonEntranceIndex != -1 && DungeonSceneKind(scene) != 0) {
         gSaveContext.entranceIndex = gSaveContext.ship.quest.data.randomizer.dungeonEntranceIndex;
+        if (gSaveContext.entranceIndex >= ENTRANCE_GROTTO_LOAD_START &&
+            gSaveContext.entranceIndex <= ENTRANCE_GROTTO_EXIT_START + NUM_GROTTOS) {
+            gSaveContext.entranceIndex = Grotto_OverrideSpecialEntrance(gSaveContext.entranceIndex);
+        }
     }
 }
 
@@ -348,6 +352,10 @@ void Entrance_SetSavewarpEntrance(void) {
 
     if (gSaveContext.ship.quest.data.randomizer.dungeonEntranceIndex != -1 && DungeonSceneKind(scene) != 0) {
         gSaveContext.entranceIndex = gSaveContext.ship.quest.data.randomizer.dungeonEntranceIndex;
+        if (gSaveContext.entranceIndex >= ENTRANCE_GROTTO_LOAD_START &&
+            gSaveContext.entranceIndex <= ENTRANCE_GROTTO_EXIT_START + NUM_GROTTOS) {
+            gSaveContext.entranceIndex = Grotto_OverrideSpecialEntrance(gSaveContext.entranceIndex);
+        }
     } else if (scene == SCENE_LINKS_HOUSE &&
                Randomizer_GetSettingValue(RSK_SHUFFLE_INTERIOR_ENTRANCES) != RO_INTERIOR_ENTRANCE_SHUFFLE_ALL) {
         // Save warping in Link's house keeps the player there if Link's house not shuffled,

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.h
@@ -55,7 +55,6 @@ void Entrance_EnableFW(void);
 uint8_t Entrance_GetIsEntranceDiscovered(uint16_t entranceIndex);
 void Entrance_SetEntranceDiscovered(uint16_t entranceIndex, uint8_t isReversedEntrance);
 
-extern int16_t lastDungeonEntranceIndex;
 #ifdef __cplusplus
 }
 #endif

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.h
@@ -35,7 +35,8 @@ extern "C" {
 
 void Entrance_Init(void);
 void Entrance_ResetEntranceTable(void);
-uint8_t Entrance_EntranceIsNull(EntranceOverride* entranceOverride);
+int8_t DungeonSceneKind(int scene);
+uint8_t Entrance_EntranceIsNull(const EntranceOverride* entranceOverride);
 int16_t Entrance_GetOverride(int16_t index);
 int16_t Entrance_OverrideNextIndex(int16_t nextEntranceIndex);
 int16_t Entrance_PeekNextIndexOverride(int16_t nextEntranceIndex);

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.h
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.h
@@ -53,6 +53,8 @@ int32_t Entrance_OverrideSpawnSceneRoom(int32_t sceneNum, int32_t spawn, int32_t
 void Entrance_EnableFW(void);
 uint8_t Entrance_GetIsEntranceDiscovered(uint16_t entranceIndex);
 void Entrance_SetEntranceDiscovered(uint16_t entranceIndex, uint8_t isReversedEntrance);
+
+extern int16_t lastDungeonEntranceIndex;
 #ifdef __cplusplus
 }
 #endif

--- a/soh/soh/Enhancements/randomizer/savefile.cpp
+++ b/soh/soh/Enhancements/randomizer/savefile.cpp
@@ -243,11 +243,10 @@ extern "C" void Randomizer_InitSaveFile() {
     // Starts pending ice traps out at 0 before potentially incrementing them down the line.
     gSaveContext.ship.pendingIceTrapCount = 0;
 
-    // Reset triforce pieces collected.
+    // Reset ship data
     gSaveContext.ship.quest.data.randomizer.triforcePiecesCollected = 0;
-
-    // Reset Bombchu Bag Upgrade
     gSaveContext.ship.quest.data.randomizer.bombchuUpgradeLevel = 0;
+    gSaveContext.ship.quest.data.randomizer.dungeonEntranceIndex = -1;
 
     SetStartingItems();
 

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -230,7 +230,8 @@ void SaveManager::LoadRandomizer() {
     SaveManager::Instance->LoadData("triforcePiecesCollected",
                                     gSaveContext.ship.quest.data.randomizer.triforcePiecesCollected);
     SaveManager::Instance->LoadData("bombchuUpgradeLevel", gSaveContext.ship.quest.data.randomizer.bombchuUpgradeLevel);
-    SaveManager::Instance->LoadData("dungeonEntranceIndex", gSaveContext.ship.quest.data.randomizer.dungeonEntranceIndex);
+    SaveManager::Instance->LoadData("dungeonEntranceIndex",
+                                    gSaveContext.ship.quest.data.randomizer.dungeonEntranceIndex);
 
     SaveManager::Instance->LoadData("pendingIceTrapCount", gSaveContext.ship.pendingIceTrapCount);
 
@@ -385,7 +386,8 @@ void SaveManager::SaveRandomizer(SaveContext* saveContext, int sectionID, bool f
     SaveManager::Instance->SaveData("triforcePiecesCollected",
                                     saveContext->ship.quest.data.randomizer.triforcePiecesCollected);
     SaveManager::Instance->SaveData("bombchuUpgradeLevel", saveContext->ship.quest.data.randomizer.bombchuUpgradeLevel);
-    SaveManager::Instance->SaveData("dungeonEntranceIndex", saveContext->ship.quest.data.randomizer.dungeonEntranceIndex);
+    SaveManager::Instance->SaveData("dungeonEntranceIndex",
+                                    saveContext->ship.quest.data.randomizer.dungeonEntranceIndex);
 
     SaveManager::Instance->SaveData("pendingIceTrapCount", saveContext->ship.pendingIceTrapCount);
 

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -230,6 +230,7 @@ void SaveManager::LoadRandomizer() {
     SaveManager::Instance->LoadData("triforcePiecesCollected",
                                     gSaveContext.ship.quest.data.randomizer.triforcePiecesCollected);
     SaveManager::Instance->LoadData("bombchuUpgradeLevel", gSaveContext.ship.quest.data.randomizer.bombchuUpgradeLevel);
+    SaveManager::Instance->LoadData("dungeonEntranceIndex", gSaveContext.ship.quest.data.randomizer.dungeonEntranceIndex);
 
     SaveManager::Instance->LoadData("pendingIceTrapCount", gSaveContext.ship.pendingIceTrapCount);
 
@@ -384,6 +385,7 @@ void SaveManager::SaveRandomizer(SaveContext* saveContext, int sectionID, bool f
     SaveManager::Instance->SaveData("triforcePiecesCollected",
                                     saveContext->ship.quest.data.randomizer.triforcePiecesCollected);
     SaveManager::Instance->SaveData("bombchuUpgradeLevel", saveContext->ship.quest.data.randomizer.bombchuUpgradeLevel);
+    SaveManager::Instance->SaveData("dungeonEntranceIndex", saveContext->ship.quest.data.randomizer.dungeonEntranceIndex);
 
     SaveManager::Instance->SaveData("pendingIceTrapCount", saveContext->ship.pendingIceTrapCount);
 


### PR DESCRIPTION
hacked together concept to avoid soft locking savewarps in entrance rando / player warping to start of dungeon when logically

this is important for reverse dungeon entry (possible today), & vital for doorsanity

Idea: instead of savewarping to start of dungeon, savewarping should go to the last overworld->dungeon entrance taken. this means player can always take exit they spawn in front of to return to overworld

Problem: decoupled entrances. In particular, cases where overworld->dungeon entrance comes out in front of a dungeon->dungeon entrance. Solution: in decoupled save warping in a dungeon spawns you _outside_ the last overworld->dungeon entrance you took. In theory this could be applied to non-decoupled too, but I think the inconsistency is worth keeping a more vanilla/convenient experience outside decoupled

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6523901416.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6523818740.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6523778555.zip)
<!--- section:artifacts:end -->