### PR TITLE
Clean OTRGlobals 2

### DIFF
--- a/soh/soh/Enhancements/Cheats/Infinite/Ammo.cpp
+++ b/soh/soh/Enhancements/Cheats/Infinite/Ammo.cpp
@@ -1,5 +1,6 @@
 #include <libultraship/bridge.h>
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 #include "soh/OTRGlobals.h"
 #include "soh/ShipInit.hpp"
 #include "z64save.h"

--- a/soh/soh/Enhancements/Difficulty/PermanentLosses.cpp
+++ b/soh/soh/Enhancements/Difficulty/PermanentLosses.cpp
@@ -1,4 +1,5 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 #include "soh/OTRGlobals.h"
 #include "soh/SaveManager.h"
 #include "soh/ShipInit.hpp"

--- a/soh/soh/Enhancements/InjectItemCounts.cpp
+++ b/soh/soh/Enhancements/InjectItemCounts.cpp
@@ -1,4 +1,5 @@
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/soh/soh/Enhancements/Items/BetterBombchuShopping.cpp
+++ b/soh/soh/Enhancements/Items/BetterBombchuShopping.cpp
@@ -1,4 +1,5 @@
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <variables.h>

--- a/soh/soh/Enhancements/NoSkulltulaFreeze.cpp
+++ b/soh/soh/Enhancements/NoSkulltulaFreeze.cpp
@@ -1,4 +1,5 @@
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/soh/soh/Enhancements/Presets/Presets.cpp
+++ b/soh/soh/Enhancements/Presets/Presets.cpp
@@ -7,12 +7,15 @@
 #include <libultraship/libultraship.h>
 #include <ship/resource/type/Json.h>
 #include "soh/OTRGlobals.h"
+#include "soh/util.h"
 #include "soh/SohGui/MenuTypes.h"
 #include "soh/SohGui/SohMenu.h"
 #include "soh/SohGui/SohGui.hpp"
 #include "soh/Enhancements/randomizer/randomizer_check_tracker.h"
 #include "soh/Enhancements/randomizer/randomizer_entrance_tracker.h"
 #include "soh/Enhancements/randomizer/randomizer_item_tracker.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
+#include "soh/Enhancements/randomizer/settings.h"
 
 namespace fs = std::filesystem;
 

--- a/soh/soh/Enhancements/QoL/OpenAllHours.cpp
+++ b/soh/soh/Enhancements/QoL/OpenAllHours.cpp
@@ -1,4 +1,5 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 #include "soh/OTRGlobals.h"
 #include "soh/ShipInit.hpp"
 

--- a/soh/soh/Enhancements/TimeSavers/MarketSneak.cpp
+++ b/soh/soh/Enhancements/TimeSavers/MarketSneak.cpp
@@ -1,4 +1,5 @@
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <variables.h>

--- a/soh/soh/Enhancements/TimeSavers/QuitFishingAtDoor.cpp
+++ b/soh/soh/Enhancements/TimeSavers/QuitFishingAtDoor.cpp
@@ -1,4 +1,5 @@
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <variables.h>

