### PR TITLE
[Bugfix] Token count off-by-1

### DIFF
--- a/soh/soh/Enhancements/Items/InjectItemCounts.cpp
+++ b/soh/soh/Enhancements/Items/InjectItemCounts.cpp
@@ -26,6 +26,9 @@ void BuildSkulltulaMessage(uint16_t* textId, bool* loadFromMessageTable) {
         msg = msg + "\x0E\x3C";
     }
     int16_t gsCount = gSaveContext.inventory.gsTokens;
+    if (IS_RANDO && RAND_GET_OPTION(RSK_SHUFFLE_TOKENS)) {
+        gsCount += 1;
+    }
     msg.InsertNumber(static_cast<uint8_t>(gsCount));
     msg.AutoFormat(ITEM_SKULL_TOKEN);
     msg.LoadIntoFont();


### PR DESCRIPTION
Resolves #6776 

Ordinarily, most token shuffles and randomizers have some sort of get item animation skip in place
If you _don't_ have that set _and_ you have item count injection for tokens enabled, you'll be shown one less.
Looking back, this was probably the original intent of the ternary that always added 1 if `IS_RANDO`.

Tested the following to ensure that there's no staggler conditions:
- Vanilla
- Tokensanity w/ Get Item Disabled
- Tokensanity Off w/ Get Item Disabled

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7919026875.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7918953618.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7918936457.zip)
<!--- section:artifacts:end -->