### PR TITLE
[Modding] Add Adult Mask DL for mod compability

### DIFF
--- a/soh/assets/objects/object_link_boy/object_link_boy.h
+++ b/soh/assets/objects/object_link_boy/object_link_boy.h
@@ -510,5 +510,30 @@ static const ALIGN_ASSET(2) char gLinkAdultVtx_0340A0[] = dgLinkAdultVtx_0340A0;
 #define dgLinkAdultVtx_02E7E0 "__OTR__objects/object_link_boy/gLinkAdultVtx_02E7E0"
 static const ALIGN_ASSET(2) char gLinkAdultVtx_02E7E0[] = dgLinkAdultVtx_02E7E0;
 
+// Adult-fitted mask display lists (for use when adult Link wears child masks via the AdultMasks enhancement)
+#define dgLinkAdultKeatonMaskDL "__OTR__objects/object_link_boy/gLinkAdultKeatonMaskDL"
+static const ALIGN_ASSET(2) char gLinkAdultKeatonMaskDL[] = dgLinkAdultKeatonMaskDL;
+
+#define dgLinkAdultSkullMaskDL "__OTR__objects/object_link_boy/gLinkAdultSkullMaskDL"
+static const ALIGN_ASSET(2) char gLinkAdultSkullMaskDL[] = dgLinkAdultSkullMaskDL;
+
+#define dgLinkAdultSpookyMaskDL "__OTR__objects/object_link_boy/gLinkAdultSpookyMaskDL"
+static const ALIGN_ASSET(2) char gLinkAdultSpookyMaskDL[] = dgLinkAdultSpookyMaskDL;
+
+#define dgLinkAdultBunnyHoodDL "__OTR__objects/object_link_boy/gLinkAdultBunnyHoodDL"
+static const ALIGN_ASSET(2) char gLinkAdultBunnyHoodDL[] = dgLinkAdultBunnyHoodDL;
+
+#define dgLinkAdultGoronMaskDL "__OTR__objects/object_link_boy/gLinkAdultGoronMaskDL"
+static const ALIGN_ASSET(2) char gLinkAdultGoronMaskDL[] = dgLinkAdultGoronMaskDL;
+
+#define dgLinkAdultZoraMaskDL "__OTR__objects/object_link_boy/gLinkAdultZoraMaskDL"
+static const ALIGN_ASSET(2) char gLinkAdultZoraMaskDL[] = dgLinkAdultZoraMaskDL;
+
+#define dgLinkAdultGerudoMaskDL "__OTR__objects/object_link_boy/gLinkAdultGerudoMaskDL"
+static const ALIGN_ASSET(2) char gLinkAdultGerudoMaskDL[] = dgLinkAdultGerudoMaskDL;
+
+#define dgLinkAdultMaskOfTruthDL "__OTR__objects/object_link_boy/gLinkAdultMaskOfTruthDL"
+static const ALIGN_ASSET(2) char gLinkAdultMaskOfTruthDL[] = dgLinkAdultMaskOfTruthDL;
+
 
 #endif // OBJECTS_OBJECT_LINK_BOY_H

