### PR TITLE
Scope strict FP to the decompiled sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,14 +137,6 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 set(CMAKE_OBJCXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 endif()
 
-# Enforce strict, deterministic IEEE-754 floating-point to match N64 (MIPS) semantics.
-# Never enable fast-math, and disable FMA contraction: the R4300 CPU and RSP have no
-# fused multiply-add, so contracting mul+add into an FMA produces extra precision.
-add_compile_options($<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-fno-fast-math>)
-add_compile_options($<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-ffp-contract=off>)
-add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/fp:precise>)
-add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/fp:except->)
-
 if(NOT CMAKE_BUILD_TYPE )
     set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build." FORCE)
 endif()

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -189,6 +189,14 @@ endif()
 file(GLOB_RECURSE src__ RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "src/*.c" "src/*.h")
 set_source_files_properties(${src__} PROPERTIES COMPILE_OPTIONS "${WARNING_OVERRIDE}")
 
+# Strict N64 float semantics, decomp only (so the rest keeps FMA/-O3).
+# -ffp-contract=off must follow -fno-fast-math, which resets contraction to on.
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    set_property(SOURCE ${src__} APPEND PROPERTY COMPILE_OPTIONS -fno-fast-math -ffp-contract=off)
+elseif(MSVC)
+    set_property(SOURCE ${src__} APPEND PROPERTY COMPILE_OPTIONS /fp:precise)
+endif()
+
 list(APPEND src__ ${CMAKE_CURRENT_SOURCE_DIR}/Resource.rc)
 list(FILTER src__ EXCLUDE REGEX "src/dmadata/")
 list(FILTER src__ EXCLUDE REGEX "src/elf_message/")


### PR DESCRIPTION
Follow-up to #6811: scope the no-FMA / no-fast-math flags to `soh/src` (decomp) instead of the whole build. `IS_ZERO` removal retained.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7863014786.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7862902544.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7862234424.zip)
<!--- section:artifacts:end -->