### PR TITLE
[Enhancement] Restore Saria's gesture animation in her house

### DIFF
--- a/soh/soh/Enhancements/Graphics/SariaGestureFriendsForever.cpp
+++ b/soh/soh/Enhancements/Graphics/SariaGestureFriendsForever.cpp
@@ -1,0 +1,42 @@
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/ShipInit.hpp"
+
+extern "C" {
+#include "src/overlays/actors/ovl_En_Sa/z_en_sa.h"
+extern "C" PlayState* gPlayState;
+
+void EnSa_ChangeAnim(EnSa* enSa, s32 index);
+}
+
+static constexpr int32_t CVAR_SARIA_GESTURE_DEFAULT = 0;
+#define CVAR_SARIA_GESTURE_NAME CVAR_ENHANCEMENT("SariaGestureFriendsForever")
+#define CVAR_SARIA_GESTURE_VALUE CVarGetInteger(CVAR_SARIA_GESTURE_NAME, CVAR_SARIA_GESTURE_DEFAULT)
+
+// Resets Saria back to her usual swaying animation; otherwise, she stands frozen
+static void EnSa_ResetAnimation(EnSa* enSa) {
+    static bool sAnimationStarted = false;
+
+    if (enSa->unk_20B == 7 && enSa->unk_20A == 2 && !sAnimationStarted) {
+        sAnimationStarted = true;
+    }
+
+    if (sAnimationStarted &&
+        Animation_OnFrame(&enSa->skelAnime, enSa->skelAnime.endFrame)) {
+            EnSa_ChangeAnim(enSa, 4);
+            sAnimationStarted = false;
+    }
+}
+
+static void RegisterSariaGestureFriendsForever() {
+    COND_VB_SHOULD(VB_SARIA_GESTURE, CVAR_SARIA_GESTURE_VALUE, {
+        bool isInHouse = gPlayState->sceneNum == SCENE_SARIAS_HOUSE;
+        *should = *should || isInHouse;
+
+        if (isInHouse) {
+            EnSa* enSa = va_arg(args, EnSa*);
+            EnSa_ResetAnimation(enSa);
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterSariaGestureFriendsForever, { CVAR_SARIA_GESTURE_NAME });

--- a/soh/soh/Enhancements/Graphics/SariaGestureFriendsForever.cpp
+++ b/soh/soh/Enhancements/Graphics/SariaGestureFriendsForever.cpp
@@ -20,10 +20,9 @@ static void EnSa_ResetAnimation(EnSa* enSa) {
         sAnimationStarted = true;
     }
 
-    if (sAnimationStarted &&
-        Animation_OnFrame(&enSa->skelAnime, enSa->skelAnime.endFrame)) {
-            EnSa_ChangeAnim(enSa, 4);
-            sAnimationStarted = false;
+    if (sAnimationStarted && Animation_OnFrame(&enSa->skelAnime, enSa->skelAnime.endFrame)) {
+        EnSa_ChangeAnim(enSa, 4);
+        sAnimationStarted = false;
     }
 }
 

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -926,6 +926,19 @@ typedef enum {
     VB_PLAY_HORSEBACK_ARCHERY,
 
     // #### `result`
+    // ##### In `func_80AF6448`
+    // ```c
+    // play->sceneNum == SCENE_KOKIRI_FOREST
+    // ```
+    // ##### Also in `func_80AF6448`
+    // ```c
+    // false
+    // ```
+    // #### `args`
+    // - None
+    VB_SARIA_GESTURE,
+
+    // #### `result`
     // ```c
     // true
     // ```

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -926,16 +926,11 @@ typedef enum {
     VB_PLAY_HORSEBACK_ARCHERY,
 
     // #### `result`
-    // ##### In `func_80AF6448`
     // ```c
     // play->sceneNum == SCENE_KOKIRI_FOREST
     // ```
-    // ##### Also in `func_80AF6448`
-    // ```c
-    // false
-    // ```
     // #### `args`
-    // - None
+    // - `*EnSa`
     VB_SARIA_GESTURE,
 
     // #### `result`

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -628,12 +628,6 @@ void SohMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip(
             "When Medallions are collected, the Medallion imprints around the Master Sword Pedestal in the Temple "
             "of Time will become colored-in."));
-    AddWidget(path, "Saria Gestures in Her House", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_ENHANCEMENT("SariaGestureFriendsForever"))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip(
-            "Saria has an unused animation that goes with her line, \"Saria and Link will be friends forever.\" "
-            "This line is spoken when talking to her in her house. This option enables that animation."));
 
     path.column = SECTION_COLUMN_2;
     AddWidget(path, "UI", WIDGET_SEPARATOR_TEXT);
@@ -1190,6 +1184,11 @@ void SohMenu::AddMenuEnhancements() {
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip(
             "Restores an unfinished feature to pulsate the boss room icon when you are in the boss room."));
+    AddWidget(path, "Saria's Friends Forever Gesture", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("SariaGestureFriendsForever"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip(
+            "Restores an unused animation of Saria when she says, \"Saria and Link will be friends forever.\""));
 
     AddWidget(path, "Glitch Restorations", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Fish while Hovering", WIDGET_CVAR_CHECKBOX)

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -628,6 +628,12 @@ void SohMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip(
             "When Medallions are collected, the Medallion imprints around the Master Sword Pedestal in the Temple "
             "of Time will become colored-in."));
+    AddWidget(path, "Saria Gestures in Her House", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("SariaGestureFriendsForever"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip(
+            "Saria has an unused animation that goes with her line, \"Saria and Link will be friends forever.\" "
+            "This line is spoken when talking to her in her house. This option enables that animation."));
 
     path.column = SECTION_COLUMN_2;
     AddWidget(path, "UI", WIDGET_SEPARATOR_TEXT);

--- a/soh/src/overlays/actors/ovl_En_Sa/z_en_sa.c
+++ b/soh/src/overlays/actors/ovl_En_Sa/z_en_sa.c
@@ -544,7 +544,7 @@ void EnSa_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void func_80AF6448(EnSa* this, PlayState* play) {
-    if (play->sceneNum == SCENE_KOKIRI_FOREST) {
+    if (GameInteractor_Should(VB_SARIA_GESTURE, play->sceneNum == SCENE_KOKIRI_FOREST, this)) {
         if (this->interactInfo.talkState != NPC_TALK_STATE_IDLE) {
             switch (this->actor.textId) {
                 case 0x1002:


### PR DESCRIPTION
I realize that this is very minor, but I noticed that this animation was set up in the code, where supposedly, Saria would have this conversation and make a gesture if you talked to her at some point in the forest, if you came back after leaving but before meeting Zelda. Since she got moved into her house at that point, that rendered the animation inactive. I added a mod option that restores it.

The tricky thing was making sure that she doesn't just become frozen after the animation is done, so she needs to be reset to her normal animation at that point. I've attached two clips to show that it works regardless of whether you're still talking to her or not.

<img width="682" height="123" alt="saria-gesture" src="https://github.com/user-attachments/assets/eb6c3914-2297-45f9-be2f-7b440fab514b" />

https://github.com/user-attachments/assets/207b13d0-9e82-496c-9787-532aa7a6d6a7

https://github.com/user-attachments/assets/4fc4f3f1-b0ff-46b4-90d6-bb626da0f168

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6695297896.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6694956996.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6694922363.zip)
<!--- section:artifacts:end -->