### PR TITLE
fix halfmilk RBA

### DIFF
--- a/soh/soh/Enhancements/Restorations/BottleAdventure.cpp
+++ b/soh/soh/Enhancements/Restorations/BottleAdventure.cpp
@@ -452,6 +452,11 @@ void DoRBA(uint8_t itemToPutInBottle) {
     }
 }
 
+bool DoHalfMilkRBA(uint8_t item) {
+    auto itemOnCRight = gSaveContext.equips.buttonItems[3];
+    return (item == ITEM_BOTTLE) && (gSaveContext.inventory.items[itemOnCRight] == ITEM_MILK_BOTTLE);
+}
+
 void RegisterBottleAdventure() {
     REGISTER_VB_SHOULD(VB_SET_BUTTON_ITEM_FROM_C_BUTTON_SLOT, {
         // if we aren't dealing with the b button, early return
@@ -475,6 +480,17 @@ void RegisterBottleAdventure() {
 
         auto itemToPutInBottle = static_cast<uint8_t>(va_arg(args, int32_t));
         DoRBA(itemToPutInBottle);
+    });
+
+    REGISTER_VB_SHOULD(VB_EMPTY_BOTTLE_TO_HALF_MILK, {
+        // if we aren't dealing with a bottle on b, early return
+        auto buttonBottleIsOn = static_cast<uint8_t>(va_arg(args, int32_t));
+        if (buttonBottleIsOn != 0) {
+            return;
+        }
+
+        auto item = static_cast<uint8_t>(va_arg(args, int32_t));
+        *should = DoHalfMilkRBA(item);
     });
 }
 

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -622,6 +622,16 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // (gSaveContext.inventory.items[gSaveContext.equips.cButtonSlots[button - 1]] == ITEM_MILK_BOTTLE) &&
+    //     (item == ITEM_BOTTLE)
+    // ```
+    // #### `args`
+    // - `int32_t` (button - promoted from `u8`)
+    // - `int32_t` (item - promoted from `u8`)
+    VB_EMPTY_BOTTLE_TO_HALF_MILK,
+
+    // #### `result`
+    // ```c
     // (Message_GetState(&play->msgCtx) == TEXT_STATE_EVENT) && Message_ShouldAdvance(play)
     // ```
     // #### `args`

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2670,17 +2670,12 @@ void Inventory_UpdateBottleItem(PlayState* play, u8 item, u8 button) {
                  gSaveContext.equips.cButtonSlots[button - 1],
                  gSaveContext.inventory.items[gSaveContext.equips.cButtonSlots[button - 1]]);
 
-    u8 bottleSlot;
-    if (button == 0) {
-        // bottle on b, assign c right value
-        bottleSlot = gSaveContext.equips.buttonItems[3];
-    } else {
-        // default behavior
-        bottleSlot = gSaveContext.equips.cButtonSlots[button - 1];
-    }
-
     // Special case to only empty half of a Lon Lon Milk Bottle
-    if ((gSaveContext.inventory.items[bottleSlot] == ITEM_MILK_BOTTLE) && (item == ITEM_BOTTLE)) {
+    if (GameInteractor_Should(
+            VB_EMPTY_BOTTLE_TO_HALF_MILK,
+            (gSaveContext.inventory.items[gSaveContext.equips.cButtonSlots[button - 1]] == ITEM_MILK_BOTTLE) &&
+                (item == ITEM_BOTTLE),
+            button, item)) {
         item = ITEM_MILK_HALF;
     }
 

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2670,9 +2670,17 @@ void Inventory_UpdateBottleItem(PlayState* play, u8 item, u8 button) {
                  gSaveContext.equips.cButtonSlots[button - 1],
                  gSaveContext.inventory.items[gSaveContext.equips.cButtonSlots[button - 1]]);
 
+    u8 bottleSlot;
+    if (button == 0) {
+        // bottle on b, assign c right value
+        bottleSlot = gSaveContext.equips.buttonItems[3];
+    } else {
+        // default behavior
+        bottleSlot = gSaveContext.equips.cButtonSlots[button - 1];
+    }
+
     // Special case to only empty half of a Lon Lon Milk Bottle
-    if ((gSaveContext.inventory.items[gSaveContext.equips.cButtonSlots[button - 1]] == ITEM_MILK_BOTTLE) &&
-        (item == ITEM_BOTTLE)) {
+    if ((gSaveContext.inventory.items[bottleSlot] == ITEM_MILK_BOTTLE) && (item == ITEM_BOTTLE)) {
         item = ITEM_MILK_HALF;
     }
 


### PR DESCRIPTION
I tested the other RBA related PR. It did not fix this.
I did my best to follow the other RBA related code please let me know if this follows convention.

Explanation of halfmilk RBA here:

https://www.zeldaspeedruns.com/oot/ba/halfmilk-rba

I noticed this on 37 water temple keys route. Timestamp
https://youtu.be/xwMThSjdvqU?t=1649

Reproduction steps:

Bugs on B, bomb bag 20 on c-right,
26 water temple keys
Press B to empty bottle

Expected Behavior:

Keys should go to 31
halfmilk on B

Current Behavior:

keys go to 20
empty bottle on b

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7375427676.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7375367811.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7375302687.zip)
<!--- section:artifacts:end -->