### PR TITLE
Ivan: Allow Ivan to break pots and crates while far from Link

### DIFF
--- a/soh/soh/Enhancements/ExtraModes/IvanCoop.cpp
+++ b/soh/soh/Enhancements/ExtraModes/IvanCoop.cpp
@@ -65,7 +65,6 @@ static bool ShouldPatchDist(s16 actorId) {
         // Checks for explosions if player is nearby:
         case ACTOR_BG_SPOT17_BAKUDANKABE:
             return true;
-
     }
     return false;
 }
@@ -84,7 +83,6 @@ static f32 ClampDist(f32 distance, s16 actorId) {
         case ACTOR_OBJ_KIBAKO:
         case ACTOR_OBJ_TSUBO:
             return fmaxf(distance, 100.0f);
-
     }
     return distance;
 }

--- a/soh/soh/Enhancements/ExtraModes/IvanCoop.cpp
+++ b/soh/soh/Enhancements/ExtraModes/IvanCoop.cpp
@@ -40,18 +40,15 @@ static void KillIvan() {
 
 static bool ShouldPatchDist(s16 actorId) {
     switch (actorId) {
-
         // AC is enabled when player is nearby:
         case ACTOR_BG_BOMBWALL:
         case ACTOR_BG_SPOT08_BAKUDANKABE:
         case ACTOR_OBJ_KIBAKO2: // Note: Checks for explosions regardless of distance
             return true;
-
         // OC is enabled when player is nearby:
         case ACTOR_EN_ICE_HONO:
         case ACTOR_OBJ_HANA:
             return true;
-
         // AC/OC are enabled when player is nearby:
         case ACTOR_EN_ISHI:
         case ACTOR_EN_KUSA:
@@ -61,7 +58,6 @@ static bool ShouldPatchDist(s16 actorId) {
         case ACTOR_OBJ_KIBAKO:
         case ACTOR_OBJ_TSUBO:
             return true;
-
         // Checks for explosions if player is nearby:
         case ACTOR_BG_SPOT17_BAKUDANKABE:
             return true;
@@ -71,11 +67,9 @@ static bool ShouldPatchDist(s16 actorId) {
 
 static f32 ClampDist(f32 distance, s16 actorId) {
     switch (actorId) {
-
         // Avoid offering bottle capture
         case ACTOR_EN_ICE_HONO:
             return fmaxf(distance, 60.0f);
-
         // Avoid offering carry
         case ACTOR_EN_ISHI:
             return fmaxf(distance, 90.0f);

--- a/soh/soh/Enhancements/ExtraModes/IvanCoop.cpp
+++ b/soh/soh/Enhancements/ExtraModes/IvanCoop.cpp
@@ -36,6 +36,75 @@ static void KillIvan() {
         Actor_Kill(ivan);
 }
 
+// #region Patch distance checks (allows Ivan to break pots and crates while far from Link)
+
+static bool ShouldPatchDist(s16 actorId) {
+    switch (actorId) {
+
+        // AC is enabled when player is nearby:
+        case ACTOR_BG_BOMBWALL:
+        case ACTOR_BG_SPOT08_BAKUDANKABE:
+        case ACTOR_OBJ_KIBAKO2: // Note: Checks for explosions regardless of distance
+            return true;
+
+        // OC is enabled when player is nearby:
+        case ACTOR_EN_ICE_HONO:
+        case ACTOR_OBJ_HANA:
+            return true;
+
+        // AC/OC are enabled when player is nearby:
+        case ACTOR_EN_ISHI:
+        case ACTOR_EN_KUSA:
+        case ACTOR_EN_WOOD02:
+        case ACTOR_OBJ_BOMBIWA: // Note: Checks for explosions regardless of distance
+        case ACTOR_OBJ_HAMISHI:
+        case ACTOR_OBJ_KIBAKO:
+        case ACTOR_OBJ_TSUBO:
+            return true;
+
+        // Checks for explosions if player is nearby:
+        case ACTOR_BG_SPOT17_BAKUDANKABE:
+            return true;
+
+    }
+    return false;
+}
+
+static f32 ClampDist(f32 distance, s16 actorId) {
+    switch (actorId) {
+
+        // Avoid offering bottle capture
+        case ACTOR_EN_ICE_HONO:
+            return fmaxf(distance, 60.0f);
+
+        // Avoid offering carry
+        case ACTOR_EN_ISHI:
+            return fmaxf(distance, 90.0f);
+        case ACTOR_EN_KUSA:
+        case ACTOR_OBJ_KIBAKO:
+        case ACTOR_OBJ_TSUBO:
+            return fmaxf(distance, 100.0f);
+
+    }
+    return distance;
+}
+
+static void PatchDistIfNeeded(Actor* actor) {
+    if (!ShouldPatchDist(actor->id))
+        return;
+
+    Actor* ivan = Actor_Find(&gPlayState->actorCtx, gEnPartnerId, ACTORCAT_ITEMACTION);
+    if (ivan == nullptr)
+        return;
+
+    f32 ivanDist = Actor_WorldDistXZToActor(actor, ivan);
+    ivanDist = ClampDist(ivanDist, actor->id);
+    if (ivanDist < actor->xzDistToPlayer)
+        actor->xzDistToPlayer = ivanDist;
+}
+
+// #endregion
+
 static void RegisterIvanCoop() {
     if (CVAR_VALUE)
         SpawnIvan();
@@ -43,6 +112,11 @@ static void RegisterIvanCoop() {
         KillIvan();
 
     COND_ID_HOOK(OnActorSpawn, ACTOR_PLAYER, CVAR_VALUE, [](void*) { SpawnIvan(); });
+
+    COND_HOOK(ShouldActorUpdate, CVAR_VALUE, [](void* actorRef, bool*) {
+        Actor* actor = static_cast<Actor*>(actorRef);
+        PatchDistIfNeeded(actor);
+    });
 }
 
 static RegisterShipInitFunc initFunc(RegisterIvanCoop, { CVAR_NAME });


### PR DESCRIPTION
Adds a new hook when Ivan is enabled. The hook patches `xzDistToPlayer` for **_certain_** supported actors so that Ivan can interact with those actors even when Link is a bit far away.

In addition to being able to smash pots and crates and such, this change also prevents Ivan from clipping through such objects when Link is far away (those that use an OC).

I’ve tested with all the actors listed in the **`ShouldPatchDist`** function. Note that `xzDistToPlayer` is [calculated](https://github.com/HarbourMasters/Shipwright/blob/4ea17f6933c931c4438abb0c625598ee046f7ba7/soh/src/code/z_actor.c#L2668) by the engine just prior to calling `ShouldActorUpdate`, so there should be no need to “unpatch” these values as they’ll get fixed in the next frame.

Below is a couple of videos (you’ll want to zoom into the center to see Ivan).

https://github.com/user-attachments/assets/1550a184-11d1-49a7-bd6c-0a9bbce7a1d4

https://github.com/user-attachments/assets/892d36c4-74a9-4b45-ae17-efa101814f3d


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7757239127.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7757139151.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7757110443.zip)
<!--- section:artifacts:end -->