### PR TITLE
Rando: UX improvements of Locations page

### DIFF
--- a/soh/soh/SohGui/SohMenuRandomizer.cpp
+++ b/soh/soh/SohGui/SohMenuRandomizer.cpp
@@ -1,3 +1,4 @@
+#include <unordered_set>
 #include "SohMenu.h"
 #include "soh/Enhancements/enhancementTypes.h"
 #include "soh/Enhancements/randomizer/randomizer_check_objects.h"
@@ -83,73 +84,73 @@ void DrawLocationsMenu(WidgetInfo& info) {
     }
 
     // Locations
-    static std::map<RandomizerCheckArea, bool> areaTreeIncluded{
-        { RCAREA_KOKIRI_FOREST, true },
-        { RCAREA_LOST_WOODS, true },
-        { RCAREA_SACRED_FOREST_MEADOW, true },
-        { RCAREA_HYRULE_FIELD, true },
-        { RCAREA_LAKE_HYLIA, true },
-        { RCAREA_GERUDO_VALLEY, true },
-        { RCAREA_GERUDO_FORTRESS, true },
-        { RCAREA_WASTELAND, true },
-        { RCAREA_DESERT_COLOSSUS, true },
-        { RCAREA_MARKET, true },
-        { RCAREA_HYRULE_CASTLE, true },
-        { RCAREA_KAKARIKO_VILLAGE, true },
-        { RCAREA_GRAVEYARD, true },
-        { RCAREA_DEATH_MOUNTAIN_TRAIL, true },
-        { RCAREA_GORON_CITY, true },
-        { RCAREA_DEATH_MOUNTAIN_CRATER, true },
-        { RCAREA_ZORAS_RIVER, true },
-        { RCAREA_ZORAS_DOMAIN, true },
-        { RCAREA_ZORAS_FOUNTAIN, true },
-        { RCAREA_LON_LON_RANCH, true },
-        { RCAREA_DEKU_TREE, true },
-        { RCAREA_DODONGOS_CAVERN, true },
-        { RCAREA_JABU_JABUS_BELLY, true },
-        { RCAREA_FOREST_TEMPLE, true },
-        { RCAREA_FIRE_TEMPLE, true },
-        { RCAREA_WATER_TEMPLE, true },
-        { RCAREA_SPIRIT_TEMPLE, true },
-        { RCAREA_SHADOW_TEMPLE, true },
-        { RCAREA_BOTTOM_OF_THE_WELL, true },
-        { RCAREA_ICE_CAVERN, true },
-        { RCAREA_GERUDO_TRAINING_GROUND, true },
-        { RCAREA_GANONS_CASTLE, true },
+    static std::unordered_set<RandomizerCheckArea> areaTreeIncluded{
+        RCAREA_KOKIRI_FOREST,
+        RCAREA_LOST_WOODS,
+        RCAREA_SACRED_FOREST_MEADOW,
+        RCAREA_HYRULE_FIELD,
+        RCAREA_LAKE_HYLIA,
+        RCAREA_GERUDO_VALLEY,
+        RCAREA_GERUDO_FORTRESS,
+        RCAREA_WASTELAND,
+        RCAREA_DESERT_COLOSSUS,
+        RCAREA_MARKET,
+        RCAREA_HYRULE_CASTLE,
+        RCAREA_KAKARIKO_VILLAGE,
+        RCAREA_GRAVEYARD,
+        RCAREA_DEATH_MOUNTAIN_TRAIL,
+        RCAREA_GORON_CITY,
+        RCAREA_DEATH_MOUNTAIN_CRATER,
+        RCAREA_ZORAS_RIVER,
+        RCAREA_ZORAS_DOMAIN,
+        RCAREA_ZORAS_FOUNTAIN,
+        RCAREA_LON_LON_RANCH,
+        RCAREA_DEKU_TREE,
+        RCAREA_DODONGOS_CAVERN,
+        RCAREA_JABU_JABUS_BELLY,
+        RCAREA_FOREST_TEMPLE,
+        RCAREA_FIRE_TEMPLE,
+        RCAREA_WATER_TEMPLE,
+        RCAREA_SPIRIT_TEMPLE,
+        RCAREA_SHADOW_TEMPLE,
+        RCAREA_BOTTOM_OF_THE_WELL,
+        RCAREA_ICE_CAVERN,
+        RCAREA_GERUDO_TRAINING_GROUND,
+        RCAREA_GANONS_CASTLE,
     };
-    static std::map<RandomizerCheckArea, bool> areaTreeExcluded{
-        { RCAREA_KOKIRI_FOREST, true },
-        { RCAREA_LOST_WOODS, true },
-        { RCAREA_SACRED_FOREST_MEADOW, true },
-        { RCAREA_HYRULE_FIELD, true },
-        { RCAREA_LAKE_HYLIA, true },
-        { RCAREA_GERUDO_VALLEY, true },
-        { RCAREA_GERUDO_FORTRESS, true },
-        { RCAREA_WASTELAND, true },
-        { RCAREA_DESERT_COLOSSUS, true },
-        { RCAREA_MARKET, true },
-        { RCAREA_HYRULE_CASTLE, true },
-        { RCAREA_KAKARIKO_VILLAGE, true },
-        { RCAREA_GRAVEYARD, true },
-        { RCAREA_DEATH_MOUNTAIN_TRAIL, true },
-        { RCAREA_GORON_CITY, true },
-        { RCAREA_DEATH_MOUNTAIN_CRATER, true },
-        { RCAREA_ZORAS_RIVER, true },
-        { RCAREA_ZORAS_DOMAIN, true },
-        { RCAREA_ZORAS_FOUNTAIN, true },
-        { RCAREA_LON_LON_RANCH, true },
-        { RCAREA_DEKU_TREE, true },
-        { RCAREA_DODONGOS_CAVERN, true },
-        { RCAREA_JABU_JABUS_BELLY, true },
-        { RCAREA_FOREST_TEMPLE, true },
-        { RCAREA_FIRE_TEMPLE, true },
-        { RCAREA_WATER_TEMPLE, true },
-        { RCAREA_SPIRIT_TEMPLE, true },
-        { RCAREA_SHADOW_TEMPLE, true },
-        { RCAREA_BOTTOM_OF_THE_WELL, true },
-        { RCAREA_ICE_CAVERN, true },
-        { RCAREA_GERUDO_TRAINING_GROUND, true },
-        { RCAREA_GANONS_CASTLE, true },
+    static std::unordered_set<RandomizerCheckArea> areaTreeExcluded{
+        RCAREA_KOKIRI_FOREST,
+        RCAREA_LOST_WOODS,
+        RCAREA_SACRED_FOREST_MEADOW,
+        RCAREA_HYRULE_FIELD,
+        RCAREA_LAKE_HYLIA,
+        RCAREA_GERUDO_VALLEY,
+        RCAREA_GERUDO_FORTRESS,
+        RCAREA_WASTELAND,
+        RCAREA_DESERT_COLOSSUS,
+        RCAREA_MARKET,
+        RCAREA_HYRULE_CASTLE,
+        RCAREA_KAKARIKO_VILLAGE,
+        RCAREA_GRAVEYARD,
+        RCAREA_DEATH_MOUNTAIN_TRAIL,
+        RCAREA_GORON_CITY,
+        RCAREA_DEATH_MOUNTAIN_CRATER,
+        RCAREA_ZORAS_RIVER,
+        RCAREA_ZORAS_DOMAIN,
+        RCAREA_ZORAS_FOUNTAIN,
+        RCAREA_LON_LON_RANCH,
+        RCAREA_DEKU_TREE,
+        RCAREA_DODONGOS_CAVERN,
+        RCAREA_JABU_JABUS_BELLY,
+        RCAREA_FOREST_TEMPLE,
+        RCAREA_FIRE_TEMPLE,
+        RCAREA_WATER_TEMPLE,
+        RCAREA_SPIRIT_TEMPLE,
+        RCAREA_SHADOW_TEMPLE,
+        RCAREA_BOTTOM_OF_THE_WELL,
+        RCAREA_ICE_CAVERN,
+        RCAREA_GERUDO_TRAINING_GROUND,
+        RCAREA_GANONS_CASTLE,
     };
 
     static ImGuiTextFilter locationSearch;
@@ -172,21 +173,21 @@ void DrawLocationsMenu(WidgetInfo& info) {
         if (UIWidgets::Button("Collapse All##included",
                               UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.f, 0.f)))) {
             for (int i = 0; i < RCAREA_INVALID; i++) {
-                areaTreeIncluded[static_cast<RandomizerCheckArea>(i)] = false;
+                areaTreeIncluded.erase(static_cast<RandomizerCheckArea>(i));
             }
         }
         ImGui::SameLine();
         if (UIWidgets::Button("Open All##included",
                               UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.f, 0.f)))) {
             for (int i = 0; i < RCAREA_INVALID; i++) {
-                areaTreeIncluded[static_cast<RandomizerCheckArea>(i)] = true;
+                areaTreeIncluded.insert(static_cast<RandomizerCheckArea>(i));
             }
         }
         ImGui::SameLine();
         if (UIWidgets::Button("Exclude Visible",
                               UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.f, 0.f)))) {
             for (auto& [rcArea, locations] : RandomizerCheckObjects::GetAllRCObjectsByArea()) {
-                if (!areaTreeIncluded[rcArea]) {
+                if (!areaTreeIncluded.contains(rcArea)) {
                     continue;
                 }
                 for (RandomizerCheck rc : locations) {
@@ -213,7 +214,7 @@ void DrawLocationsMenu(WidgetInfo& info) {
 
             if (hasItems) {
                 std::string areaLabel = RandomizerCheckObjects::GetRCAreaName(rcArea) + "##included";
-                ImGui::TreeNodeSetOpen(ImGui::GetID(areaLabel.c_str()), areaTreeIncluded[rcArea]);
+                ImGui::TreeNodeSetOpen(ImGui::GetID(areaLabel.c_str()), areaTreeIncluded.contains(rcArea));
                 ImGui::SetNextItemOpen(true, ImGuiCond_Once);
                 if (ImGui::TreeNode(areaLabel.c_str())) {
                     for (auto& location : locations) {
@@ -229,10 +230,10 @@ void DrawLocationsMenu(WidgetInfo& info) {
                             ImGui::Text("%s", Rando::StaticData::GetLocation(location)->GetShortName().c_str());
                         }
                     }
-                    areaTreeIncluded[rcArea] = true;
+                    areaTreeIncluded.insert(rcArea);
                     ImGui::TreePop();
                 } else {
-                    areaTreeIncluded[rcArea] = false;
+                    areaTreeIncluded.erase(rcArea);
                 }
             }
         }
@@ -245,21 +246,21 @@ void DrawLocationsMenu(WidgetInfo& info) {
         if (UIWidgets::Button("Collapse All##excluded",
                               UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.f, 0.f)))) {
             for (int i = 0; i < RCAREA_INVALID; i++) {
-                areaTreeExcluded[static_cast<RandomizerCheckArea>(i)] = false;
+                areaTreeExcluded.erase(static_cast<RandomizerCheckArea>(i));
             }
         }
         ImGui::SameLine();
         if (UIWidgets::Button("Open All##excluded",
                               UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.f, 0.f)))) {
             for (int i = 0; i < RCAREA_INVALID; i++) {
-                areaTreeExcluded[static_cast<RandomizerCheckArea>(i)] = true;
+                areaTreeExcluded.insert(static_cast<RandomizerCheckArea>(i));
             }
         }
         ImGui::SameLine();
         if (UIWidgets::Button("Include Visible",
                               UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.f, 0.f)))) {
             for (auto& [rcArea, locations] : RandomizerCheckObjects::GetAllRCObjectsByArea()) {
-                if (!areaTreeExcluded[rcArea]) {
+                if (!areaTreeExcluded.contains(rcArea)) {
                     continue;
                 }
                 for (RandomizerCheck rc : locations) {
@@ -286,7 +287,7 @@ void DrawLocationsMenu(WidgetInfo& info) {
 
             if (hasItems) {
                 std::string areaLabel = RandomizerCheckObjects::GetRCAreaName(rcArea) + "##excluded";
-                ImGui::TreeNodeSetOpen(ImGui::GetID(areaLabel.c_str()), areaTreeExcluded[rcArea]);
+                ImGui::TreeNodeSetOpen(ImGui::GetID(areaLabel.c_str()), areaTreeExcluded.contains(rcArea));
                 ImGui::SetNextItemOpen(true, ImGuiCond_Once);
                 if (ImGui::TreeNode(areaLabel.c_str())) {
                     for (auto& location : locations) {
@@ -303,10 +304,10 @@ void DrawLocationsMenu(WidgetInfo& info) {
                             ImGui::Text("%s", Rando::StaticData::GetLocation(location)->GetShortName().c_str());
                         }
                     }
-                    areaTreeExcluded[rcArea] = true;
+                    areaTreeExcluded.insert(rcArea);
                     ImGui::TreePop();
                 } else {
-                    areaTreeExcluded[rcArea] = false;
+                    areaTreeExcluded.erase(rcArea);
                 }
             }
         }
@@ -373,75 +374,75 @@ void DrawTricksMenu(WidgetInfo& info) {
     ImGui::BeginDisabled(CVarGetInteger(CVAR_SETTING("DisableChanges"), 0) || disableEditingRandoSettings);
 
     // Tricks
-    static std::map<RandomizerArea, bool> areaTreeDisabled{
-        { RA_NONE, true },
-        { RA_KOKIRI_FOREST, true },
-        { RA_THE_LOST_WOODS, true },
-        { RA_SACRED_FOREST_MEADOW, true },
-        { RA_HYRULE_FIELD, true },
-        { RA_LAKE_HYLIA, true },
-        { RA_GERUDO_VALLEY, true },
-        { RA_GERUDO_FORTRESS, true },
-        { RA_HAUNTED_WASTELAND, true },
-        { RA_DESERT_COLOSSUS, true },
-        { RA_THE_MARKET, true },
-        { RA_HYRULE_CASTLE, true },
-        { RA_KAKARIKO_VILLAGE, true },
-        { RA_THE_GRAVEYARD, true },
-        { RA_DEATH_MOUNTAIN_TRAIL, true },
-        { RA_GORON_CITY, true },
-        { RA_DEATH_MOUNTAIN_CRATER, true },
-        { RA_ZORAS_RIVER, true },
-        { RA_ZORAS_DOMAIN, true },
-        { RA_ZORAS_FOUNTAIN, true },
-        { RA_LON_LON_RANCH, true },
-        { RA_DEKU_TREE, true },
-        { RA_DODONGOS_CAVERN, true },
-        { RA_JABU_JABUS_BELLY, true },
-        { RA_FOREST_TEMPLE, true },
-        { RA_FIRE_TEMPLE, true },
-        { RA_WATER_TEMPLE, true },
-        { RA_SPIRIT_TEMPLE, true },
-        { RA_SHADOW_TEMPLE, true },
-        { RA_BOTTOM_OF_THE_WELL, true },
-        { RA_ICE_CAVERN, true },
-        { RA_GERUDO_TRAINING_GROUND, true },
-        { RA_GANONS_CASTLE, true },
+    static std::unordered_set<RandomizerArea> areaTreeDisabled{
+        RA_NONE,
+        RA_KOKIRI_FOREST,
+        RA_THE_LOST_WOODS,
+        RA_SACRED_FOREST_MEADOW,
+        RA_HYRULE_FIELD,
+        RA_LAKE_HYLIA,
+        RA_GERUDO_VALLEY,
+        RA_GERUDO_FORTRESS,
+        RA_HAUNTED_WASTELAND,
+        RA_DESERT_COLOSSUS,
+        RA_THE_MARKET,
+        RA_HYRULE_CASTLE,
+        RA_KAKARIKO_VILLAGE,
+        RA_THE_GRAVEYARD,
+        RA_DEATH_MOUNTAIN_TRAIL,
+        RA_GORON_CITY,
+        RA_DEATH_MOUNTAIN_CRATER,
+        RA_ZORAS_RIVER,
+        RA_ZORAS_DOMAIN,
+        RA_ZORAS_FOUNTAIN,
+        RA_LON_LON_RANCH,
+        RA_DEKU_TREE,
+        RA_DODONGOS_CAVERN,
+        RA_JABU_JABUS_BELLY,
+        RA_FOREST_TEMPLE,
+        RA_FIRE_TEMPLE,
+        RA_WATER_TEMPLE,
+        RA_SPIRIT_TEMPLE,
+        RA_SHADOW_TEMPLE,
+        RA_BOTTOM_OF_THE_WELL,
+        RA_ICE_CAVERN,
+        RA_GERUDO_TRAINING_GROUND,
+        RA_GANONS_CASTLE,
     };
-    static std::map<RandomizerArea, bool> areaTreeEnabled{
-        { RA_NONE, true },
-        { RA_KOKIRI_FOREST, true },
-        { RA_THE_LOST_WOODS, true },
-        { RA_SACRED_FOREST_MEADOW, true },
-        { RA_HYRULE_FIELD, true },
-        { RA_LAKE_HYLIA, true },
-        { RA_GERUDO_VALLEY, true },
-        { RA_GERUDO_FORTRESS, true },
-        { RA_HAUNTED_WASTELAND, true },
-        { RA_DESERT_COLOSSUS, true },
-        { RA_THE_MARKET, true },
-        { RA_HYRULE_CASTLE, true },
-        { RA_KAKARIKO_VILLAGE, true },
-        { RA_THE_GRAVEYARD, true },
-        { RA_DEATH_MOUNTAIN_TRAIL, true },
-        { RA_GORON_CITY, true },
-        { RA_DEATH_MOUNTAIN_CRATER, true },
-        { RA_ZORAS_RIVER, true },
-        { RA_ZORAS_DOMAIN, true },
-        { RA_ZORAS_FOUNTAIN, true },
-        { RA_LON_LON_RANCH, true },
-        { RA_DEKU_TREE, true },
-        { RA_DODONGOS_CAVERN, true },
-        { RA_JABU_JABUS_BELLY, true },
-        { RA_FOREST_TEMPLE, true },
-        { RA_FIRE_TEMPLE, true },
-        { RA_WATER_TEMPLE, true },
-        { RA_SPIRIT_TEMPLE, true },
-        { RA_SHADOW_TEMPLE, true },
-        { RA_BOTTOM_OF_THE_WELL, true },
-        { RA_ICE_CAVERN, true },
-        { RA_GERUDO_TRAINING_GROUND, true },
-        { RA_GANONS_CASTLE, true },
+    static std::unordered_set<RandomizerArea> areaTreeEnabled{
+        RA_NONE,
+        RA_KOKIRI_FOREST,
+        RA_THE_LOST_WOODS,
+        RA_SACRED_FOREST_MEADOW,
+        RA_HYRULE_FIELD,
+        RA_LAKE_HYLIA,
+        RA_GERUDO_VALLEY,
+        RA_GERUDO_FORTRESS,
+        RA_HAUNTED_WASTELAND,
+        RA_DESERT_COLOSSUS,
+        RA_THE_MARKET,
+        RA_HYRULE_CASTLE,
+        RA_KAKARIKO_VILLAGE,
+        RA_THE_GRAVEYARD,
+        RA_DEATH_MOUNTAIN_TRAIL,
+        RA_GORON_CITY,
+        RA_DEATH_MOUNTAIN_CRATER,
+        RA_ZORAS_RIVER,
+        RA_ZORAS_DOMAIN,
+        RA_ZORAS_FOUNTAIN,
+        RA_LON_LON_RANCH,
+        RA_DEKU_TREE,
+        RA_DODONGOS_CAVERN,
+        RA_JABU_JABUS_BELLY,
+        RA_FOREST_TEMPLE,
+        RA_FIRE_TEMPLE,
+        RA_WATER_TEMPLE,
+        RA_SPIRIT_TEMPLE,
+        RA_SHADOW_TEMPLE,
+        RA_BOTTOM_OF_THE_WELL,
+        RA_ICE_CAVERN,
+        RA_GERUDO_TRAINING_GROUND,
+        RA_GANONS_CASTLE,
     };
 
     static std::map<Rando::Tricks::Tag, bool> showTag{
@@ -508,14 +509,14 @@ void DrawTricksMenu(WidgetInfo& info) {
             if (UIWidgets::Button("Collapse All##disabled",
                                   UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.f, 0.f)))) {
                 for (int i = 0; i < RA_MAX; i++) {
-                    areaTreeDisabled[static_cast<RandomizerArea>(i)] = false;
+                    areaTreeDisabled.erase(static_cast<RandomizerArea>(i));
                 }
             }
             ImGui::SameLine();
             if (UIWidgets::Button("Open All##disabled",
                                   UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.f, 0.f)))) {
                 for (int i = 0; i < RA_MAX; i++) {
-                    areaTreeDisabled[static_cast<RandomizerArea>(i)] = true;
+                    areaTreeDisabled.insert(static_cast<RandomizerArea>(i));
                 }
             }
             ImGui::SameLine();
@@ -524,7 +525,7 @@ void DrawTricksMenu(WidgetInfo& info) {
                 for (int i = 0; i < RT_MAX; i++) {
                     auto option = randoSettings->GetTrickSetting(static_cast<RandomizerTrick>(i));
                     if (!enabledTricks.count(static_cast<RandomizerTrick>(i)) &&
-                        trickSearch.PassFilter(option.GetName().c_str()) && areaTreeDisabled[option.GetArea()] &&
+                        trickSearch.PassFilter(option.GetName().c_str()) && areaTreeDisabled.contains(option.GetArea()) &&
                         Rando::Tricks::CheckTags(showTag, option.GetTags())) {
                         enabledTricks.insert(static_cast<RandomizerTrick>(i));
                     }
@@ -546,7 +547,7 @@ void DrawTricksMenu(WidgetInfo& info) {
                 }
                 if (hasTricks) {
                     std::string areaLabel = Rando::Tricks::GetAreaName(area) + "##disabled";
-                    ImGui::TreeNodeSetOpen(ImGui::GetID(areaLabel.c_str()), areaTreeDisabled[area]);
+                    ImGui::TreeNodeSetOpen(ImGui::GetID(areaLabel.c_str()), areaTreeDisabled.contains(area));
                     ImGui::SetNextItemOpen(true, ImGuiCond_Once);
                     if (ImGui::TreeNode(areaLabel.c_str())) {
                         for (auto rt : trickIds) {
@@ -565,10 +566,10 @@ void DrawTricksMenu(WidgetInfo& info) {
                                 UIWidgets::Tooltip(option.GetDescription().c_str());
                             }
                         }
-                        areaTreeDisabled[area] = true;
+                        areaTreeDisabled.insert(area);
                         ImGui::TreePop();
                     } else {
-                        areaTreeDisabled[area] = false;
+                        areaTreeDisabled.erase(area);
                     }
                 }
             }
@@ -581,14 +582,14 @@ void DrawTricksMenu(WidgetInfo& info) {
             if (UIWidgets::Button("Collapse All##enabled",
                                   UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.f, 0.f)))) {
                 for (int i = 0; i < RA_MAX; i++) {
-                    areaTreeEnabled[static_cast<RandomizerArea>(i)] = false;
+                    areaTreeEnabled.erase(static_cast<RandomizerArea>(i));
                 }
             }
             ImGui::SameLine();
             if (UIWidgets::Button("Open All##enabled",
                                   UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.f, 0.f)))) {
                 for (int i = 0; i < RA_MAX; i++) {
-                    areaTreeEnabled[static_cast<RandomizerArea>(i)] = true;
+                    areaTreeEnabled.insert(static_cast<RandomizerArea>(i));
                 }
             }
             ImGui::SameLine();
@@ -597,7 +598,7 @@ void DrawTricksMenu(WidgetInfo& info) {
                 for (int i = 0; i < RT_MAX; i++) {
                     auto option = randoSettings->GetTrickSetting(static_cast<RandomizerTrick>(i));
                     if (enabledTricks.count(static_cast<RandomizerTrick>(i)) &&
-                        trickSearch.PassFilter(option.GetName().c_str()) && areaTreeEnabled[option.GetArea()] &&
+                        trickSearch.PassFilter(option.GetName().c_str()) && areaTreeEnabled.contains(option.GetArea()) &&
                         Rando::Tricks::CheckTags(showTag, option.GetTags())) {
                         enabledTricks.erase(static_cast<RandomizerTrick>(i));
                     }
@@ -619,7 +620,7 @@ void DrawTricksMenu(WidgetInfo& info) {
                 }
                 if (hasTricks) {
                     std::string areaLabel = Rando::Tricks::GetAreaName(area) + "##enabled";
-                    ImGui::TreeNodeSetOpen(ImGui::GetID(areaLabel.c_str()), areaTreeEnabled[area]);
+                    ImGui::TreeNodeSetOpen(ImGui::GetID(areaLabel.c_str()), areaTreeEnabled.contains(area));
                     ImGui::SetNextItemOpen(true, ImGuiCond_Once);
                     if (ImGui::TreeNode(areaLabel.c_str())) {
                         for (auto rt : trickIds) {
@@ -638,10 +639,10 @@ void DrawTricksMenu(WidgetInfo& info) {
                                 UIWidgets::Tooltip(option.GetDescription().c_str());
                             }
                         }
-                        areaTreeEnabled[area] = true;
+                        areaTreeEnabled.insert(area);
                         ImGui::TreePop();
                     } else {
-                        areaTreeEnabled[area] = false;
+                        areaTreeEnabled.erase(area);
                     }
                 }
             }

--- a/soh/soh/SohGui/SohMenuRandomizer.cpp
+++ b/soh/soh/SohGui/SohMenuRandomizer.cpp
@@ -525,7 +525,8 @@ void DrawTricksMenu(WidgetInfo& info) {
                 for (int i = 0; i < RT_MAX; i++) {
                     auto option = randoSettings->GetTrickSetting(static_cast<RandomizerTrick>(i));
                     if (!enabledTricks.count(static_cast<RandomizerTrick>(i)) &&
-                        trickSearch.PassFilter(option.GetName().c_str()) && areaTreeDisabled.contains(option.GetArea()) &&
+                        trickSearch.PassFilter(option.GetName().c_str()) &&
+                        areaTreeDisabled.contains(option.GetArea()) &&
                         Rando::Tricks::CheckTags(showTag, option.GetTags())) {
                         enabledTricks.insert(static_cast<RandomizerTrick>(i));
                     }
@@ -598,7 +599,8 @@ void DrawTricksMenu(WidgetInfo& info) {
                 for (int i = 0; i < RT_MAX; i++) {
                     auto option = randoSettings->GetTrickSetting(static_cast<RandomizerTrick>(i));
                     if (enabledTricks.count(static_cast<RandomizerTrick>(i)) &&
-                        trickSearch.PassFilter(option.GetName().c_str()) && areaTreeEnabled.contains(option.GetArea()) &&
+                        trickSearch.PassFilter(option.GetName().c_str()) &&
+                        areaTreeEnabled.contains(option.GetArea()) &&
                         Rando::Tricks::CheckTags(showTag, option.GetTags())) {
                         enabledTricks.erase(static_cast<RandomizerTrick>(i));
                     }

--- a/soh/soh/SohGui/SohMenuRandomizer.cpp
+++ b/soh/soh/SohGui/SohMenuRandomizer.cpp
@@ -47,6 +47,24 @@ void SaveEnabledTricks() {
     return;
 }
 
+void SaveExcludedLocations() {
+    // todo: this efficiently when we build out cvar array support
+    std::string excludedLocationString = "";
+    for (auto excludedLocationIt : excludedLocations) {
+        if (!excludedLocationString.empty()) {
+            excludedLocationString += ",";
+        }
+        excludedLocationString += std::to_string(excludedLocationIt);
+    }
+    if (excludedLocationString == "") {
+        CVarClear(CVAR_RANDOMIZER_SETTING("ExcludedLocations"));
+    } else {
+        CVarSetString(CVAR_RANDOMIZER_SETTING("ExcludedLocations"), excludedLocationString.c_str());
+    }
+    Ship::Context::GetRawInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+    locationsDirty = true;
+}
+
 void DrawLocationsMenu(WidgetInfo& info) {
     auto ctx = OTRGlobals::Instance->gRandoContext;
     int32_t currMQDungeonSetting = CVarGetInteger(CVAR_RANDOMIZER_SETTING("MQDungeons"), 0) |
@@ -64,6 +82,81 @@ void DrawLocationsMenu(WidgetInfo& info) {
         RandomizerCheckObjects::UpdateImGuiVisibility();
     }
 
+    // Locations
+    static std::map<RandomizerCheckArea, bool> areaTreeIncluded{
+        { RCAREA_KOKIRI_FOREST, true },
+        { RCAREA_LOST_WOODS, true },
+        { RCAREA_SACRED_FOREST_MEADOW, true },
+        { RCAREA_HYRULE_FIELD, true },
+        { RCAREA_LAKE_HYLIA, true },
+        { RCAREA_GERUDO_VALLEY, true },
+        { RCAREA_GERUDO_FORTRESS, true },
+        { RCAREA_WASTELAND, true },
+        { RCAREA_DESERT_COLOSSUS, true },
+        { RCAREA_MARKET, true },
+        { RCAREA_HYRULE_CASTLE, true },
+        { RCAREA_KAKARIKO_VILLAGE, true },
+        { RCAREA_GRAVEYARD, true },
+        { RCAREA_DEATH_MOUNTAIN_TRAIL, true },
+        { RCAREA_GORON_CITY, true },
+        { RCAREA_DEATH_MOUNTAIN_CRATER, true },
+        { RCAREA_ZORAS_RIVER, true },
+        { RCAREA_ZORAS_DOMAIN, true },
+        { RCAREA_ZORAS_FOUNTAIN, true },
+        { RCAREA_LON_LON_RANCH, true },
+        { RCAREA_DEKU_TREE, true },
+        { RCAREA_DODONGOS_CAVERN, true },
+        { RCAREA_JABU_JABUS_BELLY, true },
+        { RCAREA_FOREST_TEMPLE, true },
+        { RCAREA_FIRE_TEMPLE, true },
+        { RCAREA_WATER_TEMPLE, true },
+        { RCAREA_SPIRIT_TEMPLE, true },
+        { RCAREA_SHADOW_TEMPLE, true },
+        { RCAREA_BOTTOM_OF_THE_WELL, true },
+        { RCAREA_ICE_CAVERN, true },
+        { RCAREA_GERUDO_TRAINING_GROUND, true },
+        { RCAREA_GANONS_CASTLE, true },
+    };
+    static std::map<RandomizerCheckArea, bool> areaTreeExcluded{
+        { RCAREA_KOKIRI_FOREST, true },
+        { RCAREA_LOST_WOODS, true },
+        { RCAREA_SACRED_FOREST_MEADOW, true },
+        { RCAREA_HYRULE_FIELD, true },
+        { RCAREA_LAKE_HYLIA, true },
+        { RCAREA_GERUDO_VALLEY, true },
+        { RCAREA_GERUDO_FORTRESS, true },
+        { RCAREA_WASTELAND, true },
+        { RCAREA_DESERT_COLOSSUS, true },
+        { RCAREA_MARKET, true },
+        { RCAREA_HYRULE_CASTLE, true },
+        { RCAREA_KAKARIKO_VILLAGE, true },
+        { RCAREA_GRAVEYARD, true },
+        { RCAREA_DEATH_MOUNTAIN_TRAIL, true },
+        { RCAREA_GORON_CITY, true },
+        { RCAREA_DEATH_MOUNTAIN_CRATER, true },
+        { RCAREA_ZORAS_RIVER, true },
+        { RCAREA_ZORAS_DOMAIN, true },
+        { RCAREA_ZORAS_FOUNTAIN, true },
+        { RCAREA_LON_LON_RANCH, true },
+        { RCAREA_DEKU_TREE, true },
+        { RCAREA_DODONGOS_CAVERN, true },
+        { RCAREA_JABU_JABUS_BELLY, true },
+        { RCAREA_FOREST_TEMPLE, true },
+        { RCAREA_FIRE_TEMPLE, true },
+        { RCAREA_WATER_TEMPLE, true },
+        { RCAREA_SPIRIT_TEMPLE, true },
+        { RCAREA_SHADOW_TEMPLE, true },
+        { RCAREA_BOTTOM_OF_THE_WELL, true },
+        { RCAREA_ICE_CAVERN, true },
+        { RCAREA_GERUDO_TRAINING_GROUND, true },
+        { RCAREA_GANONS_CASTLE, true },
+    };
+
+    static ImGuiTextFilter locationSearch;
+    UIWidgets::PushStyleInput(THEME_COLOR);
+    locationSearch.Draw("Filter (inc,-exc)", 490.0f);
+    UIWidgets::PopStyleInput();
+
     if (ImGui::BeginTable("tableRandoLocations", 2, ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV)) {
         ImGui::TableSetupColumn("Included", ImGuiTableColumnFlags_WidthStretch, 200.0f);
         ImGui::TableSetupColumn("Excluded", ImGuiTableColumnFlags_WidthStretch, 200.0f);
@@ -76,10 +169,35 @@ void DrawLocationsMenu(WidgetInfo& info) {
         ImGui::TableNextColumn();
         // window->DC.CurrLineTextBaseOffset = 0.0f;
 
-        static ImGuiTextFilter locationSearch;
-        UIWidgets::PushStyleInput(THEME_COLOR);
-        locationSearch.Draw();
-        UIWidgets::PopStyleInput();
+        if (UIWidgets::Button("Collapse All##included",
+                              UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.f, 0.f)))) {
+            for (int i = 0; i < RCAREA_INVALID; i++) {
+                areaTreeIncluded[static_cast<RandomizerCheckArea>(i)] = false;
+            }
+        }
+        ImGui::SameLine();
+        if (UIWidgets::Button("Open All##included",
+                              UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.f, 0.f)))) {
+            for (int i = 0; i < RCAREA_INVALID; i++) {
+                areaTreeIncluded[static_cast<RandomizerCheckArea>(i)] = true;
+            }
+        }
+        ImGui::SameLine();
+        if (UIWidgets::Button("Exclude Visible",
+                              UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.f, 0.f)))) {
+            for (auto& [rcArea, locations] : RandomizerCheckObjects::GetAllRCObjectsByArea()) {
+                if (!areaTreeIncluded[rcArea]) {
+                    continue;
+                }
+                for (RandomizerCheck rc : locations) {
+                    if (ctx->GetItemLocation(rc)->IsVisible() && !excludedLocations.count(rc) &&
+                        locationSearch.PassFilter(Rando::StaticData::GetLocation(rc)->GetName().c_str())) {
+                        excludedLocations.insert(rc);
+                    }
+                }
+            }
+            SaveExcludedLocations();
+        }
 
         ImGui::BeginChild("ChildIncludedLocations", ImVec2(0, -8));
         for (auto& [rcArea, locations] : RandomizerCheckObjects::GetAllRCObjectsByArea()) {
@@ -94,33 +212,27 @@ void DrawLocationsMenu(WidgetInfo& info) {
             }
 
             if (hasItems) {
+                std::string areaLabel = RandomizerCheckObjects::GetRCAreaName(rcArea) + "##included";
+                ImGui::TreeNodeSetOpen(ImGui::GetID(areaLabel.c_str()), areaTreeIncluded[rcArea]);
                 ImGui::SetNextItemOpen(true, ImGuiCond_Once);
-                if (ImGui::TreeNode(RandomizerCheckObjects::GetRCAreaName(rcArea).c_str())) {
+                if (ImGui::TreeNode(areaLabel.c_str())) {
                     for (auto& location : locations) {
                         if (ctx->GetItemLocation(location)->IsVisible() && !excludedLocations.count(location) &&
                             locationSearch.PassFilter(Rando::StaticData::GetLocation(location)->GetName().c_str())) {
                             UIWidgets::PushStyleButton(THEME_COLOR, ImVec2(7.f, 5.f));
                             if (ImGui::ArrowButton(std::to_string(location).c_str(), ImGuiDir_Right)) {
                                 excludedLocations.insert(location);
-                                // todo: this efficiently when we build out cvar array support
-                                std::string excludedLocationString = "";
-                                for (auto excludedLocationIt : excludedLocations) {
-                                    if (!excludedLocationString.empty()) {
-                                        excludedLocationString += ",";
-                                    }
-                                    excludedLocationString += std::to_string(excludedLocationIt);
-                                }
-                                CVarSetString(CVAR_RANDOMIZER_SETTING("ExcludedLocations"),
-                                              excludedLocationString.c_str());
-                                Ship::Context::GetRawInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
-                                locationsDirty = true;
+                                SaveExcludedLocations();
                             }
                             UIWidgets::PopStyleButton();
                             ImGui::SameLine();
                             ImGui::Text("%s", Rando::StaticData::GetLocation(location)->GetShortName().c_str());
                         }
                     }
+                    areaTreeIncluded[rcArea] = true;
                     ImGui::TreePop();
+                } else {
+                    areaTreeIncluded[rcArea] = false;
                 }
             }
         }
@@ -130,48 +242,71 @@ void DrawLocationsMenu(WidgetInfo& info) {
         ImGui::TableNextColumn();
         // window->DC.CurrLineTextBaseOffset = 0.0f;
 
+        if (UIWidgets::Button("Collapse All##excluded",
+                              UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.f, 0.f)))) {
+            for (int i = 0; i < RCAREA_INVALID; i++) {
+                areaTreeExcluded[static_cast<RandomizerCheckArea>(i)] = false;
+            }
+        }
+        ImGui::SameLine();
+        if (UIWidgets::Button("Open All##excluded",
+                              UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.f, 0.f)))) {
+            for (int i = 0; i < RCAREA_INVALID; i++) {
+                areaTreeExcluded[static_cast<RandomizerCheckArea>(i)] = true;
+            }
+        }
+        ImGui::SameLine();
+        if (UIWidgets::Button("Include Visible",
+                              UIWidgets::ButtonOptions().Color(THEME_COLOR).Size(ImVec2(0.f, 0.f)))) {
+            for (auto& [rcArea, locations] : RandomizerCheckObjects::GetAllRCObjectsByArea()) {
+                if (!areaTreeExcluded[rcArea]) {
+                    continue;
+                }
+                for (RandomizerCheck rc : locations) {
+                    if (ctx->GetItemLocation(rc)->IsVisible() && excludedLocations.count(rc) &&
+                        locationSearch.PassFilter(Rando::StaticData::GetLocation(rc)->GetName().c_str())) {
+                        excludedLocations.erase(rc);
+                    }
+                }
+            }
+            SaveExcludedLocations();
+        }
+
         ImGui::BeginChild("ChildExcludedLocations", ImVec2(0, -8));
         for (auto& [rcArea, locations] : RandomizerCheckObjects::GetAllRCObjectsByArea()) {
             bool hasItems = false;
             for (RandomizerCheck rc : locations) {
-                if (ctx->GetItemLocation(rc)->IsVisible() && excludedLocations.count(rc)) {
+                if (ctx->GetItemLocation(rc)->IsVisible() && excludedLocations.count(rc) &&
+                    locationSearch.PassFilter(Rando::StaticData::GetLocation(rc)->GetName().c_str())) {
+
                     hasItems = true;
                     break;
                 }
             }
 
             if (hasItems) {
+                std::string areaLabel = RandomizerCheckObjects::GetRCAreaName(rcArea) + "##excluded";
+                ImGui::TreeNodeSetOpen(ImGui::GetID(areaLabel.c_str()), areaTreeExcluded[rcArea]);
                 ImGui::SetNextItemOpen(true, ImGuiCond_Once);
-                if (ImGui::TreeNode(RandomizerCheckObjects::GetRCAreaName(rcArea).c_str())) {
+                if (ImGui::TreeNode(areaLabel.c_str())) {
                     for (auto& location : locations) {
                         auto elfound = excludedLocations.find(location);
-                        if (ctx->GetItemLocation(location)->IsVisible() && elfound != excludedLocations.end()) {
+                        if (ctx->GetItemLocation(location)->IsVisible() && elfound != excludedLocations.end() &&
+                            locationSearch.PassFilter(Rando::StaticData::GetLocation(location)->GetName().c_str())) {
                             UIWidgets::PushStyleButton(THEME_COLOR, ImVec2(7.f, 5.f));
                             if (ImGui::ArrowButton(std::to_string(location).c_str(), ImGuiDir_Left)) {
                                 excludedLocations.erase(elfound);
-                                // todo: this efficiently when we build out cvar array support
-                                std::string excludedLocationString = "";
-                                for (auto excludedLocationIt : excludedLocations) {
-                                    if (!excludedLocationString.empty()) {
-                                        excludedLocationString += ",";
-                                    }
-                                    excludedLocationString += std::to_string(excludedLocationIt);
-                                }
-                                if (excludedLocationString == "") {
-                                    CVarClear(CVAR_RANDOMIZER_SETTING("ExcludedLocations"));
-                                } else {
-                                    CVarSetString(CVAR_RANDOMIZER_SETTING("ExcludedLocations"),
-                                                  excludedLocationString.c_str());
-                                }
-                                Ship::Context::GetRawInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
-                                locationsDirty = true;
+                                SaveExcludedLocations();
                             }
                             UIWidgets::PopStyleButton();
                             ImGui::SameLine();
                             ImGui::Text("%s", Rando::StaticData::GetLocation(location)->GetShortName().c_str());
                         }
                     }
+                    areaTreeExcluded[rcArea] = true;
                     ImGui::TreePop();
+                } else {
+                    areaTreeExcluded[rcArea] = false;
                 }
             }
         }
@@ -410,18 +545,14 @@ void DrawTricksMenu(WidgetInfo& info) {
                     }
                 }
                 if (hasTricks) {
-                    ImGui::TreeNodeSetOpen(ImGui::GetID((Rando::Tricks::GetAreaName(area) + "##disabled").c_str()),
-                                           areaTreeDisabled[area]);
+                    std::string areaLabel = Rando::Tricks::GetAreaName(area) + "##disabled";
+                    ImGui::TreeNodeSetOpen(ImGui::GetID(areaLabel.c_str()), areaTreeDisabled[area]);
                     ImGui::SetNextItemOpen(true, ImGuiCond_Once);
-                    if (ImGui::TreeNode((Rando::Tricks::GetAreaName(area) + "##disabled").c_str())) {
+                    if (ImGui::TreeNode(areaLabel.c_str())) {
                         for (auto rt : trickIds) {
                             auto option = randoSettings->GetTrickSetting(rt);
                             if (!option.IsHidden() && trickSearch.PassFilter(option.GetName().c_str()) &&
                                 !enabledTricks.count(rt) && Rando::Tricks::CheckTags(showTag, option.GetTags())) {
-                                ImGui::TreeNodeSetOpen(
-                                    ImGui::GetID((Rando::Tricks::GetAreaName(option.GetArea()) + "##disabled").c_str()),
-                                    areaTreeDisabled[option.GetArea()]);
-                                ImGui::SetNextItemOpen(true, ImGuiCond_Once);
                                 UIWidgets::PushStyleButton(THEME_COLOR, ImVec2(7.f, 5.f));
                                 if (ImGui::ArrowButton(std::to_string(rt).c_str(), ImGuiDir_Right)) {
                                     enabledTricks.insert(rt);
@@ -487,18 +618,14 @@ void DrawTricksMenu(WidgetInfo& info) {
                     }
                 }
                 if (hasTricks) {
-                    ImGui::TreeNodeSetOpen(ImGui::GetID((Rando::Tricks::GetAreaName(area) + "##enabled").c_str()),
-                                           areaTreeEnabled[area]);
+                    std::string areaLabel = Rando::Tricks::GetAreaName(area) + "##enabled";
+                    ImGui::TreeNodeSetOpen(ImGui::GetID(areaLabel.c_str()), areaTreeEnabled[area]);
                     ImGui::SetNextItemOpen(true, ImGuiCond_Once);
-                    if (ImGui::TreeNode((Rando::Tricks::GetAreaName(area) + "##enabled").c_str())) {
+                    if (ImGui::TreeNode(areaLabel.c_str())) {
                         for (auto rt : trickIds) {
                             auto option = randoSettings->GetTrickSetting(rt);
                             if (!option.IsHidden() && trickSearch.PassFilter(option.GetName().c_str()) &&
                                 enabledTricks.count(rt) && Rando::Tricks::CheckTags(showTag, option.GetTags())) {
-                                ImGui::TreeNodeSetOpen(
-                                    ImGui::GetID((Rando::Tricks::GetAreaName(option.GetArea()) + "##enabled").c_str()),
-                                    areaTreeEnabled[option.GetArea()]);
-                                ImGui::SetNextItemOpen(true, ImGuiCond_Once);
                                 UIWidgets::PushStyleButton(THEME_COLOR, ImVec2(7.f, 5.f));
                                 if (ImGui::ArrowButton(std::to_string(rt).c_str(), ImGuiDir_Left)) {
                                     enabledTricks.erase(rt);


### PR DESCRIPTION
Makes some changes to the Locations page to align the UX with the Tricks/Glitches page.

### Changes:
* Search filter now applies to both the Included and Excluded list, instead of just Included.
* Add **Collapse All**, **Open All**, and **Exclude Visible** buttons to more easily work with the long lists.
* Minor tidying of Tricks/Glitches GUI code.

### Pictograph:
<img width="1624" height="1061" alt="Screenshot 2026-06-25 at 9 20 25 PM" src="https://github.com/user-attachments/assets/5bf2c217-adf1-49c0-8e46-7cfd99ea8485" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8056815709.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8056796968.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8056774401.zip)
<!--- section:artifacts:end -->