### PR TITLE
Remove REMOTE_CONTROL flags while building

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -48,6 +48,18 @@ jobs:
         make -j 10
         sudo make install
         sudo cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/
+    - name: Install latest SDL_net
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        if [ ! -d "deps/SDL2_net-2.2.0" ]; then
+          wget https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.2.0.tar.gz
+          tar -xzf SDL2_net-2.2.0.tar.gz -C deps
+        fi
+        cd deps/SDL2_net-2.2.0
+        ./configure
+        make -j 10
+        sudo make install
+        sudo cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/
     - name: Install latest tinyxml2
       run: |
         sudo apt-get remove libtinyxml2-dev

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -153,11 +153,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set_source_files_properties(soh/Enhancements/custom-message/CustomMessageManager.h PROPERTIES COMPILE_FLAGS "/utf-8")
 endif()
 
-# handle Network removals
-if (!BUILD_REMOTE_CONTROL)
-    list(FILTER soh__ EXCLUDE REGEX "soh/Enhancements/crowd-control/")
-endif()
-
 # handle speechsynthesizer removals
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     list(FILTER soh__ EXCLUDE REGEX "soh/Enhancements/speechsynthesizer/Darwin")
@@ -308,15 +303,12 @@ FetchContent_MakeAvailable(dr_libs)
 find_package(SDL2)
 set(SDL2-INCLUDE ${SDL2_INCLUDE_DIRS})
 
-if (BUILD_REMOTE_CONTROL)
-    find_package(SDL2_net)
+find_package(SDL2_net)
 
-    if(NOT SDL2_net_FOUND)
-        message(STATUS "SDL2_net not found (it's possible the version installed is too old). Disabling BUILD_REMOTE_CONTROL.")
-        set(BUILD_REMOTE_CONTROL 0)
-    else()
-        set(SDL2-NET-INCLUDE ${SDL_NET_INCLUDE_DIRS})
-    endif()
+if(NOT SDL2_net_FOUND)
+    message(STATUS "SDL2_net not found (it's possible the version installed is too old).")
+else()
+    set(SDL2-NET-INCLUDE ${SDL_NET_INCLUDE_DIRS})
 endif()
 
 if (ESPEAK)
@@ -350,7 +342,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
             "$<$<CONFIG:Release>:"
                 "NDEBUG;"
             ">"
-            "$<$<BOOL:${BUILD_REMOTE_CONTROL}>:ENABLE_REMOTE_CONTROL>"
             "INCLUDE_GAME_PRINTF;"
             "F3DEX_GBI_2"
             "UNICODE;"
@@ -407,7 +398,6 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|Clang|AppleClang")
             "NDEBUG;"
         ">"
         "F3DEX_GBI_2;"
-        "$<$<BOOL:${BUILD_REMOTE_CONTROL}>:ENABLE_REMOTE_CONTROL>;"
         "_CONSOLE;"
         "_CRT_SECURE_NO_WARNINGS;"
         "ENABLE_OPENGL;"
@@ -652,7 +642,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
             "glu32;"
             "SDL2::SDL2;"
             "SDL2::SDL2main;"
-            "$<$<BOOL:${BUILD_REMOTE_CONTROL}>:SDL2_net::SDL2_net-static>"
+            "SDL2_net::SDL2_net-static"
             "glfw;"
             "winmm;"
             "imm32;"
@@ -718,7 +708,7 @@ else()
         "Vorbis::vorbisfile"
         "Opus::opus"
         "Opusfile::Opusfile"
-        "$<$<BOOL:${BUILD_REMOTE_CONTROL}>:SDL2_net::SDL2_net>"
+        "SDL2_net::SDL2_net"
         ${CMAKE_DL_LIBS}
         Threads::Threads
     )

--- a/soh/soh/Network/Anchor/Menu.cpp
+++ b/soh/soh/Network/Anchor/Menu.cpp
@@ -243,7 +243,6 @@ void AnchorInstructionsMenu(WidgetInfo& info) {
         "the same randomizer seed, while players on different teams can use different seeds.");
 }
 
