### PR TITLE
Feat/knockdown recovery

### DIFF
--- a/soh/soh/Enhancements/KnockdownRecovery.cpp
+++ b/soh/soh/Enhancements/KnockdownRecovery.cpp
@@ -7,8 +7,8 @@
 
 // Tell C++ that these old N64 functions exist in the codebase!
 extern "C" {
-    void func_8083BCD0(Player* thisx, PlayState* play, s32 controlStickDirection);
-    void Player_SetupRoll(Player* thisx, PlayState* play);
+void func_8083BCD0(Player* thisx, PlayState* play, s32 controlStickDirection);
+void Player_SetupRoll(Player* thisx, PlayState* play);
 }
 
 void RegisterKnockdownRecovery() {
@@ -22,8 +22,8 @@ void RegisterKnockdownRecovery() {
             } else {
                 Player_SetupRoll(player, play);
             }
-            
-            *should = true; 
+
+            *should = true;
         }
     });
 }

--- a/soh/soh/Enhancements/KnockdownRecovery.cpp
+++ b/soh/soh/Enhancements/KnockdownRecovery.cpp
@@ -1,0 +1,31 @@
+#include <libultraship/bridge.h>
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/ShipInit.hpp"
+
+#define CVAR_KNOCKDOWN_RECOVERY_NAME CVAR_ENHANCEMENT("KnockdownRecovery")
+#define CVAR_KNOCKDOWN_RECOVERY_VALUE CVarGetInteger(CVAR_KNOCKDOWN_RECOVERY_NAME, 0)
+
+// Tell C++ that these old N64 functions exist in the codebase!
+extern "C" {
+    void func_8083BCD0(Player* thisx, PlayState* play, s32 controlStickDirection);
+    void Player_SetupRoll(Player* thisx, PlayState* play);
+}
+
+void RegisterKnockdownRecovery() {
+    COND_VB_SHOULD(VB_PERFORM_KNOCKDOWN_RECOVERY, CVAR_KNOCKDOWN_RECOVERY_VALUE, {
+        Player* player = va_arg(args, Player*);
+        PlayState* play = va_arg(args, PlayState*);
+
+        if (CHECK_BTN_ALL(play->state.input[0].press.button, BTN_A)) {
+            if (player->yaw != player->actor.shape.rot.y) {
+                func_8083BCD0(player, play, PLAYER_STICK_DIR_BACKWARD);
+            } else {
+                Player_SetupRoll(player, play);
+            }
+            
+            *should = true; 
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterKnockdownRecovery, { CVAR_KNOCKDOWN_RECOVERY_NAME });

--- a/soh/soh/Enhancements/KnockdownRecovery.cpp
+++ b/soh/soh/Enhancements/KnockdownRecovery.cpp
@@ -16,7 +16,7 @@ void RegisterKnockdownRecovery() {
         Player* player = va_arg(args, Player*);
         PlayState* play = va_arg(args, PlayState*);
 
-        if (CHECK_BTN_ALL(play->state.input[0].press.button, BTN_A)) {
+        if (CHECK_BTN_ALL(sControlInput->press.button, BTN_A)) {
             if (player->yaw != player->actor.shape.rot.y) {
                 func_8083BCD0(player, play, PLAYER_STICK_DIR_BACKWARD);
             } else {

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -1610,6 +1610,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // false
+    // ```
+    // #### `args`
+    // - `*PlayState`
+    VB_PERFORM_KNOCKDOWN_RECOVERY,
+
+    // #### `result`
+    // ```c
     // true
     // ```
     // #### `args`

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -484,7 +484,8 @@ void SohMenu::AddMenuEnhancements() {
         .Options(CheckboxOptions().Tooltip("Speeds up animation of the pause menu, similar to Majora's Mask"));
     AddWidget(path, "Knockdown Recovery", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("KnockdownRecovery"))
-        .Options(CheckboxOptions().Tooltip("Allows Link to quickly recover from being knocked down by pressing the Action button."));
+        .Options(CheckboxOptions().Tooltip(
+            "Allows Link to quickly recover from being knocked down by pressing the A button."));
 
     path.column = SECTION_COLUMN_3;
     AddWidget(path, "Misc", WIDGET_SEPARATOR_TEXT);

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -482,6 +482,9 @@ void SohMenu::AddMenuEnhancements() {
     AddWidget(path, "Faster Pause Menu", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("FasterPauseMenu"))
         .Options(CheckboxOptions().Tooltip("Speeds up animation of the pause menu, similar to Majora's Mask"));
+    AddWidget(path, "Knockdown Recovery", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("KnockdownRecovery"))
+        .Options(CheckboxOptions().Tooltip("Allows Link to quickly recover from being knocked down by pressing the Action button."));
 
     path.column = SECTION_COLUMN_3;
     AddWidget(path, "Misc", WIDGET_SEPARATOR_TEXT);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -9458,6 +9458,10 @@ void Player_Action_80843954(Player* this, PlayState* play) {
 
     Player_DecelerateToZero(this);
 
+    if (GameInteractor_Should(VB_PERFORM_KNOCKDOWN_RECOVERY, false, this, play)) {
+        return;
+    }
+
     if (LinkAnimation_Update(play, &this->skelAnime) && (this->linearVelocity == 0.0f)) {
         if (this->stateFlags1 & PLAYER_STATE1_IN_CUTSCENE) {
             this->av2.actionVar2++;


### PR DESCRIPTION
Adds an enhancement that allows Link to quickly recover from knockdown by pressing A when landing, causing Link to either roll or backflip depending on which way he was knocked down. 