### PR TITLE
Fix Notifications

### DIFF
--- a/soh/soh/Notification/Notification.cpp
+++ b/soh/soh/Notification/Notification.cpp
@@ -52,7 +52,7 @@ void Window::Draw() {
 
     for (int index = 0; index < notifications.size(); ++index) {
         auto& notification = notifications[index];
-        int inverseIndex = -ABS(index - (static_cast<int>(notifications.size()) - 1));
+        int inverseIndex = ABS(index - (static_cast<int>(notifications.size()) - 1));
 
         ImGui::SetNextWindowViewport(vp->ID);
         if (notification.remainingTime < 4.0f) {


### PR DESCRIPTION
When playtesting the Stat Item prs it seemed that notifications were growing on the wrong direction. (out of screen rather than inwards

After some digging it turned out https://github.com/HarbourMasters/Shipwright/pull/5858 seems to have caused notifications to missbehave.

I also tested nightly and it was in there aswell

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7696460094.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7695611657.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7695597781.zip)
<!--- section:artifacts:end -->