### PR TITLE
feature(audio): SDL3 audio backend

### DIFF
--- a/.github/macports.yml
+++ b/.github/macports.yml
@@ -3,6 +3,10 @@ ports:
     select: [ universal ]
   - name: libsdl2_net
     select: [ universal ]
+  # SDL3 provides the optional SDL3 audio backend (loaded at runtime); its headers/config
+  # are needed at build time to compile the backend in.
+  - name: SDL3
+    select: [ universal ]
   - name: libpng
     select: [ universal ]
   - name: glew

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -133,6 +133,21 @@ jobs:
     - name: Remove distro tinyxml2
       run: sudo apt-get remove libtinyxml2-dev
     - uses: ./.github/actions/install-tinyxml2
+    - name: Install latest SDL3
+      # Ubuntu 22.04 has no libsdl3-dev. SDL3 supplies the optional SDL3 audio backend,
+      # which is loaded at runtime; its headers/config are needed at build time.
+      run: |
+        if [ ! -d "deps/SDL3-3.4.10" ]; then
+          wget https://github.com/libsdl-org/SDL/releases/download/release-3.4.10/SDL3-3.4.10.tar.gz
+          tar -xzf SDL3-3.4.10.tar.gz -C deps
+        fi
+        # SoH uses SDL3 for audio only. SDL_VIDEO=OFF avoids the X11/Wayland dev-package
+        # hard requirements (e.g. XTEST) the runner lacks; SDL_UNIX_CONSOLE_BUILD=ON lets
+        # SDL3 configure without any video backend (otherwise it refuses to build on Unix).
+        cmake -S deps/SDL3-3.4.10 -B deps/SDL3-3.4.10/build -DCMAKE_BUILD_TYPE=Release -DSDL_VIDEO=OFF -DSDL_UNIX_CONSOLE_BUILD=ON
+        cmake --build deps/SDL3-3.4.10/build -j 10
+        sudo cmake --install deps/SDL3-3.4.10/build
+        sudo cp -av /usr/local/lib/libSDL3* /lib/x86_64-linux-gnu/
     - name: Install libzip without crypto
       run: |
         sudo apt-get remove -y libzip-dev

--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -137,6 +137,21 @@ jobs:
     - name: Remove distro tinyxml2
       run: sudo apt-get remove libtinyxml2-dev
     - uses: ./.github/actions/install-tinyxml2
+    - name: Install latest SDL3
+      # Ubuntu 22.04 has no libsdl3-dev. SDL3 supplies the optional SDL3 audio backend,
+      # which is loaded at runtime; its headers/config are needed at build time.
+      run: |
+        if [ ! -d "deps/SDL3-3.4.10" ]; then
+          wget https://github.com/libsdl-org/SDL/releases/download/release-3.4.10/SDL3-3.4.10.tar.gz
+          tar -xzf SDL3-3.4.10.tar.gz -C deps
+        fi
+        # SoH uses SDL3 for audio only. SDL_VIDEO=OFF avoids the X11/Wayland dev-package
+        # hard requirements (e.g. XTEST) the runner lacks; SDL_UNIX_CONSOLE_BUILD=ON lets
+        # SDL3 configure without any video backend (otherwise it refuses to build on Unix).
+        cmake -S deps/SDL3-3.4.10 -B deps/SDL3-3.4.10/build -DCMAKE_BUILD_TYPE=Release -DSDL_VIDEO=OFF -DSDL_UNIX_CONSOLE_BUILD=ON
+        cmake --build deps/SDL3-3.4.10/build -j 10
+        sudo cmake --install deps/SDL3-3.4.10/build
+        sudo cp -av /usr/local/lib/libSDL3* /lib/x86_64-linux-gnu/
     - name: Install libzip without crypto
       run: |
         sudo apt-get remove -y libzip-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     endif()
 
     vcpkg_bootstrap()
