### PR TITLE
add fps custom equips

### DIFF
--- a/soh/assets/objects/object_custom_equip/object_custom_equip.h
+++ b/soh/assets/objects/object_custom_equip/object_custom_equip.h
@@ -7,6 +7,9 @@
 #define dgCustomBowDL "__OTR__objects/object_custom_equip/gCustomBowDL"
 static const ALIGN_ASSET(2) char gCustomBowDL[] = dgCustomBowDL;
 
+#define dgCustomFPSBowDL "__OTR__objects/object_custom_equip/gCustomFPSBowDL"
+static const ALIGN_ASSET(2) char gCustomFPSBowDL[] = dgCustomFPSBowDL;
+
 #define dgCustomHammerDL "__OTR__objects/object_custom_equip/gCustomHammerDL"
 static const ALIGN_ASSET(2) char gCustomHammerDL[] = dgCustomHammerDL;
 
@@ -15,6 +18,15 @@ static const ALIGN_ASSET(2) char gCustomHookshotDL[] = dgCustomHookshotDL;
 
 #define dgCustomLongshotDL "__OTR__objects/object_custom_equip/gCustomLongshotDL"
 static const ALIGN_ASSET(2) char gCustomLongshotDL[] = dgCustomLongshotDL;
+
+#define dgCustomFPSSlingshotDL "__OTR__objects/object_custom_equip/gCustomFPSSlingshotDL"
+static const ALIGN_ASSET(2) char gCustomFPSSlingshotDL[] = dgCustomFPSSlingshotDL;
+
+#define dgCustomFPSHookshotDL "__OTR__objects/object_custom_equip/gCustomFPSHookshotDL"
+static const ALIGN_ASSET(2) char gCustomFPSHookshotDL[] = dgCustomFPSHookshotDL;
+
+#define dgCustomFPSLongshotDL "__OTR__objects/object_custom_equip/gCustomFPSLongshotDL"
+static const ALIGN_ASSET(2) char gCustomFPSLongshotDL[] = dgCustomFPSLongshotDL;
 
 #define dgCustomHookshotTipDL "__OTR__objects/object_custom_equip/gCustomHookshotTipDL"
 static const ALIGN_ASSET(2) char gCustomHookshotTipDL[] = dgCustomHookshotTipDL;

--- a/soh/soh/Enhancements/customequipment.cpp
+++ b/soh/soh/Enhancements/customequipment.cpp
@@ -57,6 +57,22 @@ static const char* GetBrokenLongswordInSheathDL() {
         { gCustomBrokenLongswordInSheathDL, gCustomBreakableLongswordInSheathDL, gCustomLongswordInSheathDL });
 }
 