-#ifdef ENABLE_REMOTE_CONTROL
 void RegisterAnchorMenu() {
     WidgetPath path = { "Network", "Anchor", SECTION_COLUMN_1 };
     SohGui::mSohMenu->AddWidget(path, "AnchorMainMenu", WIDGET_CUSTOM)
@@ -259,4 +258,3 @@ void RegisterAnchorMenu() {
 }
 
 static RegisterMenuInitFunc menuInitFunc(RegisterAnchorMenu);
-#endif

--- a/soh/soh/Network/Network.cpp
+++ b/soh/soh/Network/Network.cpp
@@ -5,7 +5,6 @@
 // MARK: - Public
 
 void Network::Enable(const char* host, uint16_t port) {
-#ifdef ENABLE_REMOTE_CONTROL
     if (isEnabled) {
         return;
     }
@@ -22,7 +21,6 @@ void Network::Enable(const char* host, uint16_t port) {
     }
 
     receiveThread = std::thread(&Network::ReceiveFromServer, this);
-#endif
 }
 
 void Network::Disable() {
@@ -50,10 +48,8 @@ void Network::ProcessOutgoingPackets() {
 }
 
 void Network::SendDataToRemote(const char* payload) {
-#ifdef ENABLE_REMOTE_CONTROL
     SPDLOG_DEBUG("[Network] Sending data: {}", payload);
     SDLNet_TCP_Send(networkSocket, payload, strlen(payload) + 1);
-#endif
 }
 
 void Network::SendJsonToRemote(nlohmann::json payload) {
@@ -63,7 +59,6 @@ void Network::SendJsonToRemote(nlohmann::json payload) {
 // MARK: - Private
 
 void Network::ReceiveFromServer() {
-#ifdef ENABLE_REMOTE_CONTROL
     while (isEnabled) {
         while (!isConnected && isEnabled) {
             SPDLOG_TRACE("[Network] Attempting to make connection to server...");
@@ -140,7 +135,6 @@ void Network::ReceiveFromServer() {
             SPDLOG_INFO("[Network] Ending receiving thread...");
         }
     }
-#endif
 }
 
 void Network::HandleRemoteData(char payload[512]) {

--- a/soh/soh/Network/Network.h
+++ b/soh/soh/Network/Network.h
@@ -3,17 +3,13 @@
 #ifdef __cplusplus
 
 #include <thread>
-#ifdef ENABLE_REMOTE_CONTROL
 #include <SDL2/SDL_net.h>
-#endif
 #include <nlohmann/json.hpp>
 
 class Network {
   private:
-#ifdef ENABLE_REMOTE_CONTROL
     IPaddress networkAddress;
     TCPsocket networkSocket;
-#endif
     std::thread receiveThread;
     std::string receivedData;
 

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1530,9 +1530,7 @@ extern "C" void InitOTR(int argc, char* argv[]) {
     }
 
     srand(static_cast<unsigned int>(now));
-#ifdef ENABLE_REMOTE_CONTROL
     SDLNet_Init();
-#endif
     if (CVarGetInteger(CVAR_REMOTE_CROWD_CONTROL("Enabled"), 0)) {
         CrowdControl::Instance->Enable();
     }
@@ -1563,9 +1561,7 @@ extern "C" void DeinitOTR() {
     if (CVarGetInteger(CVAR_REMOTE_ANCHOR("Enabled"), 0)) {
         Anchor::Instance->Disable();
     }
-#ifdef ENABLE_REMOTE_CONTROL
     SDLNet_Quit();
-#endif
 
     // Destroying gui here because we have shared ptrs to LUS objects which output to SPDLOG which is destroyed before
     // these shared ptrs.

--- a/soh/soh/SohGui/SohMenuNetwork.cpp
+++ b/soh/soh/SohGui/SohMenuNetwork.cpp
@@ -17,18 +17,6 @@ void SohMenu::AddMenuNetwork() {
     AddMenuEntry("Network", CVAR_SETTING("Menu.NetworkSidebarSection"));
     WidgetPath path;
 
-#ifndef ENABLE_REMOTE_CONTROL
-    path = { "Network", "Info", SECTION_COLUMN_1 };
-    AddSidebarEntry("Network", path.sidebarName, 2);
-
-    AddWidget(path,
-              ICON_FA_EXCLAMATION_TRIANGLE " The Network features are unavailable because SoH was compiled without "
-                                           "network support (\"ENABLE_REMOTE_CONTROL\" build flag).",
-              WIDGET_TEXT)
-        .Options(TextOptions().Color(Colors::Orange));
-    return;
-#endif
-
     // Sail
     path = { "Network", "Sail", SECTION_COLUMN_1 };
     AddSidebarEntry("Network", path.sidebarName, 3);


### PR DESCRIPTION
Removes the BUILD_REMOTE_CONTROL flag while building and the ENABLE_REMOTE_CONTROL references in code.

I think when we initially added this because the Wii U and Switch couldn't pull in SDL_Net2 or something? According to lywx Switch would be fine with it now, and I don't know if we really want to keep the maintenance required to uphold this flag just for the Wii U and having slightly less dependencies. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7599988732.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7599946258.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7599846276.zip)
<!--- section:artifacts:end -->