### PR TITLE
Compile z_bgcheck.c on arm64 macOS with -ffp-contract=off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,10 @@ set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 set(CMAKE_OBJCXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 endif()
+# IEEE 754 compliant floating-point rounding on arm64 macOS
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    add_compile_options(-Xarch_arm64 -ffp-contract=off)
+endif()
 
 if(NOT CMAKE_BUILD_TYPE )
     set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build." FORCE)


### PR DESCRIPTION
When compiling for arm64 and x86_64, compiler optimizations for contracting floating point operations to fused-multiply-add instructions behave differently, producing code that is not IEEE 754 compliant on arm64 macOS. In some specific scenarios, these inconsistencies result in different behavior from the base game, such as not being able to enter Bottom of the Well as adult using a weirdshot.

This pull request adds the compiler flag "-ffp-contract=off" only on arm64 macOS to disable these optimizations in z_bgcheck.c, restoring IEEE 754 compliant behavior for those specific interactions.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6820348289.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6820153181.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6819716770.zip)
<!--- section:artifacts:end -->