### PR TITLE
Fix Bottom of the Well Coffin Logic

### DIFF
--- a/soh/soh/Enhancements/randomizer/location_access/dungeons/bottom_of_the_well.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/dungeons/bottom_of_the_well.cpp
@@ -155,8 +155,8 @@ void RegionTable_Init_BottomOfTheWell() {
     areaTable[RR_BOTW_CRYPT] = Region("Bottom of the Well Crypt", SCENE_BOTTOM_OF_THE_WELL, {}, {
         //Locations
         LOCATION(RC_BOTTOM_OF_THE_WELL_FREESTANDING_KEY,               logic->HasFireSourceWithTorch() || logic->CanUse(RG_FAIRY_BOW)),
-        LOCATION(RC_BOTTOM_OF_THE_WELL_COFFIN_ROOM_FRONT_LEFT_HEART,   true),
-        LOCATION(RC_BOTTOM_OF_THE_WELL_COFFIN_ROOM_MIDDLE_RIGHT_HEART, logic->HasFireSourceWithTorch() || logic->CanUse(RG_FAIRY_BOW)),
+        LOCATION(RC_BOTTOM_OF_THE_WELL_COFFIN_ROOM_FRONT_LEFT_HEART,   logic->HasFireSourceWithTorch() || logic->CanUse(RG_FAIRY_BOW)),
+        LOCATION(RC_BOTTOM_OF_THE_WELL_COFFIN_ROOM_MIDDLE_RIGHT_HEART, true),
     }, {
         //Exits
         ENTRANCE(RR_BOTW_BEHIND_MOAT, true),


### PR DESCRIPTION
Noticed this while playing Archipelago, but it seems like these coffins should have their logic swapped based on the attached picture? I went ahead and fixed it, but let me know if I'm missing anything

<img width="1903" height="1065" alt="image" src="https://github.com/user-attachments/assets/2a832786-82b1-4c7e-83f7-06582a8837e5" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7624624135.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7624558734.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7624553498.zip)
<!--- section:artifacts:end -->