-    vcpkg_install_packages(zlib bzip2 libzip libpng sdl2 sdl2-net glew glfw3 nlohmann-json tinyxml2 spdlog libogg libvorbis opus opusfile)
+    vcpkg_install_packages(zlib bzip2 libzip libpng sdl2 sdl2-net glew glfw3 nlohmann-json tinyxml2 spdlog libogg libvorbis opus opusfile sdl3)
     if (CMAKE_C_COMPILER_LAUNCHER MATCHES "ccache|sccache")
         set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     endif()
 
     vcpkg_bootstrap()
-    vcpkg_install_packages(zlib bzip2 libzip libpng sdl2 sdl2-net glew glfw3 nlohmann-json tinyxml2 spdlog libogg libvorbis opus opusfile)
+    vcpkg_install_packages(zlib bzip2 libzip libpng sdl2 sdl2-net glew glfw3 nlohmann-json tinyxml2 spdlog libogg libvorbis opus opusfile sdl3)
     if (CMAKE_C_COMPILER_LAUNCHER MATCHES "ccache|sccache")
         set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     endif()
 
     vcpkg_bootstrap()
+    # sdl3 supplies the optional SDL3 audio backend (loaded at runtime; headers needed at build).
     vcpkg_install_packages(zlib bzip2 libzip libpng sdl2 sdl2-net glew glfw3 nlohmann-json tinyxml2 spdlog libogg libvorbis opus opusfile sdl3)
     if (CMAKE_C_COMPILER_LAUNCHER MATCHES "ccache|sccache")
         set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     endif()
 
     vcpkg_bootstrap()
+    # sdl3 supplies the optional SDL3 audio backend (loaded at runtime; headers needed at build).
     vcpkg_install_packages(zlib bzip2 libzip libpng sdl2 sdl2-net glew glfw3 nlohmann-json tinyxml2 spdlog libogg libvorbis opus opusfile sdl3)
     if (CMAKE_C_COMPILER_LAUNCHER MATCHES "ccache|sccache")
         set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded)

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -134,7 +134,6 @@ zypper in gcc gcc-c++ $(cat linux-build-deps/zypper.txt)
 # or using clang
 zypper in clang libstdc++-devel $(cat linux-build-deps/zypper.txt)
 ```
-_Optional: install SDL3 (`libsdl3-dev` on Debian 13+/Ubuntu 24.10+, `sdl3` on Arch, `SDL3-devel` on Fedora 40+) to enable the SDL3 audio backend. It is compiled in only when SDL3 development files are present; without them the backend is simply left out._
 #### Nix
 This repository provides a [`linux-build-deps/flake.nix`](../linux-build-deps/flake.nix) for setting up a development environment using [Nix](https://nixos.org/).
 
@@ -156,6 +155,15 @@ If your cmake is too old, you can install a newer version via:
 - [pypi](https://pypi.org/project/cmake/)
 - [kitware apt repo](https://apt.kitware.com/) (Ubuntu only)
 - [Homebrew](https://formulae.brew.sh/formula/cmake)
+
+### Optional: SDL3 audio backend
+On Linux the default audio backend uses SDL2. An alternative SDL3 backend is also
+available and is recommended where SDL3 is present. It is **compiled in** only when
+SDL3 development files are found at build time (`libsdl3-dev` on Debian 13+/Ubuntu
+24.10+, `sdl3` on Arch, `SDL3-devel` on Fedora 40+); otherwise it is silently left out.
+It is **loaded at runtime** from the system SDL3, so the `libsdl3` runtime package must
+also be installed to select the backend in-game. Windows and macOS use their native
+WASAPI / CoreAudio backends, so this backend is primarily useful on Linux.
 
 ### Build
 
@@ -237,8 +245,6 @@ cmake --build build-cmake --target ExtractAssetHeaders
 
 ## macOS
 Requires Xcode (or xcode-tools) && `sdl2, sdl2_net, libpng, glew, ninja, cmake, tinyxml2, nlohmann-json, libzip, opusfile, libvorbis` (can be installed via [homebrew](https://brew.sh/), macports, etc)
-
-_Optional: also install SDL3 (`sdl3` via homebrew, `SDL3` via MacPorts) to enable the SDL3 audio backend; it is compiled in only when present._
 
 **Important: For maximum performance make sure you have ninja build tools installed!**
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -134,6 +134,7 @@ zypper in gcc gcc-c++ $(cat linux-build-deps/zypper.txt)
 # or using clang
 zypper in clang libstdc++-devel $(cat linux-build-deps/zypper.txt)
 ```
