### PR TITLE
Fix Free Look reversing when leaving a fixed-camera area (#4953)

### DIFF
--- a/soh/src/code/z_camera.c
+++ b/soh/src/code/z_camera.c
@@ -1450,6 +1450,20 @@ s32 Camera_Free(Camera* camera) {
     Parallel1* para1 = (Parallel1*)camera->paramData;
     f32 playerHeight;
 
+    // SOH [Enhancement] If free-look is resuming after a scene-forced/fixed camera drove the view
+    // (Camera_Free didn't run last frame while manualCamera stayed set, e.g. exiting a Spirit Temple
+    // alcove), re-seed the free-look angles from the camera's current orientation so the view continues
+    // from where it was left instead of snapping back to the pre-interruption angle.
+    static s32 sFreeLastFrame = 0;
+    s32 curFrame = camera->play->state.frames;
+    if (curFrame - sFreeLastFrame > 1) {
+        VecSph eyeAdjustment;
+        OLib_Vec3fDiffToVecSphGeo(&eyeAdjustment, &camera->at, &camera->eye);
+        camera->play->camX = eyeAdjustment.yaw;
+        camera->play->camY = eyeAdjustment.pitch;
+    }
+    sFreeLastFrame = curFrame;
+
     at->x = Camera_LERPCeilF(camera->player->actor.world.pos.x, camera->at.x, 0.5f, 1.0f);
     at->y = Camera_LERPCeilF(camera->player->actor.world.pos.y + (camera->player->rideActor != NULL
                                                                       ? Player_GetHeight(camera->player) / 2


### PR DESCRIPTION
## Closes #4953

### What this is NOT
This does **not** prevent or override the game's scene-forced cameras. Rooms like the Spirit Temple boulder-room alcoves still clamp the camera to their fixed angle exactly as the original game intends. A previous attempt to suppress the forced cameras themselves was abandoned because those cameras are load-bearing (prerendered backdrops, traversal framing, hiding geometry/OoB).

### The actual bug
With Free Look enabled, the issue is purely in the **hand-off back to Free Look** when you *leave* the alcove:

- Free Look stores its angles in `play->camX`/`camY`.
- While a fixed camera (`Camera_Fixed3` / `CAM_SET_PREREND_FIXED`) drives the alcove view, `manualCamera` stays `true`, but those stored angles are never updated.
- `SetCameraManual` only re-seeds the angles on the *rising edge* of `manualCamera` (i.e. when you flick the stick from a non-manual state), which never fires here.
- So on exit, `Camera_Free` resumes from the **stale pre-alcove angle**, snapping/reversing the view back into the alcove instead of following the player out.

This also explained the inconsistency some players saw: if targeting/first-person happened to reset `manualCamera` in between, the rising-edge re-seed *did* fire and it looked fine; a plain fixed-camera interruption left it stale.

### The fix
At the top of `Camera_Free`, detect that another camera function drove the previous frame (via a frame-number gap) and re-seed the free-look yaw/pitch from the camera's current orientation. Free Look then continues smoothly from wherever the forced camera left the view, matching how the vanilla camera follows you out of the alcoves.

```c
static s32 sFreeLastFrame = 0;
s32 curFrame = camera->play->state.frames;
if (curFrame - sFreeLastFrame > 1) {
    VecSph eyeAdjustment;
    OLib_Vec3fDiffToVecSphGeo(&eyeAdjustment, &camera->at, &camera->eye);
    camera->play->camX = eyeAdjustment.yaw;
    camera->play->camY = eyeAdjustment.pitch;
}
sFreeLastFrame = curFrame;
```

### Testing
- **Spirit Temple boulder/alcove room** (the original report): holding forward through an alcove no longer reverses the camera on exit; it follows you out.
- **Temple of Time entrance** (also `CAM_SET_PREREND_FIXED`): no regression, untouched.
- Targeting / first-person release and crawlspaces: Free Look still resumes cleanly (those paths already reset `manualCamera`; the new re-seed is idempotent with them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7840868895.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7840779841.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7840776564.zip)
<!--- section:artifacts:end -->