### PR TITLE
Don't prevent child from accessing Ganon's Castle or GV Tent

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
@@ -9,6 +9,7 @@
 #include "soh/Enhancements/randomizer/randomizer_entrance_tracker.h"
 #include <nlohmann/json.hpp>
 #include <spdlog/fmt/fmt.h>
+#include <spdlog/spdlog.h>
 
 #include <cstdio>
 #include <cstdlib>
@@ -90,8 +91,16 @@ static void WriteShuffledEntrance(std::string sphereString, Entrance* entrance) 
     int16_t destinationIndex = -1;
     int16_t replacementIndex = entrance->GetReplacement()->GetIndex();
     int16_t replacementDestinationIndex = -1;
-    std::string name = EntranceTracker::GetEntranceData(originalIndex)->source;
-    std::string text = EntranceTracker::GetEntranceData(replacementIndex)->destination;
+    const EntranceData* sourceData = EntranceTracker::GetEntranceData(originalIndex);
+    const EntranceData* destinationData = EntranceTracker::GetEntranceData(replacementIndex);
+    if (sourceData == nullptr || destinationData == nullptr) {
+        SPDLOG_ERROR("WriteShuffledEntrance: missing entrance data for index {} (override {})", originalIndex,
+                     replacementIndex);
+        assert(false);
+        return;
+    }
+    std::string name = sourceData->source;
+    std::string text = destinationData->destination;
 
     // Track the reverse destination, useful for savewarp handling
     if (entrance->GetReverse() != nullptr) {

--- a/soh/soh/Enhancements/randomizer/entrance.cpp
+++ b/soh/soh/Enhancements/randomizer/entrance.cpp
@@ -826,20 +826,16 @@ static bool ValidateWorld(Entrance* entrancePlaced) {
         // This is mostly relevant when mixing entrance pools or shuffling special interiors (such as windmill or kak
         // potion shop) Warp Songs and Overworld Spawns can also end up inside certain indoors so those need to be
         // handled as well
-        std::array<std::string, 3> childForbidden = { "OGC Great Fairy Fountain -> Castle Grounds",
-                                                      "GV Carpenter Tent -> GV Fortress Side",
-                                                      "Ganon's Castle Entryway -> Castle Grounds From Ganon's Castle" };
+        std::array<std::string, 1> childForbidden = { "OGC Great Fairy Fountain -> Castle Grounds" };
         std::array<std::string, 2> adultForbidden = { "HC Great Fairy Fountain -> Castle Grounds",
                                                       "HC Storms Grotto -> Castle Grounds" };
 
         auto allShuffleableEntrances = GetShuffleableEntrances(EntranceType::All, false);
         for (auto& entrance : allShuffleableEntrances) {
-
             std::vector<Entrance*> alreadyChecked = {};
 
             if (entrance->IsShuffled()) {
                 if (entrance->GetReplacement() != nullptr) {
-
                     auto replacementName = entrance->GetReplacement()->GetName();
                     alreadyChecked.push_back(entrance->GetReplacement()->GetReverse());
 


### PR DESCRIPTION
With more shuffles & tricks these scenarios become common

also avoid segfault & log more info when writing entrances

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7468030584.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7467986184.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7467968362.zip)
<!--- section:artifacts:end -->