### PR TITLE
Fix ganondorf hint

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -757,12 +757,10 @@ void CreateStaticItemHint(RandomizerHint hintKey, std::vector<RandomizerHintText
     // RANDOTODO choose area in case there are multiple
     auto ctx = Rando::Context::GetInstance();
     std::vector<RandomizerCheck> locations = FindItemsAndMarkHinted(items, hintChecks);
-    locations.erase(
-        std::remove_if(locations.begin(), locations.end(), [](const auto rc) { return rc == RC_UNKNOWN_CHECK; }));
     std::vector<RandomizerArea> areas;
     areas.reserve(locations.size());
     for (auto loc : locations) {
-        areas.push_back(ctx->GetItemLocation(loc)->GetRandomArea());
+        areas.push_back(loc == RC_UNKNOWN_CHECK ? RA_NONE : ctx->GetItemLocation(loc)->GetRandomArea());
     }
     ctx->AddHint(hintKey, Hint(hintKey, HINT_TYPE_AREA, hintTextKeys, locations, areas, {}, yourPocket));
 }


### PR DESCRIPTION
Location indexes need to be aligned, so rather than try erase them, just avoid RC_UNKNOWN_CHECK crash by stubbing it to "an isolated place"

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7781447313.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7781368149.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7781364977.zip)
<!--- section:artifacts:end -->