### PR TITLE
[Bugfix] Autosave timestamp seeding

### DIFF
--- a/soh/soh/Enhancements/QoL/Autosave.cpp
+++ b/soh/soh/Enhancements/QoL/Autosave.cpp
@@ -76,6 +76,7 @@ static void Autosave_SoftResetSave() {
 }
 
 static void RegisterAutosave() {
+    lastSaveTimestamp = GetUnixTimestamp();
     COND_HOOK(GameInteractor::OnLoadGame, CVAR_AUTOSAVE_VALUE,
               [](uint32_t fileNme) { lastSaveTimestamp = GetUnixTimestamp(); });
     COND_HOOK(GameInteractor::OnGameFrameUpdate, CVAR_AUTOSAVE_VALUE, Autosave_IntervalSave);


### PR DESCRIPTION
Seed `lastSaveTimestamp` inside `RegisterAutosave`, which runs on startup and on every CVar toggle.
I think this solves an issue introduced in #6298 where the timestamp could be 0 and trigger an automatic save.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6641344143.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6641305241.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6641294519.zip)
<!--- section:artifacts:end -->