### PR TITLE
feat: Add "Faster First-Person" enhancement

### DIFF
--- a/soh/soh/Enhancements/FasterFirstPerson.cpp
+++ b/soh/soh/Enhancements/FasterFirstPerson.cpp
@@ -1,0 +1,12 @@
+#include <libultraship/bridge.h>
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/ShipInit.hpp"
+
+#define CVAR_FASTER_FIRST_PERSON_NAME CVAR_ENHANCEMENT("FasterFirstPerson")
+#define CVAR_FASTER_FIRST_PERSON_VALUE CVarGetInteger(CVAR_FASTER_FIRST_PERSON_NAME, 0)
+
+void RegisterFasterFirstPerson() {
+    COND_VB_SHOULD(VB_FAST_FIRST_PERSON_TRANSITION, CVAR_FASTER_FIRST_PERSON_VALUE, { *should = true; });
+}
+
+static RegisterShipInitFunc initFunc(RegisterFasterFirstPerson, { CVAR_FASTER_FIRST_PERSON_NAME });

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -482,6 +482,10 @@ void SohMenu::AddMenuEnhancements() {
     AddWidget(path, "Faster Pause Menu", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("FasterPauseMenu"))
         .Options(CheckboxOptions().Tooltip("Speeds up animation of the pause menu, similar to Majora's Mask"));
+    AddWidget(path, "Faster First-Person Camera", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("FasterFirstPerson"))
+        .Options(CheckboxOptions().Tooltip("Reduces the camera transition delay when entering first-person view, "
+                                           "allowing you to aim your weapons much faster."));
 
     path.column = SECTION_COLUMN_3;
     AddWidget(path, "Misc", WIDGET_SEPARATOR_TEXT);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6122,7 +6122,7 @@ s32 Player_ActionHandler_13(Player* this, PlayState* play) {
             } else if (func_8083AD4C(play, this)) {
                 if (!(this->stateFlags1 & PLAYER_STATE1_ON_HORSE)) {
                     Player_SetupAction(play, this, Player_Action_8084B1D8, 1);
-                    this->av2.actionVar2 = 13;
+                    this->av2.actionVar2 = GameInteractor_Should(VB_FAST_FIRST_PERSON_TRANSITION, false, this) ? 5 : 13;
                     func_8083B010(this);
                 }
                 this->stateFlags1 |= PLAYER_STATE1_FIRST_PERSON;


### PR DESCRIPTION
Struggled to find a precise description for this, but this enhancement cuts down the delay that prevents aiming upon entering first person view. Improves responsiveness significantly. 