### PR TITLE
Add MQ water lock fix, force it in rando

### DIFF
--- a/soh/soh/Enhancements/Fixes/FixWaterMQLock.cpp
+++ b/soh/soh/Enhancements/Fixes/FixWaterMQLock.cpp
@@ -1,0 +1,26 @@
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ResourceManagerHelpers.h"
+#include "soh/ShipInit.hpp"
+
+extern "C" {
+#include "src/overlays/actors/ovl_En_Door/z_en_door.h"
+extern PlayState* gPlayState;
+}
+
+static constexpr int32_t CVAR_MQ_WATER_LOCK_DEFAULT = 0;
+#define CVAR_MQ_WATER_LOCK_FIX_NAME CVAR_ENHANCEMENT("MQWaterLockFix")
+#define CVAR_MQ_WATER_LOCK_VALUE CVarGetInteger(CVAR_MQ_WATER_LOCK_FIX_NAME, CVAR_MQ_WATER_LOCK_DEFAULT)
+
+static void OnInitEnDoor(void* refActor) {
+    EnDoor* enDoor = reinterpret_cast<EnDoor*>(refActor);
+    if (gPlayState->sceneNum == SCENE_WATER_TEMPLE && ResourceMgr_IsGameMasterQuest() &&
+        enDoor->actor.params == 22659) {
+        enDoor->actor.params = 22660;
+    }
+}
+
+static void RegisterMQWaterLockFix() {
+    COND_ID_HOOK(OnActorInit, ACTOR_EN_DOOR, IS_RANDO || CVAR_MQ_WATER_LOCK_VALUE, OnInitEnDoor);
+}
+
+static RegisterShipInitFunc initFunc(RegisterMQWaterLockFix, { CVAR_MQ_WATER_LOCK_FIX_NAME, "IS_RANDO" });

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1041,6 +1041,17 @@ void SohMenu::AddMenuEnhancements() {
             "Forces Goron City doors open if you somehow complete Fire Temple without talking to Goron Link "
             " and receiving the Goron Tunic."));
 
+    AddWidget(path, "Fix MQ Water 1F Lock", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("MQWaterLockFix"))
+        .PreFunc([](WidgetInfo& info) {
+            info.options->disabled = IS_RANDO && GameInteractor::IsSaveLoaded(true);
+            info.options->disabledTooltip = "This setting is forcefully enabled when you are playing a Randomizer.";
+        })
+        .Options(CheckboxOptions().Tooltip(
+            "The second small key lock MQ water is removed before the player can reach it by a shared flag with some "
+            "Stalfos on the way to Dark Link.\n"
+            "Enabling this will cause that lock to use a different flag, working as intended."));
+
     AddWidget(path, "Item-related Fixes", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Fix Deku Nut Upgrade", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("DekuNutUpgradeFix"))


### PR DESCRIPTION
This is specifically the lock before the 3 jet rooms in an optional part of the dungeon, leading to a skull.
In unedited MQ, defeating the 3 stalfos in the rising target room before Dark Link (mandatory before the lock during intended progression) would set the same flag as the lock uses, causing it to despawn and the nearby key to be pointless.

This PR adds an enhancement to use a different, seemingly unused flag instead, causing the lock to work as intended.

This change is forced in rando to both avoid logical headaches and help GetAvailibleChecks and other mechanics properly count keys.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6716147171.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6716035725.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6715976744.zip)
<!--- section:artifacts:end -->