+_Optional: install SDL3 (`libsdl3-dev` on Debian 13+/Ubuntu 24.10+, `sdl3` on Arch, `SDL3-devel` on Fedora 40+) to enable the SDL3 audio backend. It is compiled in only when SDL3 development files are present; without them the backend is simply left out._
 #### Nix
 This repository provides a [`linux-build-deps/flake.nix`](../linux-build-deps/flake.nix) for setting up a development environment using [Nix](https://nixos.org/).
 
@@ -236,6 +237,8 @@ cmake --build build-cmake --target ExtractAssetHeaders
 
 ## macOS
 Requires Xcode (or xcode-tools) && `sdl2, sdl2_net, libpng, glew, ninja, cmake, tinyxml2, nlohmann-json, libzip, opusfile, libvorbis` (can be installed via [homebrew](https://brew.sh/), macports, etc)
+
+_Optional: also install SDL3 (`sdl3` via homebrew, `SDL3` via MacPorts) to enable the SDL3 audio backend; it is compiled in only when present._
 
 **Important: For maximum performance make sure you have ninja build tools installed!**
 

--- a/soh/soh/SohGui/BackendTypes.h
+++ b/soh/soh/SohGui/BackendTypes.h
@@ -6,6 +6,7 @@
 static const std::map<Ship::AudioBackend, const char*> audioBackendsMap = {
     { Ship::AudioBackend::WASAPI, "Windows Audio Session API" },
     { Ship::AudioBackend::SDL, "SDL" },
+    { Ship::AudioBackend::SDL3, "SDL3" },
     { Ship::AudioBackend::COREAUDIO, "Core Audio" },
     { Ship::AudioBackend::NUL, "Null" },
 };

--- a/soh/soh/SohGui/SohGui.cpp
+++ b/soh/soh/SohGui/SohGui.cpp
@@ -33,13 +33,14 @@ static const inline std::vector<std::pair<const char*, const char*>> audioBacken
 #ifdef _WIN32
     { "wasapi", "Windows Audio Session API" },
 #endif
-#if defined(__linux)
+#if defined(__linux__)
     { "pulse", "PulseAudio" },
 #endif
 #ifdef __APPLE__
     { "coreaudio", "Core Audio" },
 #endif
-    { "sdl", "SDL Audio" }
+    { "sdl", "SDL Audio" },
+    { "sdl3", "SDL3 Audio" }
 };
 
 // MARK: - Helpers


### PR DESCRIPTION
This brings SDL3 as an optional dependency to allow using SDL3 as an audio backend. This is working much better on Linux than the only SDL2 audio backend available.

As discussed in https://github.com/Kenix3/libultraship/pull/1105 and https://github.com/Kenix3/libultraship/pull/1107, currently the SDL audio backend has quite a lot of audio artifacts. On Windows and macOS, the dedicated WASAPI and CoreAudio backends make it less important, as these backends are of good quality (fewer audio artifacts), but Linux only has the SDL2 backend available.
Since fixing SDL2 backend or merging my PipeWire backend (Linux modern audio api) does not seem to have a lot of interest, it was discussed an SDL3 backend would be a better fit for the project.

This PR does not need to migrate the whole project to SDL3, as it loads only the Audio symbols directly from the DLL/so, and is designed to work on all platforms (only tested on Linux so far), while we are waiting for a full migration.

https://github.com/Kenix3/libultraship/pull/1125 is targetting LUS' main branch, while this here pins a version on top of LUS' port-maintenance branch.

Also make sure we merge #6704, as it also adds audio artifacts.
This PR makes #6665 less important, as we now should use the SDL3 backend on Linux.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9346101551.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9345525819.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9345397268.zip)
<!--- section:artifacts:end -->