### PR TITLE
Single bombchu bag mode should give refills

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -428,9 +428,9 @@ ItemObtainability Randomizer::GetItemObtainabilityFromRandomizerGet(RandomizerGe
                 case RO_BOMBCHU_BAG_NONE:
                     return CANT_OBTAIN_MISC;
                 case RO_BOMBCHU_BAG_SINGLE:
-                    return INV_CONTENT(ITEM_BOMBCHU) == ITEM_BOMBCHU
-                               ? (infiniteUpgrades != RO_INF_UPGRADES_OFF ? CAN_OBTAIN : CANT_OBTAIN_ALREADY_HAVE)
-                               : CAN_OBTAIN;
+                    // In Single mode, the Bombchu Bag is always obtainable.
+                    // The first just grants the bag,
+                    return CAN_OBTAIN;
                 case RO_BOMBCHU_BAG_PROGRESSIVE:
                     if (Flags_GetRandomizerInf(RAND_INF_HAS_INFINITE_BOMBCHUS)) {
                         return CANT_OBTAIN_ALREADY_HAVE;

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -428,8 +428,6 @@ ItemObtainability Randomizer::GetItemObtainabilityFromRandomizerGet(RandomizerGe
                 case RO_BOMBCHU_BAG_NONE:
                     return CANT_OBTAIN_MISC;
                 case RO_BOMBCHU_BAG_SINGLE:
-                    // In Single mode, the Bombchu Bag is always obtainable.
-                    // The first just grants the bag,
                     return CAN_OBTAIN;
                 case RO_BOMBCHU_BAG_PROGRESSIVE:
                     if (Flags_GetRandomizerInf(RAND_INF_HAS_INFINITE_BOMBCHUS)) {


### PR DESCRIPTION
Should fix #6716 
I think that this nested ternary was copied from a different ammo type and doesn't really apply to this scenario.  Seems like a simple `CAN_OBTAIN` is enough here.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7538348427.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7538153763.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7538130124.zip)
<!--- section:artifacts:end -->