--- a/soh/soh/Enhancements/Graphics/AgeDependentMasks.cpp
+++ b/soh/soh/Enhancements/Graphics/AgeDependentMasks.cpp
@@ -10,28 +10,25 @@ extern SaveContext gSaveContext;
 }
 
 static const char* sAdultMaskDLists[] = {
-    gLinkAdultKeatonMaskDL,
-    gLinkAdultSkullMaskDL,
-    gLinkAdultSpookyMaskDL,
-    gLinkAdultBunnyHoodDL,
-    gLinkAdultGoronMaskDL,
-    gLinkAdultZoraMaskDL,
-    gLinkAdultGerudoMaskDL,
-    gLinkAdultMaskOfTruthDL,
+    gLinkAdultKeatonMaskDL, gLinkAdultSkullMaskDL, gLinkAdultSpookyMaskDL, gLinkAdultBunnyHoodDL,
+    gLinkAdultGoronMaskDL,  gLinkAdultZoraMaskDL,  gLinkAdultGerudoMaskDL, gLinkAdultMaskOfTruthDL,
 };
 
 static void RegisterAgeDependentMasks() {
     COND_VB_SHOULD(VB_DRAW_PLAYER_MASK, true, {
-        if (!LINK_IS_ADULT) return;
+        if (!LINK_IS_ADULT)
+            return;
 
         PlayerMask currentMask = (PlayerMask)va_arg(args, int);
         PlayState* play = va_arg(args, PlayState*);
 
         int maskIndex = currentMask - 1;
-        if (maskIndex < 0 || maskIndex >= 8) return;
+        if (maskIndex < 0 || maskIndex >= 8)
+            return;
 
         const char* adultDL = sAdultMaskDLists[maskIndex];
-        if (!ResourceGetIsCustomByName(adultDL) && !ResourceMgr_FileExists(adultDL)) return;
+        if (!ResourceGetIsCustomByName(adultDL) && !ResourceMgr_FileExists(adultDL))
+            return;
 
         *should = false;
         gSPDisplayList(play->state.gfxCtx->polyOpa.p++, (Gfx*)adultDL);

--- a/soh/soh/Enhancements/Graphics/AgeDependentMasks.cpp
+++ b/soh/soh/Enhancements/Graphics/AgeDependentMasks.cpp
@@ -1,0 +1,41 @@
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/ShipInit.hpp"
+#include "soh/ResourceManagerHelpers.h"
+
+extern "C" {
+#include "macros.h"
+#include "functions.h"
+#include "objects/object_link_boy/object_link_boy.h"
+extern SaveContext gSaveContext;
+}
+
+static const char* sAdultMaskDLists[] = {
+    gLinkAdultKeatonMaskDL,
+    gLinkAdultSkullMaskDL,
+    gLinkAdultSpookyMaskDL,
+    gLinkAdultBunnyHoodDL,
+    gLinkAdultGoronMaskDL,
+    gLinkAdultZoraMaskDL,
+    gLinkAdultGerudoMaskDL,
+    gLinkAdultMaskOfTruthDL,
+};
+
+static void RegisterAgeDependentMasks() {
+    COND_VB_SHOULD(VB_DRAW_PLAYER_MASK, true, {
+        if (!LINK_IS_ADULT) return;
+
+        PlayerMask currentMask = (PlayerMask)va_arg(args, int);
+        PlayState* play = va_arg(args, PlayState*);
+
+        int maskIndex = currentMask - 1;
+        if (maskIndex < 0 || maskIndex >= 8) return;
+
+        const char* adultDL = sAdultMaskDLists[maskIndex];
+        if (!ResourceGetIsCustomByName(adultDL) && !ResourceMgr_FileExists(adultDL)) return;
+
+        *should = false;
+        gSPDisplayList(play->state.gfxCtx->polyOpa.p++, (Gfx*)adultDL);
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterAgeDependentMasks);

--- a/soh/soh/Enhancements/Graphics/AgeDependentMasks.cpp
+++ b/soh/soh/Enhancements/Graphics/AgeDependentMasks.cpp
@@ -9,17 +9,13 @@ extern "C" {
 extern SaveContext gSaveContext;
 }
 
-static constexpr int32_t CVAR_EXTENDED_MODDING_DEFAULT = 0;
-#define CVAR_EXTENDED_MODDING_NAME CVAR_ENHANCEMENT("ExtendedModdingSupport")
-#define CVAR_EXTENDED_MODDING_VALUE CVarGetInteger(CVAR_EXTENDED_MODDING_NAME, CVAR_EXTENDED_MODDING_DEFAULT)
-
 static const char* sAdultMaskDLists[] = {
     gLinkAdultKeatonMaskDL, gLinkAdultSkullMaskDL, gLinkAdultSpookyMaskDL, gLinkAdultBunnyHoodDL,
     gLinkAdultGoronMaskDL,  gLinkAdultZoraMaskDL,  gLinkAdultGerudoMaskDL, gLinkAdultMaskOfTruthDL,
 };
 
 static void RegisterAgeDependentMasks() {
-    COND_VB_SHOULD(VB_DRAW_PLAYER_MASK, CVAR_EXTENDED_MODDING_VALUE, {
+    COND_VB_SHOULD(VB_DRAW_PLAYER_MASK, CVarGetInteger(CVAR_SETTING("AltAssets"), 1), {
         if (!LINK_IS_ADULT)
             return;
 
@@ -39,4 +35,4 @@ static void RegisterAgeDependentMasks() {
     });
 }
 
-static RegisterShipInitFunc initFunc(RegisterAgeDependentMasks, { CVAR_EXTENDED_MODDING_NAME });
+static RegisterShipInitFunc initFunc(RegisterAgeDependentMasks, { CVAR_SETTING("AltAssets") });

--- a/soh/soh/Enhancements/Graphics/AgeDependentMasks.cpp
+++ b/soh/soh/Enhancements/Graphics/AgeDependentMasks.cpp
@@ -9,13 +9,17 @@ extern "C" {
 extern SaveContext gSaveContext;
 }
 
+static constexpr int32_t CVAR_EXTENDED_MODDING_DEFAULT = 0;
+#define CVAR_EXTENDED_MODDING_NAME CVAR_ENHANCEMENT("ExtendedModdingSupport")
+#define CVAR_EXTENDED_MODDING_VALUE CVarGetInteger(CVAR_EXTENDED_MODDING_NAME, CVAR_EXTENDED_MODDING_DEFAULT)
+
 static const char* sAdultMaskDLists[] = {
     gLinkAdultKeatonMaskDL, gLinkAdultSkullMaskDL, gLinkAdultSpookyMaskDL, gLinkAdultBunnyHoodDL,
     gLinkAdultGoronMaskDL,  gLinkAdultZoraMaskDL,  gLinkAdultGerudoMaskDL, gLinkAdultMaskOfTruthDL,
 };
 
 static void RegisterAgeDependentMasks() {
-    COND_VB_SHOULD(VB_DRAW_PLAYER_MASK, true, {
+    COND_VB_SHOULD(VB_DRAW_PLAYER_MASK, CVAR_EXTENDED_MODDING_VALUE, {
         if (!LINK_IS_ADULT)
             return;
 
@@ -35,4 +39,4 @@ static void RegisterAgeDependentMasks() {
     });
 }
 
-static RegisterShipInitFunc initFunc(RegisterAgeDependentMasks);
+static RegisterShipInitFunc initFunc(RegisterAgeDependentMasks, { CVAR_EXTENDED_MODDING_NAME });

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -580,6 +580,15 @@ typedef enum {
     VB_DRAW_ADDITIONAL_RETICLES,
 
     // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `PlayerMask currentMask`
+    // - `*PlayState play`
+    VB_DRAW_PLAYER_MASK,
+
+    // #### `result`
     // In `Interface_DrawAmmoCount`:
     // ```c
     // (i == ITEM_STICK) ||

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -540,12 +540,6 @@ void SohMenu::AddMenuEnhancements() {
     path.column = SECTION_COLUMN_1;
 
     AddWidget(path, "Mods", WIDGET_SEPARATOR_TEXT);
-    AddWidget(path, "Enable Extended Modding Support", WIDGET_CVAR_CHECKBOX)
-        .CVar(CVAR_ENHANCEMENT("ExtendedModdingSupport"))
-        .RaceDisable(false)
-        .Options(CheckboxOptions().Tooltip(
-            "Enables modding quality-of-life features that go beyond the original game.\n"
-            "Allows mods to provide separate assets for situations the vanilla game did not account for."));
     AddWidget(path, "Disable Bomb Billboarding", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("DisableBombBillboarding"))
         .RaceDisable(false)

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -540,6 +540,12 @@ void SohMenu::AddMenuEnhancements() {
     path.column = SECTION_COLUMN_1;
 
     AddWidget(path, "Mods", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Enable Extended Modding Support", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("ExtendedModdingSupport"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip(
+            "Enables modding quality-of-life features that go beyond the original game.\n"
+            "Allows mods to provide separate assets for situations the vanilla game did not account for."));
     AddWidget(path, "Disable Bomb Billboarding", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("DisableBombBillboarding"))
         .RaceDisable(false)

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12449,8 +12449,10 @@ void Player_DrawGameplay(PlayState* play, Player* this, s32 lod, Gfx* cullDList,
             MATRIX_TOMTX(bunnyEarMtx);
         }
 
-        if (this->currentMask != PLAYER_MASK_BUNNY || !CVarGetInteger(CVAR_ENHANCEMENT("HideBunnyHood"), 0)) {
-            gSPDisplayList(POLY_OPA_DISP++, sMaskDlists[this->currentMask - 1]);
+        if (GameInteractor_Should(VB_DRAW_PLAYER_MASK, true, this->currentMask, play)) {
+            if (this->currentMask != PLAYER_MASK_BUNNY || !CVarGetInteger(CVAR_ENHANCEMENT("HideBunnyHood"), 0)) {
+                gSPDisplayList(POLY_OPA_DISP++, sMaskDlists[this->currentMask - 1]);
+            }
         }
 
         if (CVarGetInteger(CVAR_GENERAL("FixIceTrapWithBunnyHood"), 1))


### PR DESCRIPTION
This pr adds displaylists for adult link to use in conjunction with adult mask enhancement.

The reason is that the original dls are only made for child in mind and custom models doesnt scale well trying to load child mask on adult link.

By adding the specific DL's to use on adult link we can let mod makers do a specific export that fits better with adult rather than compromise in the middle for both child and adult.

My pikachu mod on child link
<img width="573" height="681" alt="Screenshot_20260524_173418" src="https://github.com/user-attachments/assets/aa325f95-2176-4ac8-9357-068842a24a2e" />

Original pikachu mod on adult link
<img width="609" height="741" alt="Screenshot_20260524_173624" src="https://github.com/user-attachments/assets/b0740e5d-1f6e-411a-88d1-685c53d9c583" />

Modified pikachu mod with adult mask dl in use instead.
<img width="620" height="678" alt="Screenshot_20260524_173505" src="https://github.com/user-attachments/assets/a7ae6409-06c8-42de-9a37-830cf5389eaf" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7468135160.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7468091544.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7468043479.zip)
<!--- section:artifacts:end -->