### PR TITLE
[Bug Fix] Fix Dark Link Crash/Missing Trails Bug

### DIFF
--- a/soh/soh/Network/Anchor/DummyPlayer.cpp
+++ b/soh/soh/Network/Anchor/DummyPlayer.cpp
@@ -70,7 +70,7 @@ void DummyPlayer_Init(Actor* actor, PlayState* play) {
     Player_SetModelGroup(player, Player_ActionToModelGroup(player, player->heldItemAction));
     play->playerInit(player, play, gPlayerSkelHeaders[client.linkAge]);
 
-    // Prevent dummy players from holding a weapon trail effect slot, as they don't use it anyway 
+    // Prevent dummy players from holding a weapon trail effect slot, as they don't use it anyway
     Effect_Delete(play, player->meleeWeaponEffectIndex);
     player->meleeWeaponEffectIndex = TOTAL_EFFECT_COUNT;
 

--- a/soh/soh/Network/Anchor/DummyPlayer.cpp
+++ b/soh/soh/Network/Anchor/DummyPlayer.cpp
@@ -70,6 +70,10 @@ void DummyPlayer_Init(Actor* actor, PlayState* play) {
     Player_SetModelGroup(player, Player_ActionToModelGroup(player, player->heldItemAction));
     play->playerInit(player, play, gPlayerSkelHeaders[client.linkAge]);
 
+    // Prevent dummy players from holding a weapon trail effect slot, as they don't use it anyway 
+    Effect_Delete(play, player->meleeWeaponEffectIndex);
+    player->meleeWeaponEffectIndex = TOTAL_EFFECT_COUNT;
+
     play->func_11D54(player, play);
     // #endregion
 


### PR DESCRIPTION
Fixes #6701 

Dummy Players were allocating melee weapon effect slots through Player_InitCommon but never releasing them. Over time, as players connected and disconnected, these leaked slots would accumulate until the effect pool was exhausted, causing weapon trails and other effects to stop spawning. In some cases, such as Dark Link, this could lead to a crash when a valid effect slot was assumed to exist.

This change frees the Dummy Player's melee weapon effect immediately after initialization. Since Dummy Players never use the effect, releasing it prevents the pool from gradually filling up and ensures effect slots remain available for gameplay.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7548816152.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7548685881.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7548636310.zip)
<!--- section:artifacts:end -->