### PR TITLE
Fix Outside ToT crash when using din's or dying

### DIFF
--- a/soh/soh/Enhancements/AlwaysOnFixes.cpp
+++ b/soh/soh/Enhancements/AlwaysOnFixes.cpp
@@ -3,7 +3,7 @@
 #include "soh/ShipInit.hpp"
 
 // Dying or using Din's Fire in the Outside Temple of Time area crashes the game.
-// In vanilla this can never happen, but with CrowdControl, Sail, Unregstricted Items
+// In vanilla this can never happen, but with CrowdControl, Sail, Unrestricted Items
 // and others this *can* happen. Because it checks for a camId of -1, this code path
 // shouldn't ever influence vanilla play regardless.
 void RegisterFixOutsideTotCrash() {

--- a/soh/soh/Enhancements/AlwaysOnFixes.cpp
+++ b/soh/soh/Enhancements/AlwaysOnFixes.cpp
@@ -1,0 +1,18 @@
+#include <libultraship/bridge.h>
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+
+// Dying or using Din's Fire in the Outside Temple of Time area crashes the game.
+// In vanilla this can never happen, but with CrowdControl, Sail, Unregstricted Items
+// and others this *can* happen. Because it checks for a camId of -1, this code path
+// shouldn't ever influence vanilla play regardless.
+void RegisterFixOutsideTotCrash() {
+    COND_VB_SHOULD(VB_SHOULD_LOAD_BG_IMAGE, true, {
+        int32_t* camId = va_arg(args, int*);
+        if (*camId == -1) {
+            *should = false;
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterFixOutsideTotCrash, { "" });

--- a/soh/soh/Enhancements/Cheats/UnrestrictedItems.cpp
+++ b/soh/soh/Enhancements/Cheats/UnrestrictedItems.cpp
@@ -21,12 +21,6 @@ void OnGameFrameUpdateUnrestrictedItems() {
 
 void RegisterUnrestrictedItems() {
     COND_HOOK(OnGameFrameUpdate, CVAR_UNRESTRICTED_ITEMS_VALUE, OnGameFrameUpdateUnrestrictedItems);
-    COND_VB_SHOULD(VB_SHOULD_LOAD_BG_IMAGE, CVAR_UNRESTRICTED_ITEMS_VALUE, {
-        int32_t* camId = va_arg(args, int*);
-        if (*camId == -1) {
-            *should = false;
-        }
-    });
 }
 
 static RegisterShipInitFunc initFunc(RegisterUnrestrictedItems, { CVAR_UNRESTRICTED_ITEMS_NAME });

--- a/soh/soh/Network/CrowdControl/CrowdControl.cpp
+++ b/soh/soh/Network/CrowdControl/CrowdControl.cpp
@@ -681,14 +681,3 @@ std::unique_ptr<CrowdControl::Effect> CrowdControl::ParseMessage(nlohmann::json 
 
     return effect;
 }
-
-void RegisterCrowdControlHooks() {
-    COND_VB_SHOULD(VB_SHOULD_LOAD_BG_IMAGE, CVarGetInteger(CVAR_REMOTE_CROWD_CONTROL("Enabled"), 0), {
-        int32_t* camId = va_arg(args, int*);
-        if (*camId == -1) {
-            *should = false;
-        }
-    });
-}
-
-static RegisterShipInitFunc initFunc(RegisterCrowdControlHooks, { CVAR_REMOTE_CROWD_CONTROL("Enabled") });


### PR DESCRIPTION
This fix was changed to always be on previously, but it seems when it was hookified it was tied to CrowdControl and Unrestricted Items again, while it can also happen with Sail and newer features. This changes it to always be on. It should never run this in vanilla play anyway because of the camId check of -1, so it should be safe to have it always run.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7588247517.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7588093621.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7588070922.zip)
<!--- section:artifacts:end -->