### PR TITLE
fix: pushblocks reset on room reload, softlocking Spirit/Water Temple

### DIFF
--- a/soh/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.c
+++ b/soh/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.c
@@ -43,11 +43,18 @@ void ObjBlockstop_Update(Actor* thisx, PlayState* play) {
     ObjBlockstop* this = (ObjBlockstop*)thisx;
     DynaPolyActor* dynaPolyActor;
     Vec3f sp4C;
+    Vec3f rayStart;
     s32 bgId;
     s32 pad;
 
-    if (BgCheck_EntityLineTest2(&play->colCtx, &this->actor.home.pos, &this->actor.world.pos, &sp4C,
-                                &this->actor.floorPoly, false, false, true, true, &bgId, &this->actor)) {
+    // The block comes to rest with its base on the floor at home.pos.y. Begin the upward
+    // detection ray slightly below that plane so it reliably crosses the block's underside;
+    // starting exactly on home.pos.y can miss when the block settles right on the boundary.
+    rayStart = this->actor.home.pos;
+    rayStart.y -= 2.0f;
+
+    if (BgCheck_EntityLineTest2(&play->colCtx, &rayStart, &this->actor.world.pos, &sp4C, &this->actor.floorPoly, false,
+                                false, true, true, &bgId, &this->actor)) {
         dynaPolyActor = DynaPoly_GetActor(&play->colCtx, bgId);
 
         if (dynaPolyActor != NULL && dynaPolyActor->actor.id == ACTOR_OBJ_OSHIHIKI) {


### PR DESCRIPTION
## What

Fixes pushable blocks (`Obj_Oshihiki`) that are meant to stay put once pushed into place reverting to their spawn position whenever you leave and re-enter the room. In Spirit and Water Temple this is a hard softlock: the block re-blocks the only passage and, because there's no switch on the far side, it can't be re-pushed -- the only escape is voiding out / a warp song.

## Root cause

The persistence is driven by `Obj_Blockstop`, which raycasts a 1-unit segment **upward** from its rest plane (`home.pos.y`) to detect the seated block and set the permanent switch flag (which also plays the "puzzle solved" chime, and on reload kills the now-redundant block).

The block comes to rest with its base **exactly** on `home.pos.y`, so the ray originates right on the block's bottom-face plane -- the intersection parameter is mathematically `0`. The Release build uses `-O3 -ffast-math`, whose FMA contraction and reassociation push that exact-`0` boundary to a sub-ULP nonzero, so the line test reports **no hit**. The flag is never set: no chime, and the block respawns at its origin on every room reload.

The N64 (strict IEEE-754, no FMA) computes the boundary as exactly `0` and registers the hit, which is why it works on hardware and in walkthroughs but not here.

## Fix

Start the detection ray 2 units **below** the rest plane so it crosses the block's underside unambiguously, independent of float rounding. One file, behavior-preserving on hardware-accurate math and robust under `-ffast-math`. Fixes every blockstop puzzle at once.

```c
rayStart = this->actor.home.pos;
rayStart.y -= 2.0f;
```

## Testing

Built Release (`-O3 -ffast-math`). In Spirit Temple, pushed the silver-gauntlet block into the gap: now plays `NA_SE_SY_CORRECT_CHIME` and the block stays in place across room reloads -- no softlock. Diagnosed with a temporary log probe confirming the original raycast returned `hit=0` with the block resting exactly on the segment's origin plane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7843076743.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7842986725.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7842950608.zip)
<!--- section:artifacts:end -->