### PR TITLE
Enhancement to disable heat haze

### DIFF
--- a/soh/soh/Enhancements/DisableHeatHaze.cpp
+++ b/soh/soh/Enhancements/DisableHeatHaze.cpp
@@ -1,0 +1,8 @@
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/ShipInit.hpp"
+
+void RegisterDisableHeatHaze() {
+    COND_VB_SHOULD(VB_HOT_ROOM_DISTORTION, CVarGetInteger(CVAR_SETTING("A11yNoHeatHaze"), 0), { *should = false; });
+}
+
+static RegisterShipInitFunc initFunc(RegisterDisableHeatHaze, { CVAR_SETTING("A11yNoHeatHaze") });

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -1371,6 +1371,14 @@ typedef enum {
     // ```
     // #### `args`
     // - None
+    VB_HOT_ROOM_DISTORTION,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - None
     VB_KALEIDO_UNPAUSE_CLOSE,
 
     // #### `result`

--- a/soh/soh/SohGui/SohMenuSettings.cpp
+++ b/soh/soh/SohGui/SohMenuSettings.cpp
@@ -251,6 +251,10 @@ void SohMenu::AddMenuSettings() {
         .CVar(CVAR_SETTING("A11yNoJabuWobble"))
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip("Disable the geometry wobble and camera distortion inside Jabu."));
+    AddWidget(path, "Disable Heat Haze", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_SETTING("A11yNoHeatHaze"))
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Disable the heat haze distortion effect in Death Mountain / Fire Temple."));
     AddWidget(path, "EXPERIMENTAL", WIDGET_SEPARATOR_TEXT).Options(TextOptions().Color(Colors::Orange));
     AddWidget(path, "ImGui Menu Scaling", WIDGET_CVAR_COMBOBOX)
         .CVar(CVAR_SETTING("ImGuiScale"))

--- a/soh/src/code/z_camera.c
+++ b/soh/src/code/z_camera.c
@@ -7364,10 +7364,9 @@ s32 Camera_UpdateWater(Camera* camera) {
 
 s32 Camera_UpdateHotRoom(Camera* camera) {
     camera->distortionFlags &= ~DISTORTION_HOT_ROOM;
-    if (camera->play->roomCtx.curRoom.behaviorType2 == ROOM_BEHAVIOR_TYPE2_3) {
-        if (GameInteractor_Should(VB_HOT_ROOM_DISTORTION, true)) {
-            camera->distortionFlags |= DISTORTION_HOT_ROOM;
-        }
+    if (GameInteractor_Should(VB_HOT_ROOM_DISTORTION,
+                              camera->play->roomCtx.curRoom.behaviorType2 == ROOM_BEHAVIOR_TYPE2_3)) {
+        camera->distortionFlags |= DISTORTION_HOT_ROOM;
     }
 
     return 1;

--- a/soh/src/code/z_camera.c
+++ b/soh/src/code/z_camera.c
@@ -8,6 +8,7 @@
 
 #include "soh/frame_interpolation.h"
 #include "soh/Enhancements/controls/Mouse.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 s16 Camera_ChangeSettingFlags(Camera* camera, s16 setting, s16 flags);
 s32 Camera_ChangeModeFlags(Camera* camera, s16 mode, u8 flags);
@@ -7364,7 +7365,9 @@ s32 Camera_UpdateWater(Camera* camera) {
 s32 Camera_UpdateHotRoom(Camera* camera) {
     camera->distortionFlags &= ~DISTORTION_HOT_ROOM;
     if (camera->play->roomCtx.curRoom.behaviorType2 == ROOM_BEHAVIOR_TYPE2_3) {
-        camera->distortionFlags |= DISTORTION_HOT_ROOM;
+        if (GameInteractor_Should(VB_HOT_ROOM_DISTORTION, true)) {
+            camera->distortionFlags |= DISTORTION_HOT_ROOM;
+        }
     }
 
     return 1;


### PR DESCRIPTION
Based closely on #6280, this accessibility enhancement disables the heat haze effect in DMC / Fire Temple / etc.

### Why?
Motion sickness 😵‍💫

### Send vids
Below is a before/after comparison. Focus on the boulder on the left.
<video src="https://github.com/user-attachments/assets/d6d39bd7-bfc5-4123-8347-027b74769da9" />

### Could this be done with an existing hook?
I _think_ it would be possible to hook _OnCameraState_, patch the room’s `behaviorType2`, then revert it back in _OnPlayDrawBegin_. That approach didn’t feel as sensible or readable, so this PR does it via a new VB_ flag (just like the Jabu wobble).

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7319473916.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7319470136.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7319461845.zip)
<!--- section:artifacts:end -->