### PR TITLE
Add .clangd to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -457,6 +457,7 @@ soh/src/boot/build.c
 soh/properties.h
 
 # Tools
+.clangd
 /clang-format
 /clang-format.exe
 *.o2r


### PR DESCRIPTION
Adds `.clangd` to `.gitignore` so local clangd configuration files are not accidentally committed.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7786435412.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7786419323.zip)
<!--- section:artifacts:end -->