+static const char* GetCustomFPSSlingshotDL() {
+    return ResolveCustomChain({ gCustomFPSSlingshotDL, gCustomSlingshotDL });
+}
+
+static const char* GetCustomFPSBowDL() {
+    return ResolveCustomChain({ gCustomFPSBowDL, gCustomBowDL });
+}
+
+static const char* GetCustomFPSHookshotDL() {
+    return ResolveCustomChain({ gCustomFPSHookshotDL, gCustomHookshotDL });
+}
+
+static const char* GetCustomFPSLongshotDL() {
+    return ResolveCustomChain({ gCustomFPSLongshotDL, gCustomLongshotDL });
+}
+
 static void UpdateCustomEquipmentSetModel(Player* player, u8 ModelGroup) {
     (void)ModelGroup;
 
@@ -395,8 +411,8 @@ static void ApplyCommonEquipmentPatches() {
         ApplyPatchEntries({
             { gLinkAdultRightHandHoldingHookshotNearDL, gCustomHookshotDL, "customHookshot1", "customHookshot2",
               "customHookshot3", rightHandClosed },
-            { gLinkAdultRightHandHoldingHookshotFarDL, gCustomHookshotDL, "customHookshotFPS1", "customHookshotFPS2",
-              "customHookshotFPS3", fpsHand },
+            { gLinkAdultRightHandHoldingHookshotFarDL, GetCustomFPSHookshotDL(), "customHookshotFPS1",
+              "customHookshotFPS2", "customHookshotFPS3", fpsHand },
         });
     }
 
@@ -404,8 +420,8 @@ static void ApplyCommonEquipmentPatches() {
         ApplyPatchEntries({
             { gLinkAdultRightHandHoldingHookshotNearDL, gCustomLongshotDL, "customHookshot1", "customHookshot2",
               "customHookshot3", rightHandClosed },
-            { gLinkAdultRightHandHoldingHookshotFarDL, gCustomLongshotDL, "customHookshotFPS1", "customHookshotFPS2",
-              "customHookshotFPS3", fpsHand },
+            { gLinkAdultRightHandHoldingHookshotFarDL, GetCustomFPSLongshotDL(), "customHookshotFPS1",
+              "customHookshotFPS2", "customHookshotFPS3", fpsHand },
         });
     }
 
@@ -436,16 +452,16 @@ static void ApplyCommonEquipmentPatches() {
           "customChildOcarina3", rightHandNear },
         { gLinkAdultRightHandHoldingBowNearDL, gCustomBowDL, "customBow1", "customBow2", "customBow3",
           rightHandClosed },
-        { gLinkAdultRightHandHoldingBowFirstPersonDL, gCustomBowDL, "customBowFPS1", "customBowFPS2", "customBowFPS3",
-          fpsHand },
+        { gLinkAdultRightHandHoldingBowFirstPersonDL, GetCustomFPSBowDL(), "customBowFPS1", "customBowFPS2",
+          "customBowFPS3", fpsHand },
         { gLinkAdultLeftHandHoldingHammerNearDL, gCustomHammerDL, "customHammer1", "customHammer2", "customHammer3",
           leftHandClosed },
         { gLinkChildLeftFistAndBoomerangNearDL, gCustomBoomerangDL, "customBoomerang1", "customBoomerang2",
           "customBoomerang3", leftHandClosed },
         { gLinkChildRightHandHoldingSlingshotNearDL, gCustomSlingshotDL, "customSlingshot1", "customSlingshot2",
           "customSlingshot3", rightHandClosed },
-        { gLinkChildRightArmStretchedSlingshotDL, gCustomSlingshotDL, "customSlingshotFPS1", "customSlingshotFPS2",
-          "customSlingshotFPS3", fpsHand },
+        { gLinkChildRightArmStretchedSlingshotDL, GetCustomFPSSlingshotDL(), "customSlingshotFPS1",
+          "customSlingshotFPS2", "customSlingshotFPS3", fpsHand },
     });
 
     ApplyPatchEntries({
@@ -457,8 +473,8 @@ static void ApplyCommonEquipmentPatches() {
           "customBoomerang3", leftHandClosed },
         { gLinkChildRightHandHoldingSlingshotNearDL, gCustomSlingshotDL, "customSlingshot1", "customSlingshot2",
           "customSlingshot3", rightHandClosed },
-        { gLinkChildRightArmStretchedSlingshotDL, gCustomSlingshotDL, "customSlingshotFPS1", "customSlingshotFPS2",
-          "customSlingshotFPS3", fpsHand },
+        { gLinkChildRightArmStretchedSlingshotDL, GetCustomFPSSlingshotDL(), "customSlingshotFPS1",
+          "customSlingshotFPS2", "customSlingshotFPS3", fpsHand },
     });
 }
 


### PR DESCRIPTION
custom equipment system didnt come with fps exclusive dl's, alot of modders probably dont care but as someone who sticks to n64 styles myself this is problematic, vanilla has this feature so custom equipment system should too.
fps dl's will fallback to the regular custom equipment dls of the items so existing mods arent effected and fps dl's are not required to be exported by modders

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6603943129.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6603778406.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6603728260.zip)
<!--- section:artifacts:end -->