### PR TITLE
Ivan: Move ActorDB registration into IvanCoop.cpp

### DIFF
--- a/soh/soh/ActorDB.cpp
+++ b/soh/soh/ActorDB.cpp
@@ -595,27 +595,6 @@ void ActorDB::Entry::SetDesc(const std::string& newDesc) {
     entry.desc = desc.c_str();
 }
 
-#include "src/overlays/actors/ovl_En_Partner/z_en_partner.h"
-static ActorDBInit EnPartnerInit = {
-    "En_Partner",
-    "Ivan",
-    ACTORCAT_ITEMACTION,
-    (ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_DRAW_CULLING_DISABLED | ACTOR_FLAG_HOOKSHOT_PULLS_PLAYER |
-     ACTOR_FLAG_CAN_PRESS_SWITCHES),
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnPartner),
-    (ActorFunc)EnPartner_Init,
-    (ActorFunc)EnPartner_Destroy,
-    (ActorFunc)EnPartner_Update,
-    (ActorFunc)EnPartner_Draw,
-    nullptr,
-};
-extern "C" s16 gEnPartnerId;
-
-void ActorDB::AddBuiltInCustomActors() {
-    gEnPartnerId = ActorDB::Instance->AddEntry(EnPartnerInit).entry.id;
-}
-
 extern "C" ActorDBEntry* ActorDB_Retrieve(const int id) {
     return &ActorDB::Instance->RetrieveEntry(id).entry;
 }

