### PR TITLE
uncomment code in z_camera.c

### DIFF
--- a/soh/src/code/z_camera.c
+++ b/soh/src/code/z_camera.c
@@ -4543,9 +4543,9 @@ s32 Camera_Subj4(Camera* camera) {
     }
 
     anim->unk_28 = temp_f16;
-    // camera->player->actor.world.pos = *eyeNext;
-    // camera->player->actor.world.pos.y = camera->playerGroundY;
-    // camera->player->actor.shape.rot.y = sp64.yaw;
+    camera->player->actor.world.pos = *eyeNext;
+    camera->player->actor.world.pos.y = camera->playerGroundY;
+    camera->player->actor.shape.rot.y = sp64.yaw;
     temp_f16 = ((240.0f * temp_f16) * (anim->unk_24 * 0.416667f));
     temp_a0 = temp_f16 + anim->unk_30;
     at->x = eye->x + (Math_SinS(temp_a0) * 10.0f);


### PR DESCRIPTION
pointed out by Evangelia, cause of discrepancy in crawlspace glitch:
* [Console](https://www.youtube.com/watch?v=2_tFHeEvXI0)
* [SoH](https://www.youtube.com/watch?v=-u3TzbdUr3c)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7512203275.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7512020279.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7511963779.zip)
<!--- section:artifacts:end -->