### PR TITLE
Co op syncing and tower collapse softlock fixes.

### DIFF
--- a/soh/soh/Network/Anchor/Packets/SetFlag.cpp
+++ b/soh/soh/Network/Anchor/Packets/SetFlag.cpp
@@ -71,6 +71,11 @@ void Anchor::HandlePacket_SetFlag(nlohmann::json payload) {
             return;
         }
 
+        // Special case: Ignore Tower Collapse timer start.
+        if (sceneNum == SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR && flagType == FLAG_SCENE_SWITCH && flag == 0x36) {
+            return;
+        }
+
         auto effect = new GameInteractionEffect::SetSceneFlag();
         effect->parameters[0] = sceneNum;
         effect->parameters[1] = flagType;

--- a/soh/soh/Network/Anchor/Packets/UpdateTeamState.cpp
+++ b/soh/soh/Network/Anchor/Packets/UpdateTeamState.cpp
@@ -170,7 +170,7 @@ void Anchor::HandlePacket_UpdateTeamState(nlohmann::json payload) {
         }
 
         for (int i = 0; i < 14; i++) {
-            gSaveContext.eventChkInf[i] = loadedData.eventChkInf[i];
+            gSaveContext.eventChkInf[i] |= loadedData.eventChkInf[i];
         }
 
         for (int i = 0; i < 4; i++) {
@@ -179,7 +179,7 @@ void Anchor::HandlePacket_UpdateTeamState(nlohmann::json payload) {
 
         // Skip last row of infTable, don't want to sync swordless flag
         for (int i = 0; i < 29; i++) {
-            gSaveContext.infTable[i] = loadedData.infTable[i];
+            gSaveContext.infTable[i] |= loadedData.infTable[i];
         }
 
         for (int i = 0; i < ceil((RAND_INF_MAX + 15) / 16); i++) {

--- a/soh/soh/Network/Anchor/Packets/UpdateTeamState.cpp
+++ b/soh/soh/Network/Anchor/Packets/UpdateTeamState.cpp
@@ -219,6 +219,11 @@ void Anchor::HandlePacket_UpdateTeamState(nlohmann::json payload) {
 
         gSaveContext.inventory = loadedData.inventory;
 
+        if (gSaveContext.mapIndex == SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR) {
+            gSaveContext.subTimerState = 300;
+            gSaveContext.subTimerSeconds = 300;
+        }
+
         // The commented out code below is an attempt at sending the entire randomizer seed over, in hopes that a player
         // doesn't have to generate the seed themselves Currently it doesn't work :)
         if (IS_RANDO && payload["state"].contains("rando")) {

--- a/soh/soh/Network/Anchor/Packets/UpdateTeamState.cpp
+++ b/soh/soh/Network/Anchor/Packets/UpdateTeamState.cpp
@@ -160,6 +160,13 @@ void Anchor::HandlePacket_UpdateTeamState(nlohmann::json payload) {
                     (loadedData.sceneFlags[i].swch & ~mask) | (gSaveContext.sceneFlags[i].swch & mask);
             }
 
+            if (i == SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR) {
+                // Keep collapse timer flag
+                u32 mask = (1 << 0x36);
+                loadedData.sceneFlags[i].swch =
+                    (loadedData.sceneFlags[i].swch & ~mask) | (gSaveContext.sceneFlags[i].swch & mask);
+            }
+
             gSaveContext.sceneFlags[i] = loadedData.sceneFlags[i];
             if (IsSaveLoaded() && gPlayState->sceneNum == i) {
                 gPlayState->actorCtx.flags.chest = loadedData.sceneFlags[i].chest;
@@ -174,7 +181,7 @@ void Anchor::HandlePacket_UpdateTeamState(nlohmann::json payload) {
         }
 
         for (int i = 0; i < 4; i++) {
-            gSaveContext.itemGetInf[i] = loadedData.itemGetInf[i];
+            gSaveContext.itemGetInf[i] |= loadedData.itemGetInf[i];
         }
 
         // Skip last row of infTable, don't want to sync swordless flag
@@ -183,11 +190,11 @@ void Anchor::HandlePacket_UpdateTeamState(nlohmann::json payload) {
         }
 
         for (int i = 0; i < ceil((RAND_INF_MAX + 15) / 16); i++) {
-            gSaveContext.ship.randomizerInf[i] = loadedData.ship.randomizerInf[i];
+            gSaveContext.ship.randomizerInf[i] |= loadedData.ship.randomizerInf[i];
         }
 
         for (int i = 0; i < 6; i++) {
-            gSaveContext.gsFlags[i] = loadedData.gsFlags[i];
+            gSaveContext.gsFlags[i] |= loadedData.gsFlags[i];
         }
 
         gSaveContext.ship.stats.firstInput = loadedData.ship.stats.firstInput;
@@ -218,11 +225,6 @@ void Anchor::HandlePacket_UpdateTeamState(nlohmann::json payload) {
         }
 
         gSaveContext.inventory = loadedData.inventory;
-
-        if (gSaveContext.mapIndex == SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR) {
-            gSaveContext.subTimerState = 300;
-            gSaveContext.subTimerSeconds = 300;
-        }
 
         // The commented out code below is an attempt at sending the entire randomizer seed over, in hopes that a player
         // doesn't have to generate the seed themselves Currently it doesn't work :)


### PR DESCRIPTION
This corrects a number of softlocks that can occur if multiple people send update states at similar timings (because non set flags got hard written in instead of merging) where the last state sent is the one that gets accepted as the truth. This notoriously leads to softlocking in the light arrows cutscene that plays endlessly because the state for beginning that cutscene gets overwritten as unset.

Additionally, I have corrected the tower escape timer bug. It would sync the state to begin the timer for that scene, but since the text box never finished, it never got a 'set timer value' command and this would lead to whoever was still in collapse in the textbox getting endless void outs if someone else finishes the textbox.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7449370813.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7449309883.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7449292758.zip)
<!--- section:artifacts:end -->