### PR TITLE
feature(audio): PipeWire native backend

### DIFF
--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1652,8 +1652,7 @@ extern "C" void Graph_StartFrame() {
                 case SaveStateReturn::FAIL_WRONG_GAMESTATE:
                     SPDLOG_ERROR("[SOH] Can not save a state outside of \"GamePlay\"");
                     break;
-                [[unlikely]] default:
-                    break;
+                    [[unlikely]] default : break;
             }
             break;
         }
@@ -1697,8 +1696,7 @@ extern "C" void Graph_StartFrame() {
                 case SaveStateReturn::FAIL_WRONG_GAMESTATE:
                     SPDLOG_ERROR("[SOH] Can not load a state outside of \"GamePlay\"");
                     break;
-                [[unlikely]] default:
-                    break;
+                    [[unlikely]] default : break;
             }
 
             break;

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1652,7 +1652,8 @@ extern "C" void Graph_StartFrame() {
                 case SaveStateReturn::FAIL_WRONG_GAMESTATE:
                     SPDLOG_ERROR("[SOH] Can not save a state outside of \"GamePlay\"");
                     break;
-                    [[unlikely]] default : break;
+                [[unlikely]] default:
+                    break;
             }
             break;
         }
@@ -1696,7 +1697,8 @@ extern "C" void Graph_StartFrame() {
                 case SaveStateReturn::FAIL_WRONG_GAMESTATE:
                     SPDLOG_ERROR("[SOH] Can not load a state outside of \"GamePlay\"");
                     break;
-                    [[unlikely]] default : break;
+                [[unlikely]] default:
+                    break;
             }
 
             break;

--- a/soh/soh/SohGui/MenuTypes.h
+++ b/soh/soh/SohGui/MenuTypes.h
@@ -269,6 +269,7 @@ static const std::map<Ship::AudioBackend, const char*> audioBackendsMap = {
     { Ship::AudioBackend::WASAPI, "Windows Audio Session API" },
     { Ship::AudioBackend::SDL, "SDL" },
     { Ship::AudioBackend::COREAUDIO, "Core Audio" },
+    { Ship::AudioBackend::PIPEWIRE, "PipeWire" },
     { Ship::AudioBackend::NUL, "Null" },
 };
 

--- a/soh/soh/SohGui/SohGui.cpp
+++ b/soh/soh/SohGui/SohGui.cpp
@@ -36,8 +36,8 @@ static const inline std::vector<std::pair<const char*, const char*>> audioBacken
 #ifdef _WIN32
     { "wasapi", "Windows Audio Session API" },
 #endif
-#if defined(__linux)
-    { "pulse", "PulseAudio" },
+#if defined(__linux__)
+    { "pipewire", "PipeWire" },
 #endif
 #ifdef __APPLE__
     { "coreaudio", "Core Audio" },


### PR DESCRIPTION
Requires https://github.com/Kenix3/libultraship/pull/1105

Adds a native PipeWire audio backend for Linux, replacing the SDL/PulseAudio
fallback. Implemented in libultraship (see submodule bump). Shipwright-side
changes wire it into the UI and tune the audio producer model.

libultraship (submodule bump to include):
  - PipeWireAudioPlayer: ring buffer + pw_thread_loop RT callback, underrun
    fade-out recovery, float pipeline support

Shipwright changes:

  - SohGui.cpp: add pipewire to backend list, fix __linux -> __linux__
  - MenuTypes.h,cpp: add PipeWire to audioBackendsMap, properly filter-out unavailable backends on platform
  - OTRAudio.h: make running/processing atomic_bool; remove cv_from_thread
    (audio thread now signals completion via atomic store, not condition variable)
  - OTRGlobals.cpp:
    - DesiredBuffered 1680 -> 4096 (~128 ms headroom for HDMI/external clocks)
    - Pre-buffer loop: producer refills reservoir between frame signals
    - Producer guard: skip generating PCM if ring already at desired level
      (avoids clicks from truncated buffers on CoreAudio / PipeWire)
    - Remove cv_from_thread synchronisation; main thread no longer blocks
      waiting for the audio thread (decouples audio from frame rate)

<!--- section:artifacts:start -->
### Build Artifacts
<!--- section:artifacts:end -->