### PR TITLE
Looping Octave Drop logic

### DIFF
--- a/soh/src/code/audio_playback.c
+++ b/soh/src/code/audio_playback.c
@@ -121,7 +121,11 @@ void Audio_NoteSetResamplingRate(NoteSubEu* noteSubEu, f32 resamplingRateInput) 
         noteSubEu->bitField1.hasTwoParts = true;
         if (3.99996f < resamplingRateInput) {
             if (CVarGetInteger(CVAR_AUDIO("ExperimentalOctaveDrop"), 0) || noteSubEu->bitField1.isSyntheticWave) {
-                resamplingRate = resamplingRateInput * 0.25;
+                resamplingRate = resamplingRateInput * 0.5f;
+
+                while (resamplingRate > 1.99998f) {
+                    resamplingRate *= 0.5f;
+                }
             } else {
                 resamplingRate = 1.99998f;
             }


### PR DESCRIPTION
The original tooltip for `ExperimentalOctaveDrop` says:

> Some custom sequences may have notes that are too high for the game's audio
> engine to play. Enabling this checkbox will cause these notes to drop a
> couple of octaves so they can still harmonize with the other notes of the
> sequence.

Previously, when a note exceeded the supported resampling range, this option always dropped it by a fixed two octaves. That avoids the hard clamp, but it can also move the note much farther away from the original melody than necessary.

This patch changes the behavior to drop the note one octave at a time until it fits within the supported range. The result should preserve the intended pitch more closely while still avoiding the high-note clamp.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7800935246.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7800745019.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7800701293.zip)
<!--- section:artifacts:end -->