### PR TITLE
Vanilla bugfix, Hookshot with parent + Hookshot nospawn

### DIFF
--- a/soh/soh/Enhancements/AlwaysOnFixes.cpp
+++ b/soh/soh/Enhancements/AlwaysOnFixes.cpp
@@ -2,6 +2,11 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
 
+extern "C" {
+extern void Player_UseItem(PlayState*, Player*, s32);
+extern PlayState* gPlayState;
+}
+
 // Dying or using Din's Fire in the Outside Temple of Time area crashes the game.
 // In vanilla this can never happen, but with CrowdControl, Sail, Unrestricted Items
 // and others this *can* happen. Because it checks for a camId of -1, this code path
@@ -18,8 +23,12 @@ void RegisterFixOutsideTotCrash() {
 // Vanilla bug: If Hookshot doesn't spawn, player is softlocked. (eg. use as child, no memory left)
 // Fix: Change item to none if no spawn. (Ranged weapon state is removed by `Player_InitItemAction`)
 void RegisterPreventHookshotNoSpawnSoftlock() {
-    COND_VB_SHOULD(VB_PREVENT_HOOKSHOT_NOSPAWN_SOFTLOCK, true, {
-            *should = true;
+    COND_VB_SHOULD(VB_INIT_HOOKSHOT_IA, true, {
+        Player* player = va_arg(args, Player*);
+        if (player->heldActor == NULL) {
+            Player_UseItem(gPlayState, player, 0xFF);
+        }
+
     });
 }
 
@@ -29,10 +38,10 @@ void RegisterPreventHookshotNoSpawnSoftlock() {
 // Fix: Ensure that parent actor has Hookshot actor ID before starting flying.
 void RegisterPreventHookshotParentSoftlock() {
     COND_VB_SHOULD(VB_PREVENT_HOOKSHOT_PARENT_SOFTLOCK, true, {
-            s16* parentId = va_arg(args, s16*);
-            if (*parentId != ACTOR_ARMS_HOOK) {
-                *should = false;
-            }
+        s16* parentId = va_arg(args, s16*);
+        if (*parentId != ACTOR_ARMS_HOOK) {
+            *should = false;
+        }
     });
 }
 

--- a/soh/soh/Enhancements/AlwaysOnFixes.cpp
+++ b/soh/soh/Enhancements/AlwaysOnFixes.cpp
@@ -28,7 +28,6 @@ void RegisterPreventHookshotNoSpawnSoftlock() {
         if (player->heldActor == NULL) {
             Player_UseItem(gPlayState, player, 0xFF);
         }
-
     });
 }
 

--- a/soh/soh/Enhancements/AlwaysOnFixes.cpp
+++ b/soh/soh/Enhancements/AlwaysOnFixes.cpp
@@ -15,4 +15,27 @@ void RegisterFixOutsideTotCrash() {
     });
 }
 
