### PR TITLE
fix halfmilk reverse bottle adventure

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2696,9 +2696,17 @@ void Inventory_UpdateBottleItem(PlayState* play, u8 item, u8 button) {
                  gSaveContext.equips.cButtonSlots[button - 1],
                  gSaveContext.inventory.items[gSaveContext.equips.cButtonSlots[button - 1]]);
 
+    u8 bottleSlot;
+    if (button == 0) {
+        // bottle on b, assign c right value
+        bottleSlot = gSaveContext.equips.buttonItems[3];
+    } else {
+        // default behavior
+        bottleSlot = gSaveContext.equips.cButtonSlots[button - 1];
+    }
+
     // Special case to only empty half of a Lon Lon Milk Bottle
-    if ((gSaveContext.inventory.items[gSaveContext.equips.cButtonSlots[button - 1]] == ITEM_MILK_BOTTLE) &&
-        (item == ITEM_BOTTLE)) {
+    if ((gSaveContext.inventory.items[bottleSlot] == ITEM_MILK_BOTTLE) && (item == ITEM_BOTTLE)) {
         item = ITEM_MILK_HALF;
     }
 


### PR DESCRIPTION
i ran into this bug when running the 37 water temple keys route with the following conditions shown in speedrun (with timestamp) here:
https://youtu.be/xwMThSjdvqU?t=1648 

ZSR Article:
https://www.zeldaspeedruns.com/oot/ba/halfmilk-rba

> Half-milk RBA is useless for editing the main inventory, since you can only put a full bottle on the normal bottle slots. You can endlessly perform Half-Milk RBA with item amounts, but you can also just as well use normal RBA to get infinite item amounts.

> For example, if you have a fish on B, a bottle with a normal poe on C-Right, and exactly 26 bombchus, dropping the B fish will give you 31 bombchus. However, once you drop the fish, you should immediately swap c-right to a different item (an empty bottle, bugs, or fish will work nicely), so you can recapture the fish on the B bottle without setting the ammo count back down to 25.

**How to reproduce:**

1: Emptying bugs with bomb bag 20 on c-right
2: Has 26 water temple keys

**Current behavior:** 

Water temple keys goes to 20 when emptying bottle on b
b shows empty bottle

**Expected behavior:** 

Water temple keys goes to 31
B button shows half milk
