### PR TITLE
feat: add enemy retargeting enhancement

### DIFF
--- a/soh/soh/Enhancements/EnemyRetarget.cpp
+++ b/soh/soh/Enhancements/EnemyRetarget.cpp
@@ -1,0 +1,39 @@
+#include <libultraship/bridge.h>
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/ShipInit.hpp"
+
+#define CVAR_ENEMY_RETARGET_NAME CVAR_ENHANCEMENT("EnemyRetarget")
+#define CVAR_ENEMY_RETARGET_VALUE CVarGetInteger(CVAR_ENEMY_RETARGET_NAME, 0)
+
+void RegisterEnemyRetarget() {
+    COND_VB_SHOULD(VB_DROP_Z_TARGET, CVAR_ENEMY_RETARGET_VALUE, {
+        Player* player = va_arg(args, Player*);
+        PlayState* play = va_arg(args, PlayState*);
+
+        // Determine if the lock break is due to the enemy dying/despawning
+        bool targetDied = (player->focusActor->update == NULL) || !(player->focusActor->flags & ACTOR_FLAG_ATTENTION_ENABLED);
+
+        if (targetDied) {
+            bool usingHoldTargeting = (gSaveContext.zTargetSetting != 0);
+            bool zButtonHeld = CHECK_BTN_ALL(play->state.input[0].cur.button, BTN_Z);
+
+            if (!usingHoldTargeting || zButtonHeld) {
+                // Grab the secondary target the game engine already calculated
+                Actor* nextTarget = play->actorCtx.targetCtx.unk_94;
+
+                if (nextTarget != NULL && !(nextTarget->flags & ACTOR_FLAG_LOCK_ON_DISABLED) &&
+                    CHECK_FLAG_ALL(nextTarget->flags, ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE)) {
+                    
+                    // Seamlessly transition to the new target
+                    player->focusActor = nextTarget;
+                    player->zTargetActiveTimer = 15;
+                    
+                    // Tell the engine NOT to drop the lock-on!
+                    *should = false; 
+                }
+            }
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterEnemyRetarget, { CVAR_ENEMY_RETARGET_NAME });

--- a/soh/soh/Enhancements/EnemyRetarget.cpp
+++ b/soh/soh/Enhancements/EnemyRetarget.cpp
@@ -11,7 +11,8 @@ void RegisterEnemyRetarget() {
         PlayState* play = va_arg(args, PlayState*);
 
         // Determine if the lock break is due to the enemy dying/despawning
-        bool targetDied = (player->focusActor->update == NULL) || !(player->focusActor->flags & ACTOR_FLAG_ATTENTION_ENABLED);
+        bool targetDied =
+            (player->focusActor->update == NULL) || !(player->focusActor->flags & ACTOR_FLAG_ATTENTION_ENABLED);
 
         if (targetDied) {
             bool usingHoldTargeting = (gSaveContext.zTargetSetting != 0);
@@ -23,13 +24,13 @@ void RegisterEnemyRetarget() {
 
                 if (nextTarget != NULL && !(nextTarget->flags & ACTOR_FLAG_LOCK_ON_DISABLED) &&
                     CHECK_FLAG_ALL(nextTarget->flags, ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE)) {
-                    
+
                     // Seamlessly transition to the new target
                     player->focusActor = nextTarget;
                     player->zTargetActiveTimer = 15;
-                    
+
                     // Tell the engine NOT to drop the lock-on!
-                    *should = false; 
+                    *should = false;
                 }
             }
         }

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -2966,15 +2966,15 @@ typedef enum {
     // #### `args`
     // - `*int32_t (camId)`
     VB_SHOULD_LOAD_BG_IMAGE
-    
-    // #### `result`
-    // ```c
-    // true
-    // ```
-    // #### `args`
-    // - `*Player`
-    // - `*PlayState`
-    VB_DROP_Z_TARGET,
+
+        // #### `result`
+        // ```c
+        // true
+        // ```
+        // #### `args`
+        // - `*Player`
+        // - `*PlayState`
+        VB_DROP_Z_TARGET,
 } GIVanillaBehavior;
 
 #endif

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -607,6 +607,15 @@ typedef enum {
     // true
     // ```
     // #### `args`
+    // - `*Player`
+    // - `*PlayState`
+    VB_DROP_Z_TARGET,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
     // - Player*
     VB_EMPTYING_BOTTLE,
 
@@ -2966,15 +2975,6 @@ typedef enum {
     // #### `args`
     // - `*int32_t (camId)`
     VB_SHOULD_LOAD_BG_IMAGE
-
-        // #### `result`
-        // ```c
-        // true
-        // ```
-        // #### `args`
-        // - `*Player`
-        // - `*PlayState`
-        VB_DROP_Z_TARGET,
 } GIVanillaBehavior;
 
 #endif

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -2966,6 +2966,15 @@ typedef enum {
     // #### `args`
     // - `*int32_t (camId)`
     VB_SHOULD_LOAD_BG_IMAGE
+    
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*Player`
+    // - `*PlayState`
+    VB_DROP_Z_TARGET,
 } GIVanillaBehavior;
 
 #endif

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -273,6 +273,10 @@ void SohMenu::AddMenuEnhancements() {
         })
         .CVar(CVAR_ENHANCEMENT("ReworkedTargeting.Btn"))
         .Options(BtnSelectorOptions().Tooltip("Buttons to activate target switching."));
+    AddWidget(path, "Enemy Auto-Retarget", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("EnemyRetarget"))
+        .Options(CheckboxOptions().Tooltip(
+            "Automatically locks onto the next available enemy when your current target is defeated."));
 
     AddWidget(path, "Item Count Messages", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Gold Skulltula Tokens", WIDGET_CVAR_CHECKBOX)

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3884,7 +3884,7 @@ void Player_UpdateZTargeting(Player* this, PlayState* play) {
             if (this->focusActor != NULL) {
                 if ((this->actor.category == ACTORCAT_PLAYER) && (this->focusActor != this->autoLockOnActor) &&
                     func_8002F0C8(this->focusActor, this, ignoreLeash)) {
-                    
+
                     // TRIPWIRE: Ask the Game Interactor if we should actually drop the lock
                     if (GameInteractor_Should(VB_DROP_Z_TARGET, true, this, play)) {
                         Player_ReleaseLockOn(this);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3884,8 +3884,13 @@ void Player_UpdateZTargeting(Player* this, PlayState* play) {
             if (this->focusActor != NULL) {
                 if ((this->actor.category == ACTORCAT_PLAYER) && (this->focusActor != this->autoLockOnActor) &&
                     func_8002F0C8(this->focusActor, this, ignoreLeash)) {
-                    Player_ReleaseLockOn(this);
-                    this->stateFlags1 |= PLAYER_STATE1_LOCK_ON_FORCED_TO_RELEASE;
+                    
+                    // TRIPWIRE: Ask the Game Interactor if we should actually drop the lock
+                    if (GameInteractor_Should(VB_DROP_Z_TARGET, true, this, play)) {
+                        Player_ReleaseLockOn(this);
+                        this->stateFlags1 |= PLAYER_STATE1_LOCK_ON_FORCED_TO_RELEASE;
+                    }
+
                 } else if (this->focusActor != NULL) {
                     this->focusActor->targetPriority = 40;
                 }


### PR DESCRIPTION
Enhancement to allow Link to automatically lock onto the next valid hostile target when the current target is defeated, like in Twilight Princess. 

<!--- section:artifacts:start -->
### Build Artifacts
<!--- section:artifacts:end -->