### PR TITLE
Jump out of water with Roc's feather

### DIFF
--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -2115,6 +2115,16 @@ typedef enum {
     // true
     // ```
     // #### `args`
+    // - `int32_t` (item ID)
+    // - `*u8` (pointer to button status)
+    // - `*s16` (pointer to flag)
+    VB_DISABLE_ROCS_FEATHER_WHILE_SWIMMING,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
     // - `*EnNiwLady`
     VB_SET_CUCCO_COUNT,
 

--- a/soh/soh/Enhancements/randomizer/RocsFeather.cpp
+++ b/soh/soh/Enhancements/randomizer/RocsFeather.cpp
@@ -11,21 +11,57 @@ extern "C" {
 #include "macros.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 extern PlayState* gPlayState;
+extern s32 Player_GetItemOnButton(PlayState*, s32);
 }
 
 #define MAX_ROCS_USES 1
 
 static uint8_t rocsUseCount = 0;
 static uint8_t groundTimer = 0;
+static uint8_t waterTimer = 0;
 static f32 effectsScale = 1.0f;
+
+static const u16 sItemButtons[8] = {
+    BTN_B, BTN_CLEFT, BTN_CDOWN, BTN_CRIGHT, BTN_DUP, BTN_DDOWN, BTN_DLEFT, BTN_DRIGHT,
+};
+
+static void DoRocsFeatherJump(Player* player) {
+    func_80838940(player, (LinkAnimationHeader*)&gPlayerAnim_link_rocs_feather_jump, 5.8f, gPlayState, 0);
+
+    // Actionvar needed to prevent weird animation morph
+    player->av2.actionVar2 = 1;
+
+    // Move player forward on Roc's use
+    player->linearVelocity = 5.0f;
+    player->actor.world.rot.y = player->yaw = player->actor.shape.rot.y;
+
+    if (gSaveContext.linkAge == LINK_AGE_CHILD) {
+        player->actor.velocity.y = 7.0f;
+        effectsScale = 1.0f;
+    } else {
+        player->actor.velocity.y = 7.5f;
+        effectsScale = 1.5f;
+    }
+
+    Vec3f effectsPos = player->actor.home.pos;
+    effectsPos.y += 3;
+
+    EffectSsGRipple_Spawn(gPlayState, &effectsPos, 200 * effectsScale, 300 * effectsScale, 1);
+    EffectSsGSplash_Spawn(gPlayState, &effectsPos, NULL, NULL, 0, 150 * effectsScale);
+
+    // Remove hopping state when using Roc's after sidehop/backflip to allow grabbing ledges again
+    player->stateFlags2 &= ~(PLAYER_STATE2_HOPPING);
+
+    Player_PlaySfx(&player->actor, NA_SE_PL_SKIP);
+}
 
 void RegisterRocsFeather() {
     bool shouldRegister = IS_RANDO && RAND_GET_OPTION(RSK_ROCS_FEATHER);
 
+    // Reset rocsUseCount after Link spends 3+ frames grounded or floating on the water surface.
     COND_HOOK(OnPlayerUpdate, shouldRegister, []() {
         Player* player = GET_PLAYER(gPlayState);
 
-        // Reset Rocs count when touching the ground for 3+ frames
         if (player->actor.bgCheckFlags & 1) {
             if (groundTimer <= 3) {
                 groundTimer++;
@@ -34,8 +70,50 @@ void RegisterRocsFeather() {
             groundTimer = 0;
         }
 
-        if (groundTimer >= 3) {
+        bool onSurface = (player->stateFlags1 & PLAYER_STATE1_IN_WATER) &&
+                         !(player->stateFlags2 & (PLAYER_STATE2_UNDERWATER | PLAYER_STATE2_DIVING));
+        if (onSurface) {
+            if (waterTimer <= 3) {
+                waterTimer++;
+            }
+        } else {
+            waterTimer = 0;
+        }
+
+        if (groundTimer >= 3 || waterTimer >= 3) {
             rocsUseCount = 0;
+        }
+    });
+
+    // Surface-water jump
+    // Separate because VB_CHANGE_HELD_ITEM_AND_USE_ITEM never fires while swimming
+    COND_VB_SHOULD(VB_EXECUTE_PLAYER_ACTION_FUNC, shouldRegister, {
+        if (!*should)
+            return;
+
+        Player* player = va_arg(args, Player*);
+        if (player->actor.id != ACTOR_PLAYER)
+            return;
+        if (!(player->stateFlags1 & PLAYER_STATE1_IN_WATER))
+            return;
+        if (player->stateFlags2 & (PLAYER_STATE2_UNDERWATER | PLAYER_STATE2_DIVING))
+            return;
+
+        Input* input = va_arg(args, Input*);
+
+        *should = false;
+        player->actionFunc(player, gPlayState);
+
+        if (rocsUseCount >= MAX_ROCS_USES)
+            return;
+
+        for (size_t i = 1; i < ARRAY_COUNT(sItemButtons); i++) {
+            if (Player_GetItemOnButton(gPlayState, i) == ITEM_ROCS_FEATHER &&
+                CHECK_BTN_ALL(input->press.button, sItemButtons[i])) {
+                rocsUseCount++;
+                DoRocsFeatherJump(player);
+                break;
+            }
         }
     });
 
@@ -48,36 +126,7 @@ void RegisterRocsFeather() {
 
             if (rocsUseCount < MAX_ROCS_USES) {
                 rocsUseCount++;
-
-                Player* player = GET_PLAYER(gPlayState);
-
-                func_80838940(player, (LinkAnimationHeader*)&gPlayerAnim_link_rocs_feather_jump, 5.8f, gPlayState, 0);
-
-                // Actionvar needed to prevent weird animation morph
-                player->av2.actionVar2 = 1;
-
-                // Move player forward on Roc's use
-                player->linearVelocity = 5.0f;
-                player->actor.world.rot.y = player->yaw = player->actor.shape.rot.y;
-
-                if (gSaveContext.linkAge == LINK_AGE_CHILD) {
-                    player->actor.velocity.y = 7.0f;
-                    effectsScale = 1.0f;
-                } else {
-                    player->actor.velocity.y = 7.5f;
-                    effectsScale = 1.5f;
-                }
-
-                Vec3f effectsPos = player->actor.home.pos;
-                effectsPos.y += 3;
-
-                EffectSsGRipple_Spawn(gPlayState, &effectsPos, 200 * effectsScale, 300 * effectsScale, 1);
-                EffectSsGSplash_Spawn(gPlayState, &effectsPos, NULL, NULL, 0, 150 * effectsScale);
-
-                // Remove hopping state when using Roc's after sidehop/backflip to allow grabbing ledges again
-                player->stateFlags2 &= ~(PLAYER_STATE2_HOPPING);
-
-                Player_PlaySfx(&player->actor, NA_SE_PL_SKIP);
+                DoRocsFeatherJump(GET_PLAYER(gPlayState));
             }
         }
     });

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1508,6 +1508,23 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
             }
             break;
         }
+        case VB_DISABLE_ROCS_FEATHER_WHILE_SWIMMING: {
+            s32 item = va_arg(args, s32);
+            u8* buttonStatus = va_arg(args, u8*);
+            s16* statusChanged = va_arg(args, s16*);
+            if (RAND_GET_OPTION(RSK_ROCS_FEATHER) && item == ITEM_ROCS_FEATHER) {
+                Player* player = GET_PLAYER(gPlayState);
+                if (!(player->stateFlags2 & PLAYER_STATE2_UNDERWATER) &&
+                    !(player->stateFlags2 & PLAYER_STATE2_DIVING)) {
+                    *should = false;
+                    if (*buttonStatus == BTN_DISABLED) {
+                        *statusChanged = 1;
+                    }
+                    *buttonStatus = BTN_ENABLED;
+                }
+            }
+            break;
+        }
         case VB_SPAWN_LW_FADO: {
             if (!RAND_GET_OPTION(RSK_SHUFFLE_ADULT_TRADE)) {
                 break;

--- a/soh/soh/Enhancements/randomizer/option_descriptions.cpp
+++ b/soh/soh/Enhancements/randomizer/option_descriptions.cpp
@@ -831,7 +831,8 @@ void Settings::CreateOptionDescriptions() {
         "Item placement logic will respect this option, so it might be required to use this to progress.";
     mOptionDescriptions[RSK_ROCS_FEATHER] =
         "Adds Roc's Feather to the item pool. Roc's Feather is a custom item granting the player a jump on demand. "
-        "The jump can also be used when already in mid-air. Roc's Feather is not considered by logic.";
+        "The jump can also be used when already in mid-air or while swimming on the water surface. "
+        "Roc's Feather is not considered by logic.";
     mOptionDescriptions[RSK_SLINGBOW_BREAK_BEEHIVES] =
         "Allows Slingshot and Bow to break beehives when Beehive Shuffle is turned on.";
     mOptionDescriptions[RSK_LOGIC_RULES] =

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -980,11 +980,15 @@ void func_80083108(PlayState* play) {
                             gSaveContext.buttonStatus[BUTTON_STATUS_INDEX(i)] = BTN_ENABLED;
                         }
                     } else {
-                        if (gSaveContext.buttonStatus[BUTTON_STATUS_INDEX(i)] == BTN_ENABLED) {
-                            sp28 = 1;
-                        }
+                        if (GameInteractor_Should(VB_DISABLE_ROCS_FEATHER_WHILE_SWIMMING, true,
+                                                  gSaveContext.equips.buttonItems[i],
+                                                  &gSaveContext.buttonStatus[BUTTON_STATUS_INDEX(i)], &sp28)) {
+                            if (gSaveContext.buttonStatus[BUTTON_STATUS_INDEX(i)] == BTN_ENABLED) {
+                                sp28 = 1;
+                            }
 
-                        gSaveContext.buttonStatus[BUTTON_STATUS_INDEX(i)] = BTN_DISABLED;
+                            gSaveContext.buttonStatus[BUTTON_STATUS_INDEX(i)] = BTN_DISABLED;
+                        }
                     }
                 }
 


### PR DESCRIPTION
On Apr 27 ship rando stream, ZFG said he wanted the ability to jump out of the water with Roc's.  This is my attempt at implementation

Some notes:
- Setting is in enhancements screen.  Didn't feel appropriate to place it next to the roc's feather option
- Only works if you are on the water surface (i.e.  not underwater, not diving)
- Changing the button state such that Roc's while you're on the water surface will appear as enabled
- Consolidated Roc's jump action into a single function
- Added a separate water frame counter to provide the same cooldown as ground
- Separate action function hook to handle pressing roc's feather in the water

I think I've followed existing conventions here but always open to feedback.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6694038563.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6693486482.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6693462754.zip)
<!--- section:artifacts:end -->