### PR TITLE
Fix crash when an available audio/window backend has no name-map entry

### DIFF
--- a/soh/soh/SohGui/Menu.cpp
+++ b/soh/soh/SohGui/Menu.cpp
@@ -102,7 +102,9 @@ void Menu::RemoveSidebarSearch() {
 void Menu::UpdateAudioBackendObjects() {
     availableAudioBackends = Ship::Context::GetRawInstance()->GetAudio()->GetAvailableAudioBackends();
     for (auto& backend : *availableAudioBackends) {
-        availableAudioBackendsMap[backend] = audioBackendsMap.at(backend);
+        if (auto it = audioBackendsMap.find(backend); it != audioBackendsMap.end()) {
+            availableAudioBackendsMap[backend] = it->second;
+        }
     }
 }
 
@@ -118,7 +120,10 @@ void Menu::UpdateWindowBackendObjects() {
 
     availableWindowBackends = Ship::Context::GetRawInstance()->GetWindow()->GetAvailableWindowBackends();
     for (auto& backend : *availableWindowBackends) {
-        availableWindowBackendsMap[(Fast::WindowBackend)backend] = windowBackendsMap.at((Fast::WindowBackend)backend);
+        auto windowBackend = (Fast::WindowBackend)backend;
+        if (auto it = windowBackendsMap.find(windowBackend); it != windowBackendsMap.end()) {
+            availableWindowBackendsMap[windowBackend] = it->second;
+        }
     }
 }
 


### PR DESCRIPTION
### Summary
`Menu::UpdateAudioBackendObjects()` and `Menu::UpdateWindowBackendObjects()` look up every backend reported by `GetAvailableAudioBackends()` / `GetAvailableWindowBackends()` in the static `audioBackendsMap` / `windowBackendsMap` name maps using `.at()`. If the runtime reports a backend that has no entry in those maps (e.g. a newly added or platform-specific backend), `.at()` throws `std::out_of_range` and the game crashes.

### Fix
Look the backend up with `find()` (a single lookup instead of `contains()` + `at()`) and skip any backend that isn't in the name map instead of dereferencing a missing key.

### Notes
No behavior change for known backends; this only prevents the crash for unknown ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7825295813.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7825115340.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7825065408.zip)
<!--- section:artifacts:end -->