### PR TITLE
Fix cutscene skips causing credits to spawn player in Lake Hylia

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
@@ -86,8 +86,7 @@ void RegisterShouldPlayBlueWarp() {
      * should also account for the difference between your first and following visits to the blue warp.
      */
     REGISTER_VB_SHOULD(VB_PLAY_TRANSITION_CS, {
-        // Do nothing when in a boss rush
-        if (IS_BOSS_RUSH) {
+        if (IS_BOSS_RUSH || gSaveContext.gameMode == GAMEMODE_END_CREDITS) {
             return;
         }
 


### PR DESCRIPTION
SkipBlueWarp was intercepting credits. Disable during GAMEMODE_END_CREDITS

Fixes #5913

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6519626399.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6519518588.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6519510588.zip)
<!--- section:artifacts:end -->