### PR TITLE
Add 6th notch to text speed which makes text speed instant

### DIFF
--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -435,9 +435,15 @@ void SohMenu::AddMenuEnhancements() {
     AddWidget(path, "Skip Text", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("SkipText"))
         .Options(CheckboxOptions().Tooltip("Holding down B skips text."));
-    AddWidget(path, "Text Speed: %dx", WIDGET_CVAR_SLIDER_INT)
+    AddWidget(path, "Text Speed", WIDGET_CVAR_SLIDER_INT)
         .CVar(CVAR_ENHANCEMENT("TextSpeed"))
-        .Options(IntSliderOptions().Min(1).Max(5).DefaultValue(1).Format("%dx"));
+        // Top notch (max) fills the whole text box in one frame
+        .Callback([](WidgetInfo& info) {
+            auto options = std::static_pointer_cast<IntSliderOptions>(info.options);
+            options->format = CVarGetInteger(info.cVar, 1) >= options->max ? "Instant" : "%dx";
+        })
+        .Options(IntSliderOptions().Min(1).Max(6).DefaultValue(1).Format(
+            CVarGetInteger(CVAR_ENHANCEMENT("TextSpeed"), 1) >= 6 ? "Instant" : "%dx"));
     AddWidget(path, "Slow Text Speed: %dx", WIDGET_CVAR_SLIDER_INT)
         .CVar(CVAR_ENHANCEMENT("SlowTextSpeed"))
         .Options(IntSliderOptions().Min(1).Max(5).DefaultValue(1).Format("%dx").Tooltip(

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -15,6 +15,9 @@
 #include "soh/SaveManager.h"
 #include "soh/ResourceManagerHelpers.h"
 
+// SOH [Enhancement] Text Speed which fills whole box in one frame
+#define TEXT_SPEED_INSTANT 6
+
 // #region SOH [NTSC] - Allows custom messages to work on japanese
 static bool sDisplayNextMessageAsEnglish = false;
 static u8 sLastLanguage = LANGUAGE_ENG;
@@ -1276,7 +1279,9 @@ void Message_DrawTextJPN(PlayState* play, Gfx** gfxP) {
         }
     }
 
-    if (msgCtx->textDelay == 0) {
+    if (gTextSpeed >= TEXT_SPEED_INSTANT) {
+        msgCtx->textDrawPos = msgCtx->decodedTextLen + 1;
+    } else if (msgCtx->textDelay == 0) {
         msgCtx->textDrawPos = i + gTextSpeed;
         if (msgCtx->textDrawPos > msgCtx->decodedTextLen) {
             msgCtx->textDrawPos = msgCtx->decodedTextLen + 1;
@@ -1626,7 +1631,9 @@ void Message_DrawText(PlayState* play, Gfx** gfxP) {
                 break;
         }
     }
-    if (msgCtx->textDelay == 0) {
+    if (gTextSpeed >= TEXT_SPEED_INSTANT) {
+        msgCtx->textDrawPos = msgCtx->decodedTextLen + 1;
+    } else if (msgCtx->textDelay == 0) {
         msgCtx->textDrawPos = i + gTextSpeed;
     } else if (msgCtx->textDelayTimer == 0) {
         msgCtx->textDrawPos = i + 1;


### PR DESCRIPTION
Helps frustration trying to read hints faster without skipping

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7469600724.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7469539723.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7469529026.zip)
<!--- section:artifacts:end -->