### PR TITLE
[Bugfix] Junk stone hints not generated

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -502,7 +502,7 @@ static int32_t getRandomWeight(uint32_t totalWeight) {
 
 static void DistributeAndPlaceHints(std::vector<HintDistributionSetting>& distTable, size_t totalStones) {
     auto ctx = Rando::Context::GetInstance();
-    const uint8_t junkIdx = static_cast<uint8_t>(distTable.size());
+    const uint8_t junkIdx = static_cast<uint8_t>(distTable.size() - 1);
 
     // Apply fixed hints upfront (they don't participate in weighted selection)
     for (size_t i = 0; i < distTable.size(); i++) {


### PR DESCRIPTION
Resolves #6745 

Junk index was a value that is not a valid index of distTable, and thus would never match further down
Easy to repro:  Set hint distribution to Useless and all stone hints in JSON will be "No Hint"

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7927673339.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7927627219.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7927620935.zip)
<!--- section:artifacts:end -->