### PR TITLE
fix: free look releases the door peek camera

### DIFF
--- a/soh/soh/Enhancements/camera/FreeLookDoorCamRelease.cpp
+++ b/soh/soh/Enhancements/camera/FreeLookDoorCamRelease.cpp
@@ -1,0 +1,26 @@
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/Enhancements/controls/Mouse.h"
+#include "soh/ShipInit.hpp"
+
+#include <cmath>
+
+extern "C" {
+#include "global.h"
+}
+
+void RegisterFreeLookDoorCamRelease() {
+    COND_VB_SHOULD(VB_RELEASE_DOORC_CAMERA, CVarGetInteger(CVAR_SETTING("FreeLook.Enabled"), 0), {
+        Camera* camera = va_arg(args, Camera*);
+
+        // Also release the door peek camera when free look moves it, reusing SetCameraManual's threshold.
+        f32 freeLookX = -camera->play->state.input[0].cur.right_stick_x * 10.0f;
+        f32 freeLookY = camera->play->state.input[0].cur.right_stick_y * 10.0f;
+        Mouse_HandleThirdPerson(&freeLookX, &freeLookY);
+
+        if (fabsf(freeLookX) >= 15.0f || fabsf(freeLookY) >= 15.0f) {
+            *should = true;
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterFreeLookDoorCamRelease, { CVAR_SETTING("FreeLook.Enabled") });

--- a/soh/soh/Enhancements/camera/FreeLookDoorCamRelease.cpp
+++ b/soh/soh/Enhancements/camera/FreeLookDoorCamRelease.cpp
@@ -2,7 +2,7 @@
 #include "soh/Enhancements/controls/Mouse.h"
 #include "soh/ShipInit.hpp"
 
-#include <cmath>
+#include <math.h>
 
 extern "C" {
 #include "global.h"

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -2083,6 +2083,13 @@ typedef enum {
     VB_RED_ICE_MELTED_FLAG,
 
     // #### `result`
+    // ```c
+    // camera->xzSpeed > 0.001f || <any release button pressed> || params->interfaceFlags & 0x8
+    // ```
+    // #### `args`
+    // - `Camera*` (`camera`)
+    VB_RELEASE_DOORC_CAMERA,
+
     // #### `result`
     // ```c
     // true

--- a/soh/src/code/z_camera.c
+++ b/soh/src/code/z_camera.c
@@ -6917,33 +6917,28 @@ s32 Camera_Special9(Camera* camera) {
             }
         case 4:
             camera->animState++;
-        default: {
+        default:
             camera->unk_14C |= (0x400 | 0x10);
             sCameraInterfaceFlags = 0;
 
-            // SOH [Enhancement] Also release the door camera on right-stick input, reusing the
-            // free-look activation threshold (see SetCameraManual).
-            f32 freeLookX = -D_8015BD7C->state.input[0].cur.right_stick_x * 10.0f;
-            f32 freeLookY = D_8015BD7C->state.input[0].cur.right_stick_y * 10.0f;
-            Mouse_HandleThirdPerson(&freeLookX, &freeLookY);
-            s32 freeLookMoved = CVarGetInteger(CVAR_SETTING("FreeLook.Enabled"), 0) &&
-                                (fabsf(freeLookX) >= 15.0f || fabsf(freeLookY) >= 15.0f);
-
-            if (camera->xzSpeed > 0.001f || freeLookMoved ||
-                CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_A) ||
-                CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_B) ||
-                CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_CLEFT) ||
-                CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_CDOWN) ||
-                CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_CUP) ||
-                CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_CRIGHT) ||
-                CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_R) ||
-                CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_Z) || params->interfaceFlags & 0x8) {
+            // SOH [Enhancement] VB_RELEASE_DOORC_CAMERA lets free look hand the door peek camera
+            // back on right-stick input (see soh/Enhancements/camera/FreeLookDoorCamRelease.cpp).
+            if (GameInteractor_Should(
+                    VB_RELEASE_DOORC_CAMERA,
+                    camera->xzSpeed > 0.001f || CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_A) ||
+                        CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_B) ||
+                        CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_CLEFT) ||
+                        CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_CDOWN) ||
+                        CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_CUP) ||
+                        CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_CRIGHT) ||
+                        CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_R) ||
+                        CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_Z) || params->interfaceFlags & 0x8,
+                    camera)) {
 
                 Camera_ChangeSettingFlags(camera, camera->prevSetting, 2);
                 camera->unk_14C |= (0x4 | 0x2);
             }
             break;
-        }
     }
     spAC = playerPosRot->pos;
     spAC.y += playerYOffset;

--- a/soh/src/code/z_camera.c
+++ b/soh/src/code/z_camera.c
@@ -6917,11 +6917,20 @@ s32 Camera_Special9(Camera* camera) {
             }
         case 4:
             camera->animState++;
-        default:
+        default: {
             camera->unk_14C |= (0x400 | 0x10);
             sCameraInterfaceFlags = 0;
 
-            if (camera->xzSpeed > 0.001f || CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_A) ||
+            // SOH [Enhancement] Also release the door camera on right-stick input, reusing the
+            // free-look activation threshold (see SetCameraManual).
+            f32 freeLookX = -D_8015BD7C->state.input[0].cur.right_stick_x * 10.0f;
+            f32 freeLookY = D_8015BD7C->state.input[0].cur.right_stick_y * 10.0f;
+            Mouse_HandleThirdPerson(&freeLookX, &freeLookY);
+            s32 freeLookMoved = CVarGetInteger(CVAR_SETTING("FreeLook.Enabled"), 0) &&
+                                (fabsf(freeLookX) >= 15.0f || fabsf(freeLookY) >= 15.0f);
+
+            if (camera->xzSpeed > 0.001f || freeLookMoved ||
+                CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_A) ||
                 CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_B) ||
                 CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_CLEFT) ||
                 CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_CDOWN) ||
@@ -6934,6 +6943,7 @@ s32 Camera_Special9(Camera* camera) {
                 camera->unk_14C |= (0x4 | 0x2);
             }
             break;
+        }
     }
     spAC = playerPosRot->pos;
     spAC.y += playerYOffset;


### PR DESCRIPTION
## Problem

With the Free Camera (Free Look) enhancement on, the camera felt frozen after every door. Walking through a door hands the view to the door peek camera (`CAM_SET_DOORC`, `Camera_Special9`), which only returns control to the normal camera once the player moves or presses a button. The right stick was not one of those release conditions, so free look did nothing until you nudged the player.

## Fix

Treat right-stick input as a release condition too, reusing the same stick threshold as free-look activation (`SetCameraManual`). The door peek still plays as before; it just hands control back when you start looking around. Behavior is unchanged when Free Look is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7738989465.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7738975527.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7738974710.zip)
<!--- section:artifacts:end -->