### PR TITLE
Properly send Link to the beginning to the dungeon in boss room shuffle

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_entrance.c
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance.c
@@ -143,7 +143,6 @@ void Entrance_ResetEntranceTable(void) {
 
 void Entrance_Init(void) {
     EntranceOverride* entranceOverrides = Randomizer_GetEntranceOverrides();
-    s32 index;
 
     Entrance_CopyOriginalEntranceTable();
 
@@ -156,7 +155,7 @@ void Entrance_Init(void) {
     }
 
     // Delete the title card and add a fade in for Hyrule Field from Ocarina of Time cutscene
-    for (index = ENTR_HYRULE_FIELD_16; index <= ENTR_HYRULE_FIELD_16_3; ++index) {
+    for (s32 index = ENTR_HYRULE_FIELD_16; index <= ENTR_HYRULE_FIELD_16_3; ++index) {
         gEntranceTable[index].field = ENTRANCE_INFO_FIELD(false, false, TRANS_TYPE_FADE_BLACK, TRANS_TYPE_INSTANT);
     }
 
@@ -199,7 +198,7 @@ void Entrance_Init(void) {
                 bossScene = dungeons[j].bossScene;
             }
 
-            if (index == dungeons[j].bossDoor) {
+            if (originalIndex == dungeons[j].bossDoor) {
                 saveWarpEntrance = dungeons[j].entryway;
             }
         }


### PR DESCRIPTION
A longstanding bug, according to a comment, caused Link to be placed outside the boss room when respawning even when he saved and loaded from a boss room behind a boss door instead of being sent to the beginning of the dungeon.

This incidentally fixes #5468 , which was caused by the default here failing as when making a new save from generation in decoupled, the vanilla destination was not being set. We may at some point want to properly set it, but I simply wanted to focus on the bugfix.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7371910867.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7371795026.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7371775289.zip)
<!--- section:artifacts:end -->