### PR TITLE
Enhancement CVAR: Peaceful Sword Draw

### DIFF
--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -272,7 +272,10 @@ void SohMenu::AddMenuEnhancements() {
         })
         .CVar(CVAR_ENHANCEMENT("ReworkedTargeting.Btn"))
         .Options(BtnSelectorOptions().Tooltip("Buttons to activate target switching."));
-
+    AddWidget(path, "Peaceful Sword Draw", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("PeacefulDraw"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Allows Link to draw his sword without swinging if no enemies are nearby."));
     AddWidget(path, "Item Count Messages", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Gold Skulltula Tokens", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("InjectItemCounts.GoldSkulltula"))

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2617,7 +2617,15 @@ void Player_StartChangingHeldItem(Player* this, PlayState* play) {
     }
 
     if (heldItemAction != PLAYER_IA_NONE) {
-        playSpeed *= 2.0f;
+        if (!CVarGetInteger(CVAR_ENHANCEMENT("PeacefulDraw"), 0) || 
+            (heldItemAction != PLAYER_IA_SWORD_KOKIRI && heldItemAction != PLAYER_IA_SWORD_MASTER && heldItemAction != PLAYER_IA_SWORD_BIGGORON) ||
+            (this->focusActor != NULL && (this->focusActor->flags & ACTOR_FLAG_HOSTILE)) ||
+            (play->actorCtx.targetCtx.arrowPointedActor != NULL && (play->actorCtx.targetCtx.arrowPointedActor->flags & ACTOR_FLAG_HOSTILE))) {
+            
+            playSpeed *= 2.0f;
+        } else {
+            playSpeed *= 1.5f;
+        }
     }
 
     LinkAnimation_Change(play, &this->upperSkelAnime, anim, playSpeed, startFrame, endFrame, ANIMMODE_ONCE, 0.0f);
@@ -2833,10 +2841,13 @@ s32 Player_UpperAction_Sword(Player* this, PlayState* play) {
 s32 Player_UpperAction_ChangeHeldItem(Player* this, PlayState* play) {
     if (LinkAnimation_Update(play, &this->upperSkelAnime) ||
         ((Player_ItemToItemAction(this->heldItemId) == this->heldItemAction) &&
-         (sUseHeldItem = (sUseHeldItem || GameInteractor_Should(VB_USE_HELD_ITEM_AFTER_CHANGE,
-                                                                ((this->modelAnimType != PLAYER_ANIMTYPE_3) &&
-                                                                 (play->shootingGalleryStatus == 0)),
-                                                                this))))) {
+         (sUseHeldItem =
+              (sUseHeldItem || ((this->modelAnimType != PLAYER_ANIMTYPE_3) && (play->shootingGalleryStatus == 0) &&
+                                (!CVarGetInteger(CVAR_ENHANCEMENT("PeacefulDraw"), 0) ||
+                                 (this->heldItemAction != PLAYER_IA_SWORD_KOKIRI && this->heldItemAction != PLAYER_IA_SWORD_MASTER && this->heldItemAction != PLAYER_IA_SWORD_BIGGORON) ||
+                                 (this->focusActor != NULL && (this->focusActor->flags & ACTOR_FLAG_HOSTILE)) ||
+                                 (play->actorCtx.targetCtx.arrowPointedActor != NULL && (play->actorCtx.targetCtx.arrowPointedActor->flags & ACTOR_FLAG_HOSTILE)))))))) {
+        
         Player_SetUpperActionFunc(this, sItemActionUpdateFuncs[this->heldItemAction]);
         this->unk_834 = 0;
         this->idleType = PLAYER_IDLE_DEFAULT;


### PR DESCRIPTION
What it says on the tin. 

But if you need further clarity, Wind Waker onwards made it so Link draws his sword but doesn't swing right away unless he's near an enemy. The code checks for a hostile target either locked onto or highlighted by the player's focusActor arrow. 