### PR TITLE
[Enhancement] Improved Roll

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/ImprovedRoll.cpp
+++ b/soh/soh/Enhancements/TimeSavers/ImprovedRoll.cpp
@@ -15,8 +15,8 @@ void ImprovedRoll_Register() {
         PlayState* play = va_arg(args, PlayState*);
         Input* controlInput = va_arg(args, Input*);
         s32 floorType = va_arg(args, s32);
-        if ((player->skelAnime.curFrame >= 15.0f) &&
-            CHECK_BTN_ALL(controlInput->press.button, BTN_A) && (floorType != 7)) {
+        if ((player->skelAnime.curFrame >= 15.0f) && CHECK_BTN_ALL(controlInput->press.button, BTN_A) &&
+            (floorType != 7)) {
             Player_SetupRoll(player, play);
             *should = true;
         }

--- a/soh/soh/Enhancements/TimeSavers/ImprovedRoll.cpp
+++ b/soh/soh/Enhancements/TimeSavers/ImprovedRoll.cpp
@@ -2,10 +2,6 @@
 #include "soh/ShipInit.hpp"
 #include "global.h"
 
-extern "C" {
-extern PlayState* gPlayState;
-}
-
 #define CVAR_ROLL_CHAIN_NAME CVAR_ENHANCEMENT("ImprovedRoll")
 #define CVAR_ROLL_CHAIN_VALUE CVarGetInteger(CVAR_ROLL_CHAIN_NAME, 0)
 

--- a/soh/soh/Enhancements/TimeSavers/ImprovedRoll.cpp
+++ b/soh/soh/Enhancements/TimeSavers/ImprovedRoll.cpp
@@ -2,16 +2,27 @@
 #include "soh/ShipInit.hpp"
 #include "global.h"
 
-#define CVAR_ROLL_CHAIN_NAME CVAR_ENHANCEMENT("ImprovedRoll")
-#define CVAR_ROLL_CHAIN_VALUE CVarGetInteger(CVAR_ROLL_CHAIN_NAME, 0)
+extern "C" {
+void Player_SetupRoll(Player* player, PlayState* play);
+}
 
-#define CVAR_ROLL_STEER_NAME CVAR_ENHANCEMENT("ImprovedRollSteering")
-#define CVAR_ROLL_STEER_VALUE CVarGetInteger(CVAR_ROLL_STEER_NAME, 0)
+#define CVAR_ROLL_CHAIN CVAR_ENHANCEMENT("ImprovedRoll")
+#define CVAR_ROLL_STEER CVAR_ENHANCEMENT("ImprovedRollSteering")
 
 void ImprovedRoll_Register() {
-    COND_VB_SHOULD(VB_PLAYER_ROLL_CHAIN, CVAR_ROLL_CHAIN_VALUE, { *should = true; });
+    COND_VB_SHOULD(VB_PLAYER_ROLL_CHAIN, CVarGetInteger(CVAR_ROLL_CHAIN, 0), {
+        Player* player = va_arg(args, Player*);
+        PlayState* play = va_arg(args, PlayState*);
+        Input* controlInput = va_arg(args, Input*);
+        s32 floorType = va_arg(args, s32);
+        if ((player->skelAnime.curFrame >= 15.0f) &&
+            CHECK_BTN_ALL(controlInput->press.button, BTN_A) && (floorType != 7)) {
+            Player_SetupRoll(player, play);
+            *should = true;
+        }
+    });
 
-    COND_VB_SHOULD(VB_PLAYER_ROLL_STEER, CVAR_ROLL_CHAIN_VALUE && CVAR_ROLL_STEER_VALUE, {
+    COND_VB_SHOULD(VB_PLAYER_ROLL_STEER, CVarGetInteger(CVAR_ROLL_CHAIN, 0) && CVarGetInteger(CVAR_ROLL_STEER, 0), {
         Player* player = va_arg(args, Player*);
         PlayState* play = va_arg(args, PlayState*);
         s16 yawTarget = (s16)va_arg(args, int);
@@ -22,4 +33,4 @@ void ImprovedRoll_Register() {
     });
 }
 
-static RegisterShipInitFunc initFunc(ImprovedRoll_Register, { CVAR_ROLL_CHAIN_NAME, CVAR_ROLL_STEER_NAME });
+static RegisterShipInitFunc initFunc(ImprovedRoll_Register, { CVAR_ROLL_CHAIN, CVAR_ROLL_STEER });

--- a/soh/soh/Enhancements/TimeSavers/ImprovedRoll.cpp
+++ b/soh/soh/Enhancements/TimeSavers/ImprovedRoll.cpp
@@ -1,0 +1,27 @@
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+#include "global.h"
+
+extern "C" {
+extern PlayState* gPlayState;
+}
+
+#define CVAR_ROLL_CHAIN_NAME CVAR_ENHANCEMENT("ImprovedRoll")
+#define CVAR_ROLL_CHAIN_VALUE CVarGetInteger(CVAR_ROLL_CHAIN_NAME, 0)
+
+#define CVAR_ROLL_STEER_NAME CVAR_ENHANCEMENT("ImprovedRollSteering")
+#define CVAR_ROLL_STEER_VALUE CVarGetInteger(CVAR_ROLL_STEER_NAME, 0)
+
+void ImprovedRoll_Register() {
+    COND_VB_SHOULD(VB_PLAYER_ROLL_CHAIN, CVAR_ROLL_CHAIN_VALUE, { *should = true; });
+
+    COND_VB_SHOULD(VB_PLAYER_ROLL_STEER, CVAR_ROLL_CHAIN_VALUE && CVAR_ROLL_STEER_VALUE, {
+        Player* player = va_arg(args, Player*);
+        va_arg(args, PlayState*);
+        s16 yawTarget = (s16)va_arg(args, int);
+        Math_ScaledStepToS(&player->actor.shape.rot.y, yawTarget, 0x200);
+        *should = false;
+    });
+}
+
+static RegisterShipInitFunc initFunc(ImprovedRoll_Register, { CVAR_ROLL_CHAIN_NAME, CVAR_ROLL_STEER_NAME });

--- a/soh/soh/Enhancements/TimeSavers/ImprovedRoll.cpp
+++ b/soh/soh/Enhancements/TimeSavers/ImprovedRoll.cpp
@@ -13,9 +13,11 @@ void ImprovedRoll_Register() {
 
     COND_VB_SHOULD(VB_PLAYER_ROLL_STEER, CVAR_ROLL_CHAIN_VALUE && CVAR_ROLL_STEER_VALUE, {
         Player* player = va_arg(args, Player*);
-        va_arg(args, PlayState*);
+        PlayState* play = va_arg(args, PlayState*);
         s16 yawTarget = (s16)va_arg(args, int);
-        Math_ScaledStepToS(&player->actor.shape.rot.y, yawTarget, 0x200);
+        if (!CHECK_BTN_ALL(play->state.input[0].cur.button, BTN_Z)) {
+            Math_ScaledStepToS(&player->actor.shape.rot.y, yawTarget, 0x200);
+        }
         *should = false;
     });
 }

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -1963,6 +1963,25 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // false
+    // ```
+    // #### `args`
+    // - `*Player`
+    // - `*PlayState`
+    VB_PLAYER_ROLL_CHAIN,
+
+    // #### `result`
+    // ```c
+    // false
+    // ```
+    // #### `args`
+    // - `*Player`
+    // - `*PlayState`
+    // - `s16 yawTarget` (stick world-space yaw, promoted to int in va_list)
+    VB_PLAYER_ROLL_STEER,
+
+    // #### `result`
+    // ```c
     // item == ITEM_SAW
     // ```
     // #### `args`
@@ -2965,26 +2984,7 @@ typedef enum {
     // ```
     // #### `args`
     // - `*int32_t (camId)`
-    VB_SHOULD_LOAD_BG_IMAGE,
-
-    // #### `result`
-    // ```c
-    // false
-    // ```
-    // #### `args`
-    // - `*Player`
-    // - `*PlayState`
-    VB_PLAYER_ROLL_CHAIN,
-
-    // #### `result`
-    // ```c
-    // false
-    // ```
-    // #### `args`
-    // - `*Player`
-    // - `*PlayState`
-    // - `s16 yawTarget` (stick world-space yaw, promoted to int in va_list)
-    VB_PLAYER_ROLL_STEER
+    VB_SHOULD_LOAD_BG_IMAGE
 } GIVanillaBehavior;
 
 #endif

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -2965,7 +2965,26 @@ typedef enum {
     // ```
     // #### `args`
     // - `*int32_t (camId)`
-    VB_SHOULD_LOAD_BG_IMAGE
+    VB_SHOULD_LOAD_BG_IMAGE,
+
+    // #### `result`
+    // ```c
+    // false
+    // ```
+    // #### `args`
+    // - `*Player`
+    // - `*PlayState`
+    VB_PLAYER_ROLL_CHAIN,
+
+    // #### `result`
+    // ```c
+    // false
+    // ```
+    // #### `args`
+    // - `*Player`
+    // - `*PlayState`
+    // - `s16 yawTarget` (stick world-space yaw, promoted to int in va_list)
+    VB_PLAYER_ROLL_STEER
 } GIVanillaBehavior;
 
 #endif

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -1968,6 +1968,8 @@ typedef enum {
     // #### `args`
     // - `*Player`
     // - `*PlayState`
+    // - `*Input` (sControlInput)
+    // - `s32` (sFloorType)
     VB_PLAYER_ROLL_CHAIN,
 
     // #### `result`

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -461,10 +461,9 @@ void SohMenu::AddMenuEnhancements() {
     AddWidget(path, "Improved Roll Steering", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("ImprovedRollSteering"))
         .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("ImprovedRoll"), 0); })
-        .Options(
-            CheckboxOptions().Tooltip("Allows slight directional steering with the control stick while rolling. "
-                                      "WARNING: This will interfere with glitch setups that rely on Z-target rolls, "
-                                      "as it modifies the roll's facing direction each frame."));
+        .Options(CheckboxOptions().Tooltip(
+            "Allows slight directional steering with the control stick while rolling. "
+            "Steering is automatically disabled while Z is held, preserving Z-target roll glitch setups."));
     AddWidget(path, "Skip Water Take Breath Animation", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("SkipSwimDeepEndAnim"))
         .Options(CheckboxOptions().Tooltip("Skips Link's taking breath animation after coming up from water. "

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -454,6 +454,17 @@ void SohMenu::AddMenuEnhancements() {
         .CVar(CVAR_ENHANCEMENT("FastChests"))
         .Options(CheckboxOptions().Tooltip("Makes Link always kick the chest to open it, instead of doing the longer "
                                            "chest opening animation for major items."));
+    AddWidget(path, "Improved Roll", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("ImprovedRoll"))
+        .Options(CheckboxOptions().Tooltip(
+            "Allows Link to chain a new roll by pressing A during a roll, maintaining maximum roll speed."));
+    AddWidget(path, "Improved Roll Steering", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("ImprovedRollSteering"))
+        .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("ImprovedRoll"), 0); })
+        .Options(
+            CheckboxOptions().Tooltip("Allows slight directional steering with the control stick while rolling. "
+                                      "WARNING: This will interfere with glitch setups that rely on Z-target rolls, "
+                                      "as it modifies the roll's facing direction each frame."));
     AddWidget(path, "Skip Water Take Breath Animation", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("SkipSwimDeepEndAnim"))
         .Options(CheckboxOptions().Tooltip("Skips Link's taking breath animation after coming up from water. "

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -9853,11 +9853,7 @@ void Player_Action_Roll(Player* this, PlayState* play) {
                 }
             }
 
-            if ((this->skelAnime.curFrame >= 15.0f) && CHECK_BTN_ALL(sControlInput->press.button, BTN_A) &&
-                (sFloorType != 7) && GameInteractor_Should(VB_PLAYER_ROLL_CHAIN, false, this, play)) {
-                Player_SetupRoll(this, play);
-                return;
-            }
+            if (GameInteractor_Should(VB_PLAYER_ROLL_CHAIN, false, this, play, sControlInput, sFloorType)) { return; }
 
             if ((this->skelAnime.curFrame < 15.0f) || !Player_ActionHandler_7(this, play)) {
                 if (this->skelAnime.curFrame >= 20.0f) {

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -9853,6 +9853,12 @@ void Player_Action_Roll(Player* this, PlayState* play) {
                 }
             }
 
+            if ((this->skelAnime.curFrame >= 15.0f) && CHECK_BTN_ALL(sControlInput->press.button, BTN_A) &&
+                (sFloorType != 7) && GameInteractor_Should(VB_PLAYER_ROLL_CHAIN, false, this, play)) {
+                Player_SetupRoll(this, play);
+                return;
+            }
+
             if ((this->skelAnime.curFrame < 15.0f) || !Player_ActionHandler_7(this, play)) {
                 if (this->skelAnime.curFrame >= 20.0f) {
                     func_8083A060(this, play);
@@ -9871,6 +9877,7 @@ void Player_Action_Roll(Player* this, PlayState* play) {
                     speedTarget = 3.0f;
                 }
 
+                GameInteractor_Should(VB_PLAYER_ROLL_STEER, false, this, play, yawTarget);
                 func_8083DF68(this, speedTarget, this->actor.shape.rot.y);
 
                 if (func_8084269C(play, this)) {

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -9853,7 +9853,9 @@ void Player_Action_Roll(Player* this, PlayState* play) {
                 }
             }
 
-            if (GameInteractor_Should(VB_PLAYER_ROLL_CHAIN, false, this, play, sControlInput, sFloorType)) { return; }
+            if (GameInteractor_Should(VB_PLAYER_ROLL_CHAIN, false, this, play, sControlInput, sFloorType)) {
+                return;
+            }
 
             if ((this->skelAnime.curFrame < 15.0f) || !Player_ActionHandler_7(this, play)) {
                 if (this->skelAnime.curFrame >= 20.0f) {


### PR DESCRIPTION
This PR adds an option to have improved rolling capabilities.

It is 2 stage cvar.

First cvar enables it so player can reroll during a roll by pressing A at the end of a roll window.

Second cvar enables the ability to steer during rolling. Reason why this is separated is that roll steering interferes with glitch setups during z-targeting. I have added a z target protection so steering cant happen if Z is held. Im still feeling it should be a separate cvar. I have tested and succesfully done the King zora skip clip as child with this enabled.


https://github.com/user-attachments/assets/3904734f-d28a-4dfd-b886-cce122c37d3b


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6914528134.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6914473561.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/6914299499.zip)
<!--- section:artifacts:end -->