### PR TITLE
Fix mirror shield color editor

### DIFF
--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -2707,6 +2707,7 @@ void RegisterCosmeticHooks() {
               [](s16 sceneNum) { CosmeticsEditor_AutoRandomizeAll(); });
 
     COND_HOOK(OnGameFrameUpdate, true, CosmeticsUpdateTick);
+    COND_HOOK(OnAssetAltChange, true, []() { ApplyOrResetCustomGfxPatches(true); });
 }
 
 void RegisterCosmeticWidgets() {

--- a/soh/soh/Enhancements/customequipment.cpp
+++ b/soh/soh/Enhancements/customequipment.cpp
@@ -137,7 +137,9 @@ void PatchOrUnpatch(const char* resource, const char* gfx, const char* dlist1, c
             ResourceMgr_UnpatchGfxByName(resource, dlist3);
         }
         // Drop any cached version of the resource so it reloads clean (unpatched) next use.
-        ResourceMgr_UnloadResource(resource);
+        if (ResourceGetIsCustomByName(resource)) {
+            ResourceMgr_UnloadResource(resource);
+        }
         return;
     }
 

--- a/soh/soh/Enhancements/customequipment.cpp
+++ b/soh/soh/Enhancements/customequipment.cpp
@@ -121,6 +121,8 @@ static bool IsDummyPlayer(const Player* player) {
     return player != nullptr && player->actor.update == DummyPlayer_Update;
 }
 
+static bool sPrevAltAssetsEnabled = false;
+
 void PatchOrUnpatch(const char* resource, const char* gfx, const char* dlist1, const char* dlist2, const char* dlist3,
                     const char* alternateDL) {
     if (resource == NULL || gfx == NULL || dlist1 == NULL || dlist2 == NULL) {
@@ -128,6 +130,7 @@ void PatchOrUnpatch(const char* resource, const char* gfx, const char* dlist1, c
     }
 
     const bool altAssetsRuntime = ResourceMgr_IsAltAssetsEnabled();
+    const bool altAssetsChanged = (altAssetsRuntime != sPrevAltAssetsEnabled);
 
     if (!altAssetsRuntime) {
         // Alt assets are off; ensure any prior patches using these names are reverted.
@@ -136,11 +139,17 @@ void PatchOrUnpatch(const char* resource, const char* gfx, const char* dlist1, c
         if (dlist3 != NULL) {
             ResourceMgr_UnpatchGfxByName(resource, dlist3);
         }
-        // Drop any cached version of the resource so it reloads clean (unpatched) next use.
-        if (ResourceGetIsCustomByName(resource)) {
+        // Only unload on a state transition (alt assets just turned off) so the vanilla
+        // DL reloads clean. Unloading every frame wipes cosmetics patches unnecessarily.
+        if (altAssetsChanged) {
             ResourceMgr_UnloadResource(resource);
         }
         return;
+    }
+
+    // Alt assets just turned on: unload the cached vanilla DL so the custom version loads.
+    if (altAssetsChanged) {
+        ResourceMgr_UnloadResource(resource);
     }
 
     if (!ResourceGetIsCustomByName(gfx)) {
@@ -512,4 +521,6 @@ void UpdatePatchCustomEquipmentDlists() {
     }
 
     ApplyCommonEquipmentPatches();
+
+    sPrevAltAssetsEnabled = ResourceMgr_IsAltAssetsEnabled();
 }

--- a/soh/soh/Enhancements/customequipment.cpp
+++ b/soh/soh/Enhancements/customequipment.cpp
@@ -139,15 +139,12 @@ void PatchOrUnpatch(const char* resource, const char* gfx, const char* dlist1, c
         if (dlist3 != NULL) {
             ResourceMgr_UnpatchGfxByName(resource, dlist3);
         }
-        // Only unload on a state transition (alt assets just turned off) so the vanilla
-        // DL reloads clean. Unloading every frame wipes cosmetics patches unnecessarily.
         if (altAssetsChanged) {
             ResourceMgr_UnloadResource(resource);
         }
         return;
     }
 
-    // Alt assets just turned on: unload the cached vanilla DL so the custom version loads.
     if (altAssetsChanged) {
         ResourceMgr_UnloadResource(resource);
     }


### PR DESCRIPTION
Oversight on my end that customequipment.cpp unloaded and reloaded assets abit to aggressive.

Adds a guard to make sure to only unload if custom asset is used and to not unload then reload vanilla asset.

Have tested it with fados customequipment and confirmed that mirrorshield is working as intended.

Fixes https://github.com/HarbourMasters/Shipwright/issues/6269

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6532255345.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6531825038.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6531753039.zip)
<!--- section:artifacts:end -->