--- a/soh/soh/ActorDB.h
+++ b/soh/soh/ActorDB.h
@@ -62,8 +62,6 @@ class ActorDB {
     Entry& RetrieveEntry(const int id);
     int RetrieveId(const std::string& name);
 
-    static void AddBuiltInCustomActors();
-
     int GetEntryCount();
 
   private:

--- a/soh/soh/Enhancements/ExtraModes/IvanCoop.cpp
+++ b/soh/soh/Enhancements/ExtraModes/IvanCoop.cpp
@@ -9,10 +9,36 @@ extern "C" {
 extern PlayState* gPlayState;
 }
 
-static s16 ivanActorId;
-
 #define CVAR_NAME CVAR_ENHANCEMENT("IvanCoopModeEnabled")
 #define CVAR_VALUE CVarGetInteger(CVAR_NAME, 0)
+
+static s16 ivanActorId = -1;
+
+static void AddToActorDB() {
+    if (ivanActorId == -1) {
+        ActorDBInit entry = {
+            "En_Partner",
+            "Ivan",
+            ACTORCAT_ITEMACTION,
+            (ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_DRAW_CULLING_DISABLED | ACTOR_FLAG_HOOKSHOT_PULLS_PLAYER |
+             ACTOR_FLAG_CAN_PRESS_SWITCHES),
+            OBJECT_GAMEPLAY_KEEP,
+            sizeof(EnPartner),
+            (ActorFunc)EnPartner_Init,
+            (ActorFunc)EnPartner_Destroy,
+            (ActorFunc)EnPartner_Update,
+            (ActorFunc)EnPartner_Draw,
+            nullptr,
+        };
+        ivanActorId = ActorDB::Instance->AddEntry(entry).entry.id;
+    }
+}
+
+static Actor* FindIvan(ActorContext* actorCtx) {
+    if (ivanActorId == -1)
+        return nullptr;
+    return Actor_Find(actorCtx, ivanActorId, ACTORCAT_ITEMACTION);
+}
 
 static void SpawnIvan() {
     if (!gPlayState)
@@ -22,8 +48,10 @@ static void SpawnIvan() {
     if (!player)
         return;
 
-    if (Actor_Find(&gPlayState->actorCtx, ivanActorId, ACTORCAT_ITEMACTION))
+    if (FindIvan(&gPlayState->actorCtx))
         return;
+
+    AddToActorDB();
 
     PosRot& world = player->actor.world;
     Actor_Spawn(&gPlayState->actorCtx, gPlayState, ivanActorId, world.pos.x,
@@ -34,7 +62,7 @@ static void KillIvan() {
     if (!gPlayState)
         return;
 
-    Actor* ivan = Actor_Find(&gPlayState->actorCtx, ivanActorId, ACTORCAT_ITEMACTION);
+    Actor* ivan = FindIvan(&gPlayState->actorCtx);
     if (ivan)
         Actor_Kill(ivan);
 }
@@ -88,8 +116,8 @@ static void PatchDistIfNeeded(Actor* actor) {
     if (!ShouldPatchDist(actor->id))
         return;
 
-    Actor* ivan = Actor_Find(&gPlayState->actorCtx, ivanActorId, ACTORCAT_ITEMACTION);
-    if (ivan == nullptr)
+    Actor* ivan = FindIvan(&gPlayState->actorCtx);
+    if (!ivan)
         return;
 
     f32 ivanDist = Actor_WorldDistXZToActor(actor, ivan);
@@ -100,26 +128,7 @@ static void PatchDistIfNeeded(Actor* actor) {
 
 // #endregion
 
-static ActorDBInit EnPartnerInit = {
-    "En_Partner",
-    "Ivan",
-    ACTORCAT_ITEMACTION,
-    (ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_DRAW_CULLING_DISABLED | ACTOR_FLAG_HOOKSHOT_PULLS_PLAYER |
-     ACTOR_FLAG_CAN_PRESS_SWITCHES),
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnPartner),
-    (ActorFunc)EnPartner_Init,
-    (ActorFunc)EnPartner_Destroy,
-    (ActorFunc)EnPartner_Update,
-    (ActorFunc)EnPartner_Draw,
-    nullptr,
-};
-
 static void RegisterIvanCoop() {
-    // Register in ActorDB on boot, regardless of whether Ivan is enabled
-    if (!ivanActorId)
-        ivanActorId = ActorDB::Instance->AddEntry(EnPartnerInit).entry.id;
-
     if (CVAR_VALUE)
         SpawnIvan();
     else

--- a/soh/soh/Enhancements/ExtraModes/IvanCoop.cpp
+++ b/soh/soh/Enhancements/ExtraModes/IvanCoop.cpp
@@ -1,12 +1,15 @@
+#include "soh/ActorDB.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
+#include "src/overlays/actors/ovl_En_Partner/z_en_partner.h"
 
 extern "C" {
 #include "macros.h"
 #include "functions.h"
 extern PlayState* gPlayState;
-extern s16 gEnPartnerId;
 }
+
+static s16 ivanActorId;
 
 #define CVAR_NAME CVAR_ENHANCEMENT("IvanCoopModeEnabled")
 #define CVAR_VALUE CVarGetInteger(CVAR_NAME, 0)
@@ -19,11 +22,11 @@ static void SpawnIvan() {
     if (!player)
         return;
 
-    if (Actor_Find(&gPlayState->actorCtx, gEnPartnerId, ACTORCAT_ITEMACTION))
+    if (Actor_Find(&gPlayState->actorCtx, ivanActorId, ACTORCAT_ITEMACTION))
         return;
 
     PosRot& world = player->actor.world;
-    Actor_Spawn(&gPlayState->actorCtx, gPlayState, gEnPartnerId, world.pos.x,
+    Actor_Spawn(&gPlayState->actorCtx, gPlayState, ivanActorId, world.pos.x,
                 world.pos.y + Player_GetHeight(player) + 5.0f, world.pos.z, 0, world.rot.y, 0, 1);
 }
 
@@ -31,7 +34,7 @@ static void KillIvan() {
     if (!gPlayState)
         return;
 
-    Actor* ivan = Actor_Find(&gPlayState->actorCtx, gEnPartnerId, ACTORCAT_ITEMACTION);
+    Actor* ivan = Actor_Find(&gPlayState->actorCtx, ivanActorId, ACTORCAT_ITEMACTION);
     if (ivan)
         Actor_Kill(ivan);
 }
@@ -85,7 +88,7 @@ static void PatchDistIfNeeded(Actor* actor) {
     if (!ShouldPatchDist(actor->id))
         return;
 
-    Actor* ivan = Actor_Find(&gPlayState->actorCtx, gEnPartnerId, ACTORCAT_ITEMACTION);
+    Actor* ivan = Actor_Find(&gPlayState->actorCtx, ivanActorId, ACTORCAT_ITEMACTION);
     if (ivan == nullptr)
         return;
 
@@ -97,7 +100,26 @@ static void PatchDistIfNeeded(Actor* actor) {
 
 // #endregion
 
+static ActorDBInit EnPartnerInit = {
+    "En_Partner",
+    "Ivan",
+    ACTORCAT_ITEMACTION,
+    (ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_DRAW_CULLING_DISABLED | ACTOR_FLAG_HOOKSHOT_PULLS_PLAYER |
+     ACTOR_FLAG_CAN_PRESS_SWITCHES),
+    OBJECT_GAMEPLAY_KEEP,
+    sizeof(EnPartner),
+    (ActorFunc)EnPartner_Init,
+    (ActorFunc)EnPartner_Destroy,
+    (ActorFunc)EnPartner_Update,
+    (ActorFunc)EnPartner_Draw,
+    nullptr,
+};
+
 static void RegisterIvanCoop() {
+    // Register in ActorDB on boot, regardless of whether Ivan is enabled
+    if (!ivanActorId)
+        ivanActorId = ActorDB::Instance->AddEntry(EnPartnerInit).entry.id;
+
     if (CVAR_VALUE)
         SpawnIvan();
     else

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1561,7 +1561,6 @@ extern "C" void InitOTR(int argc, char* argv[]) {
     VanillaItemTable_Init();
     DebugConsole_Init();
 
-    ActorDB::AddBuiltInCustomActors();
     // #region SOH [Randomizer] TODO: Remove these and refactor spoiler file handling for randomizer
     CVarClear(CVAR_GENERAL("RandomizerNewFileDropped"));
     CVarClear(CVAR_GENERAL("RandomizerDroppedFile"));

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -33,7 +33,6 @@ Input* D_8012D1F8 = NULL;
 
 PlayState* gPlayState;
 s16 firstInit = 0;
-s16 gEnPartnerId;
 
 void Play_SpawnScene(PlayState* play, s32 sceneId, s32 spawn);
 


### PR DESCRIPTION
This PR moves Ivan’s `ActorDB->AddEntry` code out of **ActorDB.cpp**

The DB entry is now added in **IvanCoop.cpp** just before spawning Ivan. This means the ActorDB is now vanilla if Ivan is disabled.

This PR also moves more of Ivan’s code out of decomp (moving `gEnPartnerId` out of **z_play.c**).

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8076856624.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8076797416.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8076790516.zip)
<!--- section:artifacts:end -->