### PR TITLE
Fix FPS items for customequipment

### DIFF
--- a/soh/soh/Enhancements/customequipment.cpp
+++ b/soh/soh/Enhancements/customequipment.cpp
@@ -291,7 +291,7 @@ static void RegisterCustomEquipment() {
 
                     Gfx* resolvedFpsWeapon = LoadCustomGfx(fpsWeapon);
                     Gfx* resolvedFpsHand = LoadCustomGfx(fpsHand);
-                    if (resolvedFpsWeapon || resolvedFpsHand) {
+                    if (resolvedFpsWeapon) {
                         Gfx* buf = (Gfx*)Graph_Alloc(play->state.gfxCtx, 3 * sizeof(Gfx));
                         Gfx* p = buf;
                         if (resolvedFpsWeapon)


### PR DESCRIPTION
Accidentally made it so FPS dls were being pushed if either hand or fps item was found.

It should only be if fps item is found

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7764569178.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7764515777.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7764512952.zip)
<!--- section:artifacts:end -->