--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -15,6 +15,7 @@
 #include "AudioCollection.h"
 #include "soh/Enhancements/enhancementTypes.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 
 extern "C" {
 #include "z64save.h"

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -14,6 +14,7 @@
 #include "soh/OTRGlobals.h"
 #include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/enhancementTypes.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 
 extern "C" {
 #include "z64.h"

--- a/soh/soh/Enhancements/cosmetics/NoMasterSword.cpp
+++ b/soh/soh/Enhancements/cosmetics/NoMasterSword.cpp
@@ -1,4 +1,5 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 #include "soh/ShipInit.hpp"
 #include "soh/OTRGlobals.h"
 #include "soh/ResourceManagerHelpers.h"

--- a/soh/soh/Enhancements/debugconsole.cpp
+++ b/soh/soh/Enhancements/debugconsole.cpp
@@ -12,6 +12,7 @@
 #include "soh/Enhancements/cosmetics/CosmeticsEditor.h"
 #include "soh/Enhancements/audio/AudioEditor.h"
 #include "soh/Enhancements/randomizer/logic.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 #define Path _Path
 #define PATH_HACK

--- a/soh/soh/Enhancements/debugger/SohGfxDebuggerWindow.cpp
+++ b/soh/soh/Enhancements/debugger/SohGfxDebuggerWindow.cpp
@@ -1,5 +1,7 @@
 #include "SohGfxDebuggerWindow.h"
 #include "soh/OTRGlobals.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "soh/cvar_prefixes.h"
 
 void SohGfxDebuggerWindow::InitElement() {
     GfxDebuggerWindow::InitElement();

--- a/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
+++ b/soh/soh/Enhancements/debugger/debugSaveEditor.cpp
@@ -1,5 +1,6 @@
 #include "debugSaveEditor.h"
 #include "soh/Enhancements/randomizer/randomizerTypes.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 #include "soh/util.h"
 #include "soh/SohGui/ImGuiUtils.h"
 #include "soh/OTRGlobals.h"

--- a/soh/soh/Enhancements/debugger/valueViewer.cpp
+++ b/soh/soh/Enhancements/debugger/valueViewer.cpp
@@ -3,6 +3,7 @@
 #include "soh/SohGui/SohGui.hpp"
 #include "soh/OTRGlobals.h"
 #include "soh/ShipInit.hpp"
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
 
 extern "C" {
 #include <spdlog/spdlog.h>

--- a/soh/soh/Enhancements/kaleido.cpp
+++ b/soh/soh/Enhancements/kaleido.cpp
@@ -3,6 +3,7 @@
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "ship/utils/StringHelper.h"
 #include "soh/Enhancements/randomizer/randomizerTypes.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 #include "soh/ShipInit.hpp"
 #include "soh/ShipUtils.h"
 

--- a/soh/soh/Enhancements/randomizer/BigPoes.cpp
+++ b/soh/soh/Enhancements/randomizer/BigPoes.cpp
@@ -1,4 +1,5 @@
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/soh/soh/Enhancements/randomizer/Bombchus.cpp
+++ b/soh/soh/Enhancements/randomizer/Bombchus.cpp
@@ -1,6 +1,7 @@
 #include <soh/OTRGlobals.h>
 #include "soh/ShipInit.hpp"
 #include "src/overlays/actors/ovl_En_GirlA/z_en_girla.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 
 extern "C" {
 #include "z64save.h"

--- a/soh/soh/Enhancements/randomizer/ColoredMapsAndCompasses.cpp
+++ b/soh/soh/Enhancements/randomizer/ColoredMapsAndCompasses.cpp
@@ -5,6 +5,7 @@
 #include "objects/object_gi_compass/object_gi_compass.h"
 #include "objects/object_gi_map/object_gi_map.h"
 #include "soh/OTRGlobals.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 
 extern "C" {
 #include "variables.h"

--- a/soh/soh/Enhancements/randomizer/LockOverworldDoors.cpp
+++ b/soh/soh/Enhancements/randomizer/LockOverworldDoors.cpp
@@ -1,6 +1,7 @@
 #include <libultraship/libultraship.h>
 #include "soh/OTRGlobals.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 #include "soh/ShipInit.hpp"
 
 extern "C" {

--- a/soh/soh/Enhancements/randomizer/MedallionLockedTrials.cpp
+++ b/soh/soh/Enhancements/randomizer/MedallionLockedTrials.cpp
@@ -1,5 +1,6 @@
 #include "soh/OTRGlobals.h"
 #include "soh/ShipInit.hpp"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 
 extern "C" {
 extern PlayState* gPlayState;

--- a/soh/soh/Enhancements/randomizer/Messages/EntranceHints.cpp
+++ b/soh/soh/Enhancements/randomizer/Messages/EntranceHints.cpp
@@ -1,5 +1,6 @@
 #include "soh/Enhancements/randomizer/entrance.h"
 #include "soh/Enhancements/randomizer/randomizer_entrance_tracker.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 #include <soh/OTRGlobals.h>
 
 extern "C" {

--- a/soh/soh/Enhancements/randomizer/Messages/Goron.cpp
+++ b/soh/soh/Enhancements/randomizer/Messages/Goron.cpp
@@ -3,6 +3,7 @@
  * trapped Gorons have when you free them.
  */
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <variables.h>

--- a/soh/soh/Enhancements/randomizer/Messages/GossipStoneHints.cpp
+++ b/soh/soh/Enhancements/randomizer/Messages/GossipStoneHints.cpp
@@ -3,6 +3,7 @@
  * hints.
  */
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 extern PlayState* gPlayState;

--- a/soh/soh/Enhancements/randomizer/Messages/ItemMessages.cpp
+++ b/soh/soh/Enhancements/randomizer/Messages/ItemMessages.cpp
@@ -10,6 +10,7 @@
 #include "soh/Enhancements/custom-message/CustomMessageTypes.h"
 #include "soh/Enhancements/randomizer/Traps.h"
 #include "soh/Enhancements/randomizer/item.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 #include "soh/ShipInit.hpp"
 #include <soh/ResourceManagerHelpers.h>
 

--- a/soh/soh/Enhancements/randomizer/Messages/MerchantMessages.cpp
+++ b/soh/soh/Enhancements/randomizer/Messages/MerchantMessages.cpp
@@ -8,6 +8,7 @@
  */
 #include <soh/OTRGlobals.h>
 #include "soh/ObjectExtension/ObjectExtension.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 extern PlayState* gPlayState;

--- a/soh/soh/Enhancements/randomizer/Messages/Miscellaneous.cpp
+++ b/soh/soh/Enhancements/randomizer/Messages/Miscellaneous.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <variables.h>

--- a/soh/soh/Enhancements/randomizer/Messages/Navi.cpp
+++ b/soh/soh/Enhancements/randomizer/Messages/Navi.cpp
@@ -3,6 +3,7 @@
  * for the Rando-Relevant Navi Hints enhancement.
  */
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <variables.h>

--- a/soh/soh/Enhancements/randomizer/Messages/Rupees.cpp
+++ b/soh/soh/Enhancements/randomizer/Messages/Rupees.cpp
@@ -2,6 +2,7 @@
  * This file is for handling the Randomize Rupee Names enhancement
  */
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/soh/soh/Enhancements/randomizer/Messages/StaticHints.cpp
+++ b/soh/soh/Enhancements/randomizer/Messages/StaticHints.cpp
@@ -8,6 +8,7 @@
 #include "soh/Enhancements/randomizer/randomizerTypes.h"
 #include "z64scene.h"
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 extern PlayState* gPlayState;

--- a/soh/soh/Enhancements/randomizer/RocsFeather.cpp
+++ b/soh/soh/Enhancements/randomizer/RocsFeather.cpp
@@ -1,5 +1,6 @@
 #include <soh/OTRGlobals.h>
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 #include "soh/ShipInit.hpp"
 #include <soh_assets.h>
 

--- a/soh/soh/Enhancements/randomizer/SeedContext.cpp
+++ b/soh/soh/Enhancements/randomizer/SeedContext.cpp
@@ -13,6 +13,7 @@
 #include "soh/util.h"
 #include "../kaleido.h"
 #include "soh/Enhancements/randomizer/Traps.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 #include <fstream>
 #include <spdlog/spdlog.h>

--- a/soh/soh/Enhancements/randomizer/ShuffleBeehives.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleBeehives.cpp
@@ -1,6 +1,7 @@
 #include <soh/OTRGlobals.h>
 #include "static_data.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "src/overlays/actors/ovl_Obj_Comb/z_obj_comb.h"

--- a/soh/soh/Enhancements/randomizer/ShuffleBeggar.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleBeggar.cpp
@@ -1,4 +1,5 @@
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "overlays/actors/ovl_En_Hy/z_en_hy.h"

--- a/soh/soh/Enhancements/randomizer/ShuffleCows.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleCows.cpp
@@ -1,5 +1,6 @@
 #include <soh/OTRGlobals.h>
 #include "static_data.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "src/overlays/actors/ovl_En_Cow/z_en_cow.h"

--- a/soh/soh/Enhancements/randomizer/ShuffleCrates.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleCrates.cpp
@@ -5,6 +5,7 @@
 #include "global.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
 #include "item_category_adj.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/soh/soh/Enhancements/randomizer/ShuffleFairies.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleFairies.cpp
@@ -5,6 +5,7 @@
 #include "static_data.h"
 #include "soh/Enhancements/item-tables/ItemTableTypes.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "src/overlays/actors/ovl_En_Elf/z_en_elf.h"

--- a/soh/soh/Enhancements/randomizer/ShuffleFreestanding.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleFreestanding.cpp
@@ -1,4 +1,5 @@
 #include <soh/OTRGlobals.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/soh/soh/Enhancements/randomizer/ShuffleGrass.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleGrass.cpp
@@ -3,6 +3,7 @@
 #include "static_data.h"
 #include "item_category_adj.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/soh/soh/Enhancements/randomizer/ShuffleIcicles.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleIcicles.cpp
@@ -2,6 +2,7 @@
 #include "item_category_adj.h"
 #include "particle_cmc.h"
 #include "soh/frame_interpolation.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "functions.h"

--- a/soh/soh/Enhancements/randomizer/ShufflePots.cpp
+++ b/soh/soh/Enhancements/randomizer/ShufflePots.cpp
@@ -3,6 +3,7 @@
 #include "static_data.h"
 #include "item_category_adj.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.h"

--- a/soh/soh/Enhancements/randomizer/ShuffleRedIce.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleRedIce.cpp
@@ -2,6 +2,7 @@
 #include "soh/ObjectExtension/ObjectExtension.h"
 #include "item_category_adj.h"
 #include "particle_cmc.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "functions.h"

--- a/soh/soh/Enhancements/randomizer/ShuffleRocks.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleRocks.cpp
@@ -4,6 +4,7 @@
 #include "item_category_adj.h"
 #include "particle_cmc.h"
 #include "soh/frame_interpolation.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/soh/soh/Enhancements/randomizer/ShuffleSigns.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleSigns.cpp
@@ -2,6 +2,8 @@
 #include "soh/ObjectExtension/ObjectExtension.h"
 #include "item_category_adj.h"
 #include "particle_cmc.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
+
 extern "C" {
 extern PlayState* gPlayState;
 #include "overlays/actors/ovl_En_Kanban/z_en_kanban.h"

--- a/soh/soh/Enhancements/randomizer/ShuffleSpeak.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleSpeak.cpp
@@ -1,8 +1,10 @@
 #include <soh/OTRGlobals.h>
+#include "z64.h"
+#include "functions.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
+#include "overlays/actors/ovl_En_Ossan/z_en_ossan.h"
 extern "C" {
 extern PlayState* gPlayState;
-#include "functions.h"
-#include "overlays/actors/ovl_En_Ossan/z_en_ossan.h"
 }
 
 void RegisterShuffleSpeak() {

--- a/soh/soh/Enhancements/randomizer/ShuffleTrees.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleTrees.cpp
@@ -3,6 +3,7 @@
 #include "static_data.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
 #include "item_category_adj.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/soh/soh/Enhancements/randomizer/ShuffleWonderItems.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleWonderItems.cpp
@@ -5,6 +5,7 @@
 #include "soh/ObjectExtension/ActorListIndex.h"
 #include "item_category_adj.h"
 #include "particle_cmc.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.h"

--- a/soh/soh/Enhancements/randomizer/draw.cpp
+++ b/soh/soh/Enhancements/randomizer/draw.cpp
@@ -5,6 +5,7 @@
 #include "soh_assets.h"
 #include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/cosmetics/cosmeticsTypes.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "z64.h"

--- a/soh/soh/Enhancements/randomizer/fishsanity.cpp
+++ b/soh/soh/Enhancements/randomizer/fishsanity.cpp
@@ -6,6 +6,8 @@
 #include "functions.h"
 #include "macros.h"
 #include <libultraship/bridge/consolevariablebridge.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
+#include "soh/Enhancements/randomizer/randomizerTypes.h"
 
 extern "C" {
 #include "src/overlays/actors/ovl_Fishing/z_fishing.h"

--- a/soh/soh/Enhancements/randomizer/fishsanity.h
+++ b/soh/soh/Enhancements/randomizer/fishsanity.h
@@ -25,6 +25,8 @@ typedef enum {
 } FishsanityCheckType;
 
 #ifdef __cplusplus
+#include "soh/Enhancements/randomizer/location.h"
+
 namespace Rando {
 
 /**

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -14,6 +14,7 @@
 #include "soh/ShipInit.hpp"
 #include "soh/ObjectExtension/ObjectExtension.h"
 #include "item_category_adj.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "macros.h"

--- a/soh/soh/Enhancements/randomizer/item.cpp
+++ b/soh/soh/Enhancements/randomizer/item.cpp
@@ -9,6 +9,7 @@
 #include "macros.h"
 #include "functions.h"
 #include "../../OTRGlobals.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 namespace Rando {
 Item::Item()

--- a/soh/soh/Enhancements/randomizer/particle_cmc.h
+++ b/soh/soh/Enhancements/randomizer/particle_cmc.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <ship/utils/color.h>
 #include "soh/OTRGlobals.h"
+#include "soh/Enhancements/item-tables/ItemTableTypes.h"
 
 #ifndef PARTICLE_CMC_H
 #define PARTICLE_CMC_H

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -14,6 +14,7 @@
 #include "location_access.h"
 #include "3drando/fill.hpp"
 #include "soh/Enhancements/debugger/performanceTimer.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 #include <string>
 #include <sstream>

--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <libultraship/controller/controldeck/ControlDeck.h>
 #include <libultraship/libultraship.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <z64.h>

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -18,6 +18,7 @@
 #include "soh/SohGui/SohMenu.h"
 #include "soh/SohGui/UIWidgets.hpp"
 #include "soh/util.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <z64.h>

--- a/soh/soh/Enhancements/randomizer/savefile.cpp
+++ b/soh/soh/Enhancements/randomizer/savefile.cpp
@@ -3,6 +3,7 @@
 #include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/randomizer/logic.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include <z64.h>

--- a/soh/soh/Network/Anchor/Anchor.cpp
+++ b/soh/soh/Network/Anchor/Anchor.cpp
@@ -4,6 +4,7 @@
 #include "soh/OTRGlobals.h"
 #include "soh/Enhancements/nametag.h"
 #include "soh/ObjectExtension/ObjectExtension.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/soh/soh/Network/Anchor/AnchorRoomWindow.cpp
+++ b/soh/soh/Network/Anchor/AnchorRoomWindow.cpp
@@ -1,5 +1,7 @@
 #include "Anchor.h"
 #include "soh/OTRGlobals.h"
+#include "soh/util.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 
 extern "C" {
 #include "variables.h"

--- a/soh/soh/Network/Anchor/Packets/SetCheckStatus.cpp
+++ b/soh/soh/Network/Anchor/Packets/SetCheckStatus.cpp
@@ -3,6 +3,7 @@
 #include <libultraship/libultraship.h>
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/OTRGlobals.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 static bool isResultOfHandling = false;
 

--- a/soh/soh/Network/Anchor/Packets/UpdateClientState.cpp
+++ b/soh/soh/Network/Anchor/Packets/UpdateClientState.cpp
@@ -3,6 +3,7 @@
 #include <nlohmann/json.hpp>
 #include <libultraship/libultraship.h>
 #include "soh/OTRGlobals.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 
 extern "C" {
 #include "variables.h"

--- a/soh/soh/Network/Anchor/Packets/UpdateTeamState.cpp
+++ b/soh/soh/Network/Anchor/Packets/UpdateTeamState.cpp
@@ -4,6 +4,7 @@
 #include <libultraship/libultraship.h>
 #include "soh/OTRGlobals.h"
 #include "soh/Notification/Notification.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "variables.h"

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1796,8 +1796,6 @@ extern "C" void Graph_ProcessGfxCommands(Gfx* commands) {
          OTRGlobals::Instance->context->lastScancode = -1;*/
 }
 
-float divisor_num = 0.0f;
-
 extern "C" void OTRGetPixelDepthPrepare(float x, float y) {
     auto wnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow());
     if (wnd == nullptr) {
@@ -1825,62 +1823,6 @@ extern "C" uint8_t GetSeedIconIndex(uint8_t index) {
 }
 
 std::map<std::string, SoundFontSample*> cachedCustomSFs;
-
-extern "C" SoundFontSample* ReadCustomSample(const char* path) {
-    return nullptr;
-    /*
-    if (!ExtensionCache.contains(path))
-        return nullptr;
-
-    ExtensionEntry entry = ExtensionCache[path];
-
-    auto sampleRaw = Ship::Context::GetInstance()->GetResourceManager()->LoadFile(entry.path);
-    uint32_t* strem = (uint32_t*)sampleRaw->Buffer.get();
-    uint8_t* strem2 = (uint8_t*)strem;
-
-    SoundFontSample* sampleC = new SoundFontSample;
-
-    if (entry.ext == "wav") {
-        drwav_uint32 channels;
-        drwav_uint32 sampleRate;
-        drwav_uint64 totalPcm;
-        drmp3_int16* pcmData =
-            drwav_open_memory_and_read_pcm_frames_s16(strem2, sampleRaw->BufferSize, &channels, &sampleRate, &totalPcm,
-    NULL); sampleC->size = totalPcm; sampleC->sampleAddr = (uint8_t*)pcmData; sampleC->codec = CODEC_S16;
-
-        sampleC->loop = new AdpcmLoop;
-        sampleC->loop->start = 0;
-        sampleC->loop->end = sampleC->size - 1;
-        sampleC->loop->count = 0;
-        sampleC->sampleRateMagicValue = 'RIFF';
-        sampleC->sampleRate = sampleRate;
-
-        cachedCustomSFs[path] = sampleC;
-        return sampleC;
-    } else if (entry.ext == "mp3") {
-        drmp3_config mp3Info;
-        drmp3_uint64 totalPcm;
-        drmp3_int16* pcmData =
-            drmp3_open_memory_and_read_pcm_frames_s16(strem2, sampleRaw->BufferSize, &mp3Info, &totalPcm, NULL);
-
-        sampleC->size = totalPcm * mp3Info.channels * sizeof(short);
-        sampleC->sampleAddr = (uint8_t*)pcmData;
-        sampleC->codec = CODEC_S16;
-
-        sampleC->loop = new AdpcmLoop;
-        sampleC->loop->start = 0;
-        sampleC->loop->end = sampleC->size;
-        sampleC->loop->count = 0;
-        sampleC->sampleRateMagicValue = 'RIFF';
-        sampleC->sampleRate = mp3Info.sampleRate;
-
-        cachedCustomSFs[path] = sampleC;
-        return sampleC;
-    }
-
-    return nullptr;
-    */
-}
 
 ImFont* OTRGlobals::CreateFontWithSize(float size, std::string fontPath, bool isJapaneseFont) {
     auto mImGuiIo = &ImGui::GetIO();
@@ -2510,11 +2452,7 @@ bool SoH_HandleConfigDrop(char* filePath) {
     return false;
 }
 
-extern "C" uint32_t Ship_GetInterpolationFPS() {
-    return OTRGlobals::Instance->GetInterpolationFPS();
-}
-
 // Number of interpolated frames
 extern "C" uint32_t Ship_GetInterpolationFrameCount() {
-    return ceil((float)Ship_GetInterpolationFPS() / 20.0f);
+    return ceil((float)OTRGlobals::Instance->GetInterpolationFPS() / 20.0f);
 }

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -7,9 +7,11 @@
 #include <vector>
 #include <chrono>
 #include <optional>
+#include <imgui.h>
 
 #include "ResourceManagerHelpers.h"
 #include <fast/Fast3dWindow.h>
+#include <ship/Context.h>
 #include <ship/resource/File.h>
 #include <ship/window/Window.h>
 #include <soh/GameVersions.h>
@@ -32,6 +34,7 @@
 #include "Enhancements/randomizer/static_data.h"
 #include "soh/Enhancements/randomizer/settings.h"
 #include "Enhancements/gameplaystats.h"
+#include "soh/Enhancements/savestates.h"
 #include "frame_interpolation.h"
 #include "SohGui/SohMenu.h"
 #include "SohGui/SohGui.hpp"
@@ -123,6 +126,14 @@
 
 #include "soh/config/ConfigUpdaters.h"
 #include "soh/ShipInit.hpp"
+
+#ifdef __WIIU__
+const uint32_t defaultImGuiScale = 3;
+#else
+const uint32_t defaultImGuiScale = 1;
+#endif
+
+const float imguiScaleOptionToValue[4] = { 0.75f, 1.0f, 1.5f, 2.0f };
 
 bool SoH_HandleConfigDrop(char* filePath);
 
@@ -965,25 +976,6 @@ void OTRGlobals::ScaleImGui() {
     previousImGuiScaleIndex = imGuiScaleIndex;
 }
 
-ImFont* OTRGlobals::CreateDefaultFontWithSize(float size) {
-    auto mImGuiIo = &ImGui::GetIO();
-    ImFontConfig fontCfg = ImFontConfig();
-    fontCfg.OversampleH = fontCfg.OversampleV = 1;
-    fontCfg.PixelSnapH = true;
-    fontCfg.SizePixels = size;
-    ImFont* font = mImGuiIo->Fonts->AddFontDefault(&fontCfg);
-    // FontAwesome fonts need to have their sizes reduced by 2.0f/3.0f in order to align correctly
-    float iconFontSize = size * 2.0f / 3.0f;
-    static const ImWchar sIconsRanges[] = { ICON_MIN_FA, ICON_MAX_16_FA, 0 };
-    ImFontConfig iconsConfig;
-    iconsConfig.MergeMode = true;
-    iconsConfig.PixelSnapH = true;
-    iconsConfig.GlyphMinAdvanceX = iconFontSize;
-    mImGuiIo->Fonts->AddFontFromMemoryCompressedBase85TTF(fontawesome_compressed_data_base85, iconFontSize,
-                                                          &iconsConfig, sIconsRanges);
-    return font;
-}
-
 bool OTRGlobals::HasMasterQuest() {
     return hasMasterQuest;
 }
@@ -1006,7 +998,7 @@ uint32_t OTRGlobals::GetInterpolationFPS() {
 extern "C" void OTRMessage_Init();
 extern "C" void AudioMgr_CreateNextAudioBuffer(s16* samples, u32 num_samples);
 extern "C" void AudioPlayer_Play(const uint8_t* buf, uint32_t len);
-extern "C" int AudioPlayer_Buffered(void);
+int AudioPlayer_Buffered(void);
 extern "C" int AudioPlayer_GetDesiredBuffered(void);
 std::unordered_map<std::string, ExtensionEntry> ExtensionCache;
 
@@ -1050,8 +1042,7 @@ void OTRAudio_Thread() {
     }
 }
 
-// C->C++ Bridge
-extern "C" void OTRAudio_Init() {
+void OTRAudio_Init() {
     // Precache all our samples, sequences, etc...
     ResourceMgr_LoadDirectory("audio");
 
@@ -1061,6 +1052,7 @@ extern "C" void OTRAudio_Init() {
     }
 }
 
+// C->C++ Bridge
 extern "C" char** sequenceMap;
 extern "C" size_t sequenceMapSize;
 
@@ -1092,7 +1084,7 @@ extern "C" void OTRAudio_Exit() {
 #endif
 }
 
-extern "C" void VanillaItemTable_Init() {
+void VanillaItemTable_Init() {
     static GetItemEntry getItemTable[] = {
         // clang-format off
         GET_ITEM(ITEM_BOMBS_5,          OBJECT_GI_BOMB_1,        GID_BOMB,             0x32, 0x59, CHEST_ANIM_SHORT, ITEM_CATEGORY_JUNK,            MOD_NONE, GI_BOMBS_5),
@@ -1942,20 +1934,6 @@ std::filesystem::path GetSaveFile() {
     return GetSaveFile(pConf);
 }
 
-void OTRGlobals::CheckSaveFile(size_t sramSize) const {
-    const std::shared_ptr<Ship::Config> pConf = Instance->context->GetConfig();
-
-    std::filesystem::path savePath = GetSaveFile(pConf);
-    std::fstream saveFile(savePath, std::fstream::in | std::fstream::out | std::fstream::binary);
-    if (saveFile.fail()) {
-        saveFile.open(savePath, std::fstream::in | std::fstream::out | std::fstream::binary | std::fstream::app);
-        for (size_t i = 0; i < sramSize; i++) {
-            saveFile.write("\0", 1);
-        }
-    }
-    saveFile.close();
-}
-
 extern "C" void Ctx_ReadSaveFile(uintptr_t addr, void* dramAddr, size_t size) {
     SaveManager::ReadSaveFile(GetSaveFile(), addr, dramAddr, size);
 }
@@ -2080,14 +2058,6 @@ extern "C" void OTRGfxPrint(const char* str, void* printer, void (*printImpl)(vo
             }
         }
     }
-}
-
-extern "C" uint32_t OTRGetCurrentWidth() {
-    return OTRGlobals::Instance->context->GetWindow()->GetWidth();
-}
-
-extern "C" uint32_t OTRGetCurrentHeight() {
-    return OTRGlobals::Instance->context->GetWindow()->GetHeight();
 }
 
 Color_RGB8 GetColorForControllerLED() {
@@ -2261,7 +2231,7 @@ extern "C" int16_t OTRGetRectDimensionFromRightEdge(float v) {
     return ((int)ceilf(OTRGetDimensionFromRightEdge(v)));
 }
 
-extern "C" int AudioPlayer_Buffered(void) {
+int AudioPlayer_Buffered(void) {
     return AudioPlayerBuffered();
 }
 
@@ -2349,10 +2319,6 @@ extern "C" void Randomizer_ParseSpoiler(const char* fileLoc) {
     OTRGlobals::Instance->gRandoContext->ParseSpoiler(fileLoc);
 }
 
-extern "C" bool Randomizer_IsTrialRequired(s32 trialFlag) {
-    return OTRGlobals::Instance->gRandomizer->IsTrialRequired(trialFlag);
-}
-
 extern "C" u32 SpoilerFileExists(const char* spoilerFileName) {
     return OTRGlobals::Instance->gRandomizer->SpoilerFileExists(spoilerFileName);
 }
@@ -2381,15 +2347,6 @@ extern "C" GetItemEntry ItemTable_RetrieveEntry(s16 tableID, s16 getItemID) {
     return ItemTableManager::Instance->RetrieveItemEntry(tableID, getItemID);
 }
 
-extern "C" GetItemEntry Randomizer_GetItemFromActor(s16 actorId, s16 sceneNum, s16 actorParams, GetItemID ogId) {
-    return OTRGlobals::Instance->gRandomizer->GetItemFromActor(actorId, sceneNum, actorParams, ogId);
-}
-
-extern "C" GetItemEntry Randomizer_GetItemFromActorWithoutObtainabilityCheck(s16 actorId, s16 sceneNum, s16 actorParams,
-                                                                             GetItemID ogId) {
-    return OTRGlobals::Instance->gRandomizer->GetItemFromActor(actorId, sceneNum, actorParams, ogId, false);
-}
-
 extern "C" GetItemEntry Randomizer_GetItemFromKnownCheck(RandomizerCheck randomizerCheck, GetItemID ogId) {
     return OTRGlobals::Instance->gRandomizer->GetItemFromKnownCheck(randomizerCheck, ogId);
 }
@@ -2397,10 +2354,6 @@ extern "C" GetItemEntry Randomizer_GetItemFromKnownCheck(RandomizerCheck randomi
 extern "C" GetItemEntry Randomizer_GetItemFromKnownCheckWithoutObtainabilityCheck(RandomizerCheck randomizerCheck,
                                                                                   GetItemID ogId) {
     return OTRGlobals::Instance->gRandomizer->GetItemFromKnownCheck(randomizerCheck, ogId, false);
-}
-
-extern "C" RandomizerInf Randomizer_GetRandomizerInfFromCheck(RandomizerCheck randomizerCheck) {
-    return OTRGlobals::Instance->gRandomizer->GetRandomizerInfFromCheck(randomizerCheck);
 }
 
 extern "C" ItemObtainability Randomizer_GetItemObtainabilityFromRandomizerCheck(RandomizerCheck randomizerCheck) {
@@ -2417,10 +2370,6 @@ extern "C" GetItemEntry GetItemMystery() {
 
 extern "C" uint8_t Randomizer_IsSeedGenerated() {
     return OTRGlobals::Instance->gRandoContext->IsSeedGenerated() ? 1 : 0;
-}
-
-extern "C" void Randomizer_SetSeedGenerated(bool seedGenerated) {
-    OTRGlobals::Instance->gRandoContext->SetSeedGenerated(seedGenerated);
 }
 
 extern "C" uint8_t Randomizer_IsSpoilerLoaded() {
@@ -2559,10 +2508,6 @@ bool SoH_HandleConfigDrop(char* filePath) {
         return false;
     }
     return false;
-}
-
-extern "C" void CheckTracker_RecalculateAvailableChecks() {
-    CheckTracker::RecalculateAvailableChecks();
 }
 
 extern "C" uint32_t Ship_GetInterpolationFPS() {

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -30,6 +30,7 @@
 #include "Enhancements/randomizer/randomizer_entrance_tracker.h"
 #include "Enhancements/randomizer/randomizer_check_tracker.h"
 #include "Enhancements/randomizer/static_data.h"
+#include "soh/Enhancements/randomizer/settings.h"
 #include "Enhancements/gameplaystats.h"
 #include "frame_interpolation.h"
 #include "SohGui/SohMenu.h"

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -17,16 +17,11 @@
 
 #define M_PIf 3.14159265358979323846f
 #define M_PI_2f 1.57079632679489661923f // pi/2
-#define M_SQRT2f 1.41421356237309504880f
-#define M_SQRT1_2f 0.70710678118654752440f /* 1/sqrt(2) */
 
 #ifdef __cplusplus
-#include <ship/Context.h>
-#include "Enhancements/savestates.h"
-#include <memory>
+#include <memory> // for shared_ptr
 #include <string>
-#include <vector>
-#include <imgui.h>
+#include <unordered_map>
 
 struct ExtensionEntry {
     std::string path;
@@ -37,19 +32,18 @@ extern std::unordered_map<std::string, ExtensionEntry> ExtensionCache;
 
 const std::string appShortName = "soh";
 
-#ifdef __WIIU__
-const uint32_t defaultImGuiScale = 3;
-#else
-const uint32_t defaultImGuiScale = 1;
-#endif
-
-const float imguiScaleOptionToValue[4] = { 0.75f, 1.0f, 1.5f, 2.0f };
-
 class Randomizer;
+class SaveStateMgr;
 
 namespace Rando {
     class Context;
 }
+
+namespace Ship {
+    class Context;
+}
+
+struct ImFont;
 
 class OTRGlobals {
   public:
@@ -80,10 +74,8 @@ class OTRGlobals {
     uint32_t GetInterpolationFPS();
 
   private:
-    void CheckSaveFile(size_t sramSize) const;
     bool hasMasterQuest;
     bool hasOriginal;
-    ImFont* CreateDefaultFontWithSize(float size);
     ImFont* CreateFontWithSize(float size, std::string fontPath, bool isJapaneseFont = false);
 };
 #endif
@@ -91,8 +83,6 @@ class OTRGlobals {
 #ifndef __cplusplus
 void InitOTR(int argc, char* argv[]);
 void DeinitOTR(void);
-void VanillaItemTable_Init();
-void OTRAudio_Init();
 void OTRMessage_Init();
 void Graph_StartFrame();
 void Graph_ProcessGfxCommands(Gfx* commands);
@@ -106,8 +96,6 @@ void Ctx_WriteSaveFile(uintptr_t addr, void* dramAddr, size_t size);
 uint64_t GetPerfCounter();
 uint64_t osGetTime(void);
 uint32_t osGetCount(void);
-uint32_t OTRGetCurrentWidth(void);
-uint32_t OTRGetCurrentHeight(void);
 float OTRGetAspectRatio(void);
 float OTRGetDimensionFromLeftEdge(float v);
 float OTRGetDimensionFromRightEdge(float v);
@@ -115,7 +103,6 @@ int16_t OTRGetRectDimensionFromLeftEdge(float v);
 int16_t OTRGetRectDimensionFromRightEdge(float v);
 uint32_t OTRGetGameRenderWidth();
 uint32_t OTRGetGameRenderHeight();
-int AudioPlayer_Buffered(void);
 int AudioPlayer_GetDesiredBuffered(void);
 void AudioPlayer_Play(const uint8_t* buf, uint32_t len);
 void AudioMgr_CreateNextAudioBuffer(s16* samples, u32 num_samples);
@@ -128,18 +115,12 @@ u8 Randomizer_GetSettingValue(RandomizerSettingKey randoSettingKey);
 RandomizerCheck Randomizer_GetCheckFromActor(s16 actorId, s16 sceneNum, s16 actorParams);
 ShopItemIdentity Randomizer_IdentifyShopItem(s32 sceneNum, u8 slotIndex);
 void Randomizer_ParseSpoiler(const char* fileLoc);
-bool Randomizer_IsTrialRequired(s32 trialFlag);
-GetItemEntry Randomizer_GetItemFromActor(s16 actorId, s16 sceneNum, s16 actorParams, GetItemID ogId);
-GetItemEntry Randomizer_GetItemFromActorWithoutObtainabilityCheck(s16 actorId, s16 sceneNum, s16 actorParams,
-                                                                  GetItemID ogId);
 GetItemEntry Randomizer_GetItemFromKnownCheck(RandomizerCheck randomizerCheck, GetItemID ogId);
 GetItemEntry Randomizer_GetItemFromKnownCheckWithoutObtainabilityCheck(RandomizerCheck randomizerCheck, GetItemID ogId);
-RandomizerInf Randomizer_GetRandomizerInfFromCheck(RandomizerCheck randomizerCheck);
 bool Randomizer_IsCheckShuffled(RandomizerCheck check);
 GetItemEntry GetItemMystery();
 ItemObtainability Randomizer_GetItemObtainabilityFromRandomizerCheck(RandomizerCheck randomizerCheck);
 uint8_t Randomizer_IsSeedGenerated();
-void Randomizer_SetSeedGenerated(bool seedGenerated);
 uint8_t Randomizer_IsSpoilerLoaded();
 void Randomizer_SetSpoilerLoaded(bool spoilerLoaded);
 uint8_t Randomizer_GenerateRandomizer();
@@ -152,13 +133,11 @@ void Gfx_RegisterBlendedTexture(const char* name, u8* mask, u8* replacement);
 void Gfx_UnregisterBlendedTexture(const char* name);
 void Gfx_TextureCacheDelete(const uint8_t* addr);
 void SaveManager_ThreadPoolWait();
-void CheckTracker_RecalculateAvailableChecks();
 
 GetItemID RetrieveGetItemIDFromItemID(ItemID itemID);
 RandomizerGet RetrieveRandomizerGetFromItemID(ItemID itemID);
 void Messagebox_ShowErrorBox(char* title, char* body);
 
-uint32_t Ship_GetInterpolationFPS();
 uint32_t Ship_GetInterpolationFrameCount();
 #endif
 

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -60,10 +60,6 @@ class OTRGlobals {
     std::shared_ptr<Randomizer> gRandomizer;
     std::shared_ptr<Rando::Context> gRandoContext;
 
-    ImFont* defaultFontSmaller;
-    ImFont* defaultFontLarger;
-    ImFont* defaultFontLargest;
-
     ImFont* fontMonoSmall = nullptr;
     ImFont* fontStandard = nullptr;
     ImFont* fontStandardLarger = nullptr;
@@ -82,7 +78,6 @@ class OTRGlobals {
     bool HasMasterQuest();
     bool HasOriginal();
     uint32_t GetInterpolationFPS();
-    std::shared_ptr<std::vector<std::string>> ListFiles(std::string path);
 
   private:
     void CheckSaveFile(size_t sramSize) const;
@@ -99,16 +94,11 @@ void DeinitOTR(void);
 void VanillaItemTable_Init();
 void OTRAudio_Init();
 void OTRMessage_Init();
-void InitAudio();
 void Graph_StartFrame();
 void Graph_ProcessGfxCommands(Gfx* commands);
-void Graph_ProcessFrame(void (*run_one_game_iter)(void));
-void OTRLogString(const char* src);
 void OTRGfxPrint(const char* str, void* printer, void (*printImpl)(void*, char));
 void OTRGetPixelDepthPrepare(float x, float y);
 uint16_t OTRGetPixelDepth(float x, float y);
-int32_t OTRGetLastScancode();
-char* GetResourceDataByNameHandlingMQ(const char* path);
 
 void Ctx_ReadSaveFile(uintptr_t addr, void* dramAddr, size_t size);
 void Ctx_WriteSaveFile(uintptr_t addr, void* dramAddr, size_t size);
@@ -130,8 +120,6 @@ int AudioPlayer_GetDesiredBuffered(void);
 void AudioPlayer_Play(const uint8_t* buf, uint32_t len);
 void AudioMgr_CreateNextAudioBuffer(s16* samples, u32 num_samples);
 int Controller_ShouldRumble(size_t slot);
-void Controller_BlockGameInput();
-void Controller_UnblockGameInput();
 size_t GetEquipNowMessage(char* buffer, char* src, const size_t maxBufferSize);
 u32 SpoilerFileExists(const char* spoilerFileName);
 Sprite* GetSeedTexture(uint8_t index);
@@ -164,7 +152,6 @@ void Gfx_RegisterBlendedTexture(const char* name, u8* mask, u8* replacement);
 void Gfx_UnregisterBlendedTexture(const char* name);
 void Gfx_TextureCacheDelete(const uint8_t* addr);
 void SaveManager_ThreadPoolWait();
-void CheckTracker_OnMessageClose();
 void CheckTracker_RecalculateAvailableChecks();
 
 GetItemID RetrieveGetItemIDFromItemID(ItemID itemID);

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -1,6 +1,3 @@
-#ifndef OTR_GLOBALS_H
-#define OTR_GLOBALS_H
-
 #pragma once
 
 #define BTN_CUSTOM_MODIFIER1 0x0040
@@ -147,6 +144,4 @@ extern "C" {
 uint64_t GetUnixTimestamp();
 #ifdef __cplusplus
 };
-#endif
-
 #endif

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -33,11 +33,11 @@ class Randomizer;
 class SaveStateMgr;
 
 namespace Rando {
-    class Context;
+class Context;
 }
 
 namespace Ship {
-    class Context;
+class Context;
 }
 
 struct ImFont;

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -23,9 +23,10 @@
 #ifdef __cplusplus
 #include <ship/Context.h>
 #include "Enhancements/savestates.h"
-#include "Enhancements/randomizer/randomizer.h"
-#include <vector>
+#include <memory>
 #include <string>
+#include <vector>
+#include <imgui.h>
 
 struct ExtensionEntry {
     std::string path;
@@ -33,7 +34,6 @@ struct ExtensionEntry {
 };
 
 extern std::unordered_map<std::string, ExtensionEntry> ExtensionCache;
-#include "Enhancements/randomizer/settings.h"
 
 const std::string appShortName = "soh";
 
@@ -44,6 +44,12 @@ const uint32_t defaultImGuiScale = 1;
 #endif
 
 const float imguiScaleOptionToValue[4] = { 0.75f, 1.0f, 1.5f, 2.0f };
+
+class Randomizer;
+
+namespace Rando {
+    class Context;
+}
 
 class OTRGlobals {
   public:

--- a/soh/soh/ResourceManagerHelpers.cpp
+++ b/soh/soh/ResourceManagerHelpers.cpp
@@ -5,6 +5,7 @@
 #include "cvar_prefixes.h"
 #include "Enhancements/enhancementTypes.h"
 #include "Enhancements/randomizer/dungeon.h"
+#include "soh/Enhancements/randomizer/SeedContext.h"
 #include <libultraship/libultraship.h>
 #include <soh/GameVersions.h>
 #include "resource/type/SohResourceType.h"

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -8,6 +8,7 @@
 #include "soh/util.h"
 #include "Enhancements/randomizer/hint.h"
 #include "Enhancements/randomizer/item.h"
+#include "soh/Enhancements/randomizer/settings.h"
 #include "ResourceManagerHelpers.h"
 
 #include "z64.h"

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -5,6 +5,7 @@
 #include <soh/OTRGlobals.h>
 #include <soh/Enhancements/cosmetics/authenticGfxPatches.h>
 #include <soh/Enhancements/TimeDisplay/TimeDisplay.h>
+#include "soh/Enhancements/randomizer/randomizer.h"
 
 extern "C" {
 #include "functions.h"

--- a/soh/soh/SohGui/SohMenuNetwork.cpp
+++ b/soh/soh/SohGui/SohMenuNetwork.cpp
@@ -3,6 +3,7 @@
 #include <soh/Network/Network.h>
 #include "SohGui.hpp"
 #include "soh/OTRGlobals.h"
+#include "soh/util.h"
 #include <soh/Network/Sail/Sail.h>
 #include <soh/Network/CrowdControl/CrowdControl.h>
 

--- a/soh/soh/SohGui/SohMenuRandomizer.cpp
+++ b/soh/soh/SohGui/SohMenuRandomizer.cpp
@@ -2,6 +2,7 @@
 #include "soh/Enhancements/enhancementTypes.h"
 #include "soh/Enhancements/randomizer/randomizer.h"
 #include "soh/Enhancements/randomizer/randomizerTypes.h"
+#include "soh/Enhancements/randomizer/settings.h"
 #include "soh/OTRGlobals.h"
 #include "soh/SohGui/SohGui.hpp"
 

--- a/soh/soh/resource/importer/PathFactory.cpp
+++ b/soh/soh/resource/importer/PathFactory.cpp
@@ -3,6 +3,7 @@
 #include "soh/resource/logging/PathLogger.h"
 #include "spdlog/spdlog.h"
 #include <tinyxml2.h>
+#include <libultraship/bridge/consolevariablebridge.h>
 
 namespace SOH {
 std::shared_ptr<Ship::IResource>

--- a/soh/soh/resource/type/Skeleton.cpp
+++ b/soh/soh/resource/type/Skeleton.cpp
@@ -5,11 +5,11 @@
 #include <soh_assets.h>
 #include <objects/object_link_child/object_link_child.h>
 #include <objects/object_link_boy/object_link_boy.h>
-#include "macros.h"
 
 extern "C" {
 #include "variables.h"
 #include "z64.h"
+#include "macros.h"
 #include "z64player.h"
 extern PlayState* gPlayState;
 }


### PR DESCRIPTION
Clean `OTRGlobals`.
The main effect of this PR is completely decoupling `OTRGlobals.h` from any non-std header making it so that the "everything is being rebuilt because I changed a header that at some point gets included in OTRGlobals" problem doesn't happen anymore.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7111228796.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7111200937.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7111176293.zip)
<!--- section:artifacts:end -->