### PR TITLE
fix(audio): replace stray custom-sequence printf with a debug log

### DIFF
--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -1443,7 +1443,7 @@ void AudioLoad_Init(void* heap, size_t heapSize) {
         AudioCollection_AddToCollection(customSeqList[j], seqNum);
 
         sDat->seqNumber = seqNum;
-        printf("%d\n", seqNum);
+        LUSLOG_DEBUG("Registered custom sequence \"%s\" as seqNum %d", customSeqList[j], seqNum);
         sequenceMap[sDat->seqNumber] = strdup(customSeqList[j]);
         seqNum++;
     }


### PR DESCRIPTION
The custom-sequence registration loop printed each assigned seqNum to stdout via a bare printf, spamming the console with context-free numbers on every launch. Convert it to LUSLOG_DEBUG and include the sequence name so it is hidden by default yet useful for diagnosing music-pack loading.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7655347461.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7655254910.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7655227853.zip)
<!--- section:artifacts:end -->