-static RegisterShipInitFunc initFunc(RegisterFixOutsideTotCrash, { "" });
+// Vanilla bug: If Hookshot doesn't spawn, player is softlocked. (eg. use as child, no memory left)
+// Fix: Change item to none if no spawn. (Ranged weapon state is removed by `Player_InitItemAction`)
+void RegisterPreventHookshotNoSpawnSoftlock() {
+    COND_VB_SHOULD(VB_PREVENT_HOOKSHOT_NOSPAWN_SOFTLOCK, true, {
+            *should = true;
+    });
+}
+
+// Vanilla bug: When pulling out Hookshot, if `this->actor.parent` is set but not Hookshot, player
+// is locked into repeated fly-land-fly. Possible with enemies that grab player and set themselves
+// as parent (such as Moblin in water, eaten by Like like that despawns falling through En_Holl).
+// Fix: Ensure that parent actor has Hookshot actor ID before starting flying.
+void RegisterPreventHookshotParentSoftlock() {
+    COND_VB_SHOULD(VB_PREVENT_HOOKSHOT_PARENT_SOFTLOCK, true, {
+            s16* parentId = va_arg(args, s16*);
+            if (*parentId != ACTOR_ARMS_HOOK) {
+                *should = false;
+            }
+    });
+}
+
+static RegisterShipInitFunc initFuncFixOutsideTotCrash(RegisterFixOutsideTotCrash, { "" });
+static RegisterShipInitFunc initFuncHookshotNospawnSoftlock(RegisterPreventHookshotNoSpawnSoftlock, { "" });
+static RegisterShipInitFunc initFuncHookshotParentSoftlock(RegisterPreventHookshotParentSoftlock, { "" });

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -3056,6 +3056,22 @@ typedef enum {
     // - `*EnItem00`
     VB_ITEM00_KILL,
 
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - None
+    VB_PREVENT_HOOKSHOT_NOSPAWN_SOFTLOCK,
+
+    // #### `result`
+    // ```c
+    // true if player->actor.parent->id == ARMS_HOOK_ACTOR
+    // ```
+    // #### `args`
+    // - `s16* (&this->actor.parent->id)`
+    VB_PREVENT_HOOKSHOT_PARENT_SOFTLOCK,
+
     // true
     // ```
     // #### `args`

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -3061,8 +3061,8 @@ typedef enum {
     // true
     // ```
     // #### `args`
-    // - None
-    VB_PREVENT_HOOKSHOT_NOSPAWN_SOFTLOCK,
+    // - `*Player`
+    VB_INIT_HOOKSHOT_IA,
 
     // #### `result`
     // ```c

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -3066,7 +3066,7 @@ typedef enum {
 
     // #### `result`
     // ```c
-    // true if player->actor.parent->id == ARMS_HOOK_ACTOR
+    // !(this->stateFlags1 & PLAYER_STATE1_ON_HORSE) && Player_HoldsHookshot(this)
     // ```
     // #### `args`
     // - `s16* (&this->actor.parent->id)`

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2301,12 +2301,7 @@ void Player_InitHookshotIA(PlayState* play, Player* this) {
         Actor_SpawnAsChild(&play->actorCtx, &this->actor, play, ACTOR_ARMS_HOOK, this->actor.world.pos.x,
                            this->actor.world.pos.y, this->actor.world.pos.z, 0, this->actor.shape.rot.y, 0, 0);
 
-    // SoH: Prevent softlock if Hookshot actor fails to spawn (child, out of memory, etc).
-    if (GameInteractor_Should(VB_PREVENT_HOOKSHOT_NOSPAWN_SOFTLOCK, true)) {
-        if (this->heldActor == NULL) {
-            Player_UseItem(play, this, ITEM_NONE);
-        }
-    }
+    GameInteractor_Should(VB_INIT_HOOKSHOT_IA, true, this);
 }
 
 void Player_InitBoomerangIA(PlayState* play, Player* this) {
@@ -3579,9 +3574,8 @@ int Player_CanUpdateItems(Player* this) {
  * depending on some conditions. See details below.
  */
 s32 Player_UpdateUpperBody(Player* this, PlayState* play) {
-    // SoH: Prevent player from softlocking on Hookshot use if parent is set but is not Hookshot
-    if (!(this->stateFlags1 & PLAYER_STATE1_ON_HORSE) && (this->actor.parent != NULL) && Player_HoldsHookshot(this) &&
-            GameInteractor_Should(VB_PREVENT_HOOKSHOT_PARENT_SOFTLOCK, true, &this->actor.parent->id)) {
+    if (this->actor.parent != NULL && GameInteractor_Should(VB_PREVENT_HOOKSHOT_PARENT_SOFTLOCK,
+        !(this->stateFlags1 & PLAYER_STATE1_ON_HORSE) && Player_HoldsHookshot(this), &this->actor.parent->id)) {
         Player_SetupAction(play, this, Player_Action_80850AEC, 1);
         this->stateFlags3 |= PLAYER_STATE3_FLYING_WITH_HOOKSHOT;
         Player_AnimPlayOnce(play, this, &gPlayerAnim_link_hook_fly_start);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3574,8 +3574,10 @@ int Player_CanUpdateItems(Player* this) {
  * depending on some conditions. See details below.
  */
 s32 Player_UpdateUpperBody(Player* this, PlayState* play) {
-    if (this->actor.parent != NULL && GameInteractor_Should(VB_PREVENT_HOOKSHOT_PARENT_SOFTLOCK,
-        !(this->stateFlags1 & PLAYER_STATE1_ON_HORSE) && Player_HoldsHookshot(this), &this->actor.parent->id)) {
+     if (this->actor.parent != NULL &&
+        GameInteractor_Should(VB_PREVENT_HOOKSHOT_PARENT_SOFTLOCK,
+                               !(this->stateFlags1 & PLAYER_STATE1_ON_HORSE) && Player_HoldsHookshot(this),
+                               &this->actor.parent->id)) {
         Player_SetupAction(play, this, Player_Action_80850AEC, 1);
         this->stateFlags3 |= PLAYER_STATE3_FLYING_WITH_HOOKSHOT;
         Player_AnimPlayOnce(play, this, &gPlayerAnim_link_hook_fly_start);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2300,6 +2300,13 @@ void Player_InitHookshotIA(PlayState* play, Player* this) {
     this->heldActor =
         Actor_SpawnAsChild(&play->actorCtx, &this->actor, play, ACTOR_ARMS_HOOK, this->actor.world.pos.x,
                            this->actor.world.pos.y, this->actor.world.pos.z, 0, this->actor.shape.rot.y, 0, 0);
+
+    // SoH: Prevent softlock if Hookshot actor fails to spawn (child, out of memory, etc).
+    if (GameInteractor_Should(VB_PREVENT_HOOKSHOT_NOSPAWN_SOFTLOCK, true)) {
+        if (this->heldActor == NULL) {
+            Player_UseItem(play, this, ITEM_NONE);
+        }
+    }
 }
 
 void Player_InitBoomerangIA(PlayState* play, Player* this) {
@@ -3572,7 +3579,9 @@ int Player_CanUpdateItems(Player* this) {
  * depending on some conditions. See details below.
  */
 s32 Player_UpdateUpperBody(Player* this, PlayState* play) {
-    if (!(this->stateFlags1 & PLAYER_STATE1_ON_HORSE) && (this->actor.parent != NULL) && Player_HoldsHookshot(this)) {
+    // SoH: Prevent player from softlocking on Hookshot use if parent is set but is not Hookshot
+    if (!(this->stateFlags1 & PLAYER_STATE1_ON_HORSE) && (this->actor.parent != NULL) && Player_HoldsHookshot(this) &&
+            GameInteractor_Should(VB_PREVENT_HOOKSHOT_PARENT_SOFTLOCK, true, &this->actor.parent->id)) {
         Player_SetupAction(play, this, Player_Action_80850AEC, 1);
         this->stateFlags3 |= PLAYER_STATE3_FLYING_WITH_HOOKSHOT;
         Player_AnimPlayOnce(play, this, &gPlayerAnim_link_hook_fly_start);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3574,10 +3574,10 @@ int Player_CanUpdateItems(Player* this) {
  * depending on some conditions. See details below.
  */
 s32 Player_UpdateUpperBody(Player* this, PlayState* play) {
-     if (this->actor.parent != NULL &&
+    if (this->actor.parent != NULL &&
         GameInteractor_Should(VB_PREVENT_HOOKSHOT_PARENT_SOFTLOCK,
-                               !(this->stateFlags1 & PLAYER_STATE1_ON_HORSE) && Player_HoldsHookshot(this),
-                               &this->actor.parent->id)) {
+                              !(this->stateFlags1 & PLAYER_STATE1_ON_HORSE) && Player_HoldsHookshot(this),
+                              &this->actor.parent->id)) {
         Player_SetupAction(play, this, Player_Action_80850AEC, 1);
         this->stateFlags3 |= PLAYER_STATE3_FLYING_WITH_HOOKSHOT;
         Player_AnimPlayOnce(play, this, &gPlayerAnim_link_hook_fly_start);


### PR DESCRIPTION
Fix two vanilla Hookshot softlocks:
1. Equipping Hookshot but the actor fails to spawn (child unless object is available, out of memory) - cannot do player inputs
2. Equipping Hookshot with `player->actor.parent` not NULL - stuck in fly-land-fly

In normal gameplay both are unlikely to be encountered, except maybe nr 1 in Hyrule Field due to memory.
However, with enemy randomizers the risk of nr 2 does exist with grab-type enemies that set themselves as parent while grabbing but fail to remove it for some reason (see issue #5747, bug 2 - parent being set causes slowfall/no damage, and would have softlocked on Hookshot use).

Neither fix has consequences for normal or glitched gameplay. The fix for nr 1 is also present in vanilla Majora's Mask.

It's possible to ensure the risk enemies for nr 2 always remove themselves as parent and I'm thinking about fixing them later as having a parent results in other bugs, but that would not prevent custom enemies etc from failing anyway, so nr 2 is still useful I think.

Demonstration:
Nr 1 in OoTR: https://www.youtube.com/watch?v=kXxg5GH9IZc (tested in SoH without touching child Hookshot/filling memory by replacing `Actor_Arms_Hook` spawn with `this->heldActor = NULL` in `Player_InitHookshotIA`)
Nr 2 in SoH: https://www.youtube.com/watch?v=ozf0NrFVzfs (can also be tested by adding `this->actor.parent = &this->actor` in `Player_InitHookshotIA`)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7855077139.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7855075266.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7855051297.zip)
<!--- section:artifacts:end -->