### PR TITLE
Fix random seed string gen

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/menu.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/menu.cpp
@@ -20,11 +20,11 @@ bool GenerateRandomizer(std::set<RandomizerCheck> excludedLocations, std::set<Ra
 
     // if a blank seed was entered, make a random one
     if (seedInput.empty()) {
-        char seedString[12];
+        char seedString[11];
         for (size_t i = 0; i < 10; i++) {
             seedString[i] = '0' + ShipUtils::Random(0, 10);
         }
-        seedString[11] = '\0';
+        seedString[10] = '\0';
         seedInput = std::string(seedString);
     } else if (seedInput.rfind("seed_testing_count", 0) == 0 && seedInput.length() > 18) {
         int count;

--- a/soh/soh/Enhancements/randomizer/3drando/playthrough.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/playthrough.cpp
@@ -94,11 +94,11 @@ int Playthrough_Repeat(std::set<RandomizerCheck> excludedLocations, std::set<Ran
     auto ctx = Rando::Context::GetInstance();
     uint32_t repeatedSeed = 0;
     for (int i = 0; i < count; i++) {
-        char seedString[12];
+        char seedString[11];
         for (size_t i = 0; i < 10; i++) {
             seedString[i] = '0' + ShipUtils::Random(0, 10);
         }
-        seedString[11] = '\0';
+        seedString[10] = '\0';
         ctx->SetSeedString(std::string(seedString));
         repeatedSeed = SohUtils::Hash(ctx->GetSeedString());
         ctx->SetSeed(repeatedSeed);

--- a/soh/soh/SohGui/SohMenuRandomizer.cpp
+++ b/soh/soh/SohGui/SohMenuRandomizer.cpp
@@ -563,7 +563,7 @@ void SohMenu::AddMenuRandomizer() {
                 for (size_t i = 0; i < 10; i++) {
                     seedString[i] = '0' + ShipUtils::Random(0, 10);
                 }
-                seedString[11] = '\0';
+                seedString[10] = '\0';
             }
             ImGui::SameLine();
             if (UIWidgets::Button(ICON_FA_ERASER, UIWidgets::ButtonOptions()


### PR DESCRIPTION
Index 10 was uninitialized, picking up arbitrary values in release builds, leading to an invalid UTF-8 byte and crash when writing the spoiler log

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7496747290.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7496650630.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7496637011.zip)
<!--- section:artifacts:end -->