### PR TITLE
Add fixed mode for CMC

### DIFF
--- a/soh/soh/Enhancements/randomizer/SeedContext.cpp
+++ b/soh/soh/Enhancements/randomizer/SeedContext.cpp
@@ -16,6 +16,9 @@
 #include "soh/Enhancements/randomizer/rng.h"
 #include "soh/Enhancements/randomizer/randomizer_check_tracker.h"
 #include "soh/Enhancements/randomizer/randomizer.h"
+#include "item_category_adj.h"
+#include "soh/cvar_prefixes.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 #include <vector>
 
@@ -379,12 +382,20 @@ GetItemEntry Context::GetFinalGIEntry(const RandomizerCheck rc, const bool check
         return ItemTableManager::Instance->RetrieveItemEntry(
             MOD_NONE, StaticData::RetrieveItem(StaticData::GetLocation(rc)->GetVanillaItem()).GetItemID());
     }
-    if (checkObtainability && OTRGlobals::Instance->gRandomizer->GetItemObtainabilityFromRandomizerGet(
-                                  itemLoc->GetPlacedRandomizerGet()) != CAN_OBTAIN) {
+    const auto itemCategory = itemLoc->GetPlacedItem().GetCategory();
+    const auto cmcMode = CVarGetInteger(CVAR_ENHANCEMENT("ChestSizeAndTextureMatchContents"), CSMC_OFF);
+    const auto obtainability =
+        OTRGlobals::Instance->gRandomizer->GetItemObtainabilityFromRandomizerGet(itemLoc->GetPlacedRandomizerGet());
+    if (checkObtainability && obtainability != CAN_OBTAIN) {
         if (spoilAreas) {
             CheckTracker::SpoilAreaFromCantObtain(itemLoc->GetPlacedRandomizerGet());
         }
-        return ItemTableManager::Instance->RetrieveItemEntry(MOD_NONE, GI_RUPEE_BLUE);
+        GetItemEntry bluepee = ItemTableManager::Instance->RetrieveItemEntry(MOD_NONE, GI_RUPEE_BLUE);
+        // If CSMC Fixed is enabled and we already have the item, get the original item category
+        if (cmcMode == CSMC_FIXED && obtainability == CANT_OBTAIN_ALREADY_HAVE) {
+            bluepee.getItemCategory = itemCategory;
+        }
+        return bluepee;
     }
     GetItemEntry giEntry = itemLoc->GetPlacedItem().GetGIEntry_Copy();
     if (overrides.contains(rc)) {
@@ -394,6 +405,10 @@ GetItemEntry Context::GetFinalGIEntry(const RandomizerCheck rc, const bool check
         giEntry.drawItemId = fakeGiEntry->drawItemId;
         giEntry.drawModIndex = fakeGiEntry->drawModIndex;
         giEntry.drawFunc = fakeGiEntry->drawFunc;
+    }
+    // If CSMC Fixed is enabled, override the resolution of category and get it from the item directly
+    if (cmcMode == CSMC_FIXED) {
+        giEntry.getItemCategory = itemCategory;
     }
     return giEntry;
 }

--- a/soh/soh/Enhancements/randomizer/item.cpp
+++ b/soh/soh/Enhancements/randomizer/item.cpp
@@ -506,7 +506,7 @@ const HintText& Item::GetHint() const {
     return StaticData::hintTextTable[hintKey];
 }
 
-GetItemCategory Item::GetCategory() {
+GetItemCategory Item::GetCategory() const {
     return category;
 }
 

--- a/soh/soh/Enhancements/randomizer/item.h
+++ b/soh/soh/Enhancements/randomizer/item.h
@@ -62,7 +62,7 @@ class Item {
     bool IsShieldOrTunic() const;
     RandomizerHintTextKey GetHintKey() const;
     const HintText& GetHint() const;
-    GetItemCategory GetCategory();
+    GetItemCategory GetCategory() const;
     bool operator==(const Item& right) const;
     bool operator!=(const Item& right) const;
     Item CustomIcon(const char* customIcon_, CustomIconSize iconSize_ = ICON_SIZE_32);

--- a/soh/soh/Enhancements/randomizer/item_category_adj.cpp
+++ b/soh/soh/Enhancements/randomizer/item_category_adj.cpp
@@ -1,3 +1,5 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "soh/cvar_prefixes.h"
 #include "item_category_adj.h"
 #include "z64item.h"
 #include "variables.h"
@@ -6,6 +8,11 @@
 
 GetItemCategory Randomizer_AdjustItemCategory(GetItemEntry item) {
     GetItemCategory category = item.getItemCategory;
+
+    // Fixed mode: Always show the item category
+    if (CVarGetInteger(CVAR_ENHANCEMENT("ChestSizeAndTextureMatchContents"), CSMC_OFF) == CSMC_FIXED) {
+        return category;
+    }
 
     // Downgrade bombchus to lesser if the player already has bombchus
     if (INV_CONTENT(ITEM_BOMBCHU) == ITEM_BOMBCHU &&

--- a/soh/soh/Enhancements/randomizer/item_category_adj.h
+++ b/soh/soh/Enhancements/randomizer/item_category_adj.h
@@ -6,6 +6,12 @@
 extern "C" {
 #endif
 
+typedef enum {
+    CSMC_OFF,
+    CSMC_ADAPTABLE,
+    CSMC_FIXED,
+} ContainersMatchContentsMode;
+
 GetItemCategory Randomizer_AdjustItemCategory(GetItemEntry item);
 
 #ifdef __cplusplus

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -9,6 +9,8 @@
 #include <soh/Enhancements/TimeDisplay/TimeDisplay.h>
 #include "soh/Enhancements/Restorations/GetItemManipulation.h"
 #include "soh/Enhancements/randomizer/SeedContext.h"
+#include "soh/Enhancements/randomizer/randomizer.h"
+#include "soh/Enhancements/randomizer/item_category_adj.h"
 #include <ship/Context.h>
 
 extern "C" {
@@ -138,6 +140,12 @@ static const std::map<int32_t, const char*> dampeDropRates = {
     { DAMPE_INFERNO, "Dampe's Inferno" },
 };
 
+static const std::map<int32_t, const char*> csmcValues = {
+    { CSMC_OFF, "Off" },
+    { CSMC_ADAPTABLE, "Adaptable" },
+    { CSMC_FIXED, "Fixed" },
+};
+
 static const std::map<int32_t, const char*> cursorAnywhereValues = {
     { PAUSE_ANY_CURSOR_RANDO_ONLY, "Only in Rando" },
     { PAUSE_ANY_CURSOR_ALWAYS_ON, "Always" },
@@ -211,16 +219,21 @@ void SohMenu::AddMenuEnhancements() {
             "then asks if you want to Continue, Reset, or Reset to Spawn."));
 
     AddWidget(path, "Containers Match Contents", WIDGET_SEPARATOR_TEXT);
-    AddWidget(path, "Containers Match Contents", WIDGET_CVAR_CHECKBOX)
+    AddWidget(path, "Containers Match Contents", WIDGET_CVAR_COMBOBOX)
         .CVar(CVAR_ENHANCEMENT("ChestSizeAndTextureMatchContents"))
         .Callback([](WidgetInfo& info) {
-            if (!CVarGetInteger(CVAR_ENHANCEMENT("ChestSizeAndTextureMatchContents"), 0)) {
+            if (!CVarGetInteger(CVAR_ENHANCEMENT("ChestSizeAndTextureMatchContents"), CSMC_OFF)) {
                 CVarSetInteger(CVAR_ENHANCEMENT("ChestSizeDependsStoneOfAgony"), 0);
             }
         })
-        .Options(CheckboxOptions().DefaultValue(false).Tooltip(
-            "Toggle to change container textures to match their contents in randomizer games.\n"
-            "Categories: Major items, Lesser items, Junk items, Small keys, Boss keys, Skulltula Tokens."));
+        .Options(ComboboxOptions()
+                     .ComboMap(csmcValues)
+                     .DefaultIndex(CSMC_OFF)
+                     .Tooltip("Change container textures to match their contents in randomizer games.\n"
+                              "Adaptable: a progressive upgrade or additional bottles show as a lesser item.\n"
+                              "Fixed: containers always show the item category.\n"
+                              "Categories: Major items, Lesser items, Junk items, Small keys, Boss keys, Skulltula "
+                              "Tokens, Pieces of Heart."));
     AddWidget(path, "Containers of Agony", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("ChestSizeDependsStoneOfAgony"))
         .PreFunc([](WidgetInfo& info) {


### PR DESCRIPTION
Adds a fixed mode for CMC, where only the item category is considered.
This differs from adaptable, previously the on setting, where downgrading to lesser is possible depending on inventory.
If you have had this CMC selected in prior builds, you'll see adaptable selected, so it should be back compat friendly.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9623052467.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9622924170.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9622763402.zip)
<!--- section:artifacts:end -->