### PR TITLE
Fix [Sail] OnLoadGame hook does not trigger

### DIFF
--- a/soh/soh/Network/Sail/Sail.cpp
+++ b/soh/soh/Network/Sail/Sail.cpp
@@ -347,7 +347,7 @@ void Sail::RegisterHooks() {
     });
 
     COND_HOOK(OnLoadGame, isConnected, [&](int32_t fileNum) {
-        if (!isConnected || !GameInteractor::IsSaveLoaded())
+        if (!isConnected)
             return;
 
         nlohmann::json payload;


### PR DESCRIPTION
When the `OnLoadGame` hook is triggered, `GameInteractor::IsSaveLoaded()` returns false, causing the hook to not process.
Removed the check and now it works as expected.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7582345781.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7582258400.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7582234362.zip)
<!--- section:artifacts:end -->