### PR TITLE
[Bugfix] Skull house checks showing as 0 rupees in tracker

### DIFF
--- a/soh/soh/Enhancements/randomizer/item_location.cpp
+++ b/soh/soh/Enhancements/randomizer/item_location.cpp
@@ -126,6 +126,11 @@ bool ItemLocation::HasCustomPrice() const {
     return hasCustomPrice;
 }
 
+bool ItemLocation::CanBePurchased() const {
+    const RandomizerCheckType checkType = StaticData::GetLocation(rc)->GetRCType();
+    return checkType == RCTYPE_SHOP || checkType == RCTYPE_SCRUB || checkType == RCTYPE_MERCHANT;
+}
+
 void ItemLocation::SetCustomPrice(const uint16_t price_) {
     price = price_;
     hasCustomPrice = true;

--- a/soh/soh/Enhancements/randomizer/item_location.h
+++ b/soh/soh/Enhancements/randomizer/item_location.h
@@ -32,6 +32,7 @@ class ItemLocation {
     void SetPrice(uint16_t price_);
     bool HasCustomPrice() const;
     void SetCustomPrice(uint16_t price_);
+    bool CanBePurchased() const;
     bool HasObtained() const;
     void SetCheckStatus(RandomizerCheckStatus status_);
     RandomizerCheckStatus GetCheckStatus();

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -2073,7 +2073,7 @@ void DrawLocation(RandomizerCheck rc) {
                     } else if (revealItemName) {
                         txt = itemLoc->GetPlacedItem().GetName().GetForLanguage(gSaveContext.language);
                     }
-                    if (IsVisibleInCheckTracker(rc) && status == RCSHOW_IDENTIFIED) {
+                    if (itemLoc->CanBePurchased() && IsVisibleInCheckTracker(rc) && status == RCSHOW_IDENTIFIED) {
                         auto price = OTRGlobals::Instance->gRandoContext->GetItemLocation(rc)->GetPrice();
                         txt = !txt.empty() ? fmt::format("{} - {}", txt, price) : fmt::format("{}", price);
                     }


### PR DESCRIPTION
Resolves #6746 

Opting to gate showing cost in the check tracker by RC type.  Since skull rewards inherently have no cost, they were appearing in the check tracker.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7927467704.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7927463021.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7927440574.zip)
<!--- section:artifacts:end -->