### PR TITLE
Add Easy Butterfly Fairy Cvar

### DIFF
--- a/soh/soh/Enhancements/QoL/EasyButterflyFairies.cpp
+++ b/soh/soh/Enhancements/QoL/EasyButterflyFairies.cpp
@@ -1,0 +1,24 @@
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+#include "soh/Enhancements/randomizer/SeedContext.h"
+
+extern "C" {
+#include "src/overlays/actors/ovl_En_Butte/z_en_butte.h"
+#include "variables.h"
+}
+
+void EasyButterflyFairies_Register() {
+    COND_VB_SHOULD(VB_SPAWN_BUTTERFLY_FAIRY_EASY,
+                   CVarGetInteger(CVAR_ENHANCEMENT("EasyButterflyFairies"), 0) ||
+                       (IS_RANDO && RAND_GET_OPTION(RSK_SHUFFLE_BUTTERFLY_FAIRIES)),
+                   {
+                       EnButte* enButte = va_arg(args, EnButte*);
+                       Player* player = GET_PLAYER(gPlayState);
+                       if (player->heldItemAction == PLAYER_IA_DEKU_STICK && enButte->actor.xzDistToPlayer < 60.0f) {
+                           *should = false;
+                       }
+                   });
+}
+
+static RegisterShipInitFunc initFunc(EasyButterflyFairies_Register,
+                                     { CVAR_ENHANCEMENT("EasyButterflyFairies"), "IS_RANDO" });

--- a/soh/soh/Enhancements/QoL/EasyButterflyFairies.cpp
+++ b/soh/soh/Enhancements/QoL/EasyButterflyFairies.cpp
@@ -5,6 +5,7 @@
 extern "C" {
 #include "src/overlays/actors/ovl_En_Butte/z_en_butte.h"
 #include "variables.h"
+extern void EnButte_SetupTransformIntoFairy(EnButte* enButte);
 }
 
 void EasyButterflyFairies_Register() {
@@ -15,6 +16,7 @@ void EasyButterflyFairies_Register() {
                        EnButte* enButte = va_arg(args, EnButte*);
                        Player* player = GET_PLAYER(gPlayState);
                        if (player->heldItemAction == PLAYER_IA_DEKU_STICK && enButte->actor.xzDistToPlayer < 60.0f) {
+                           EnButte_SetupTransformIntoFairy(enButte);
                            *should = false;
                        }
                    });

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -2405,6 +2405,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*EnButte`
+    VB_SPAWN_BUTTERFLY_FAIRY_EASY,
+
+    // #### `result`
+    // ```c
     // INV_CONTENT(ITEM_ARROW_FIRE) == ITEM_NONE
     // ```
     // #### `args`

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -298,6 +298,13 @@ void SohMenu::AddMenuEnhancements() {
             "The default response to Kaepora Gaebora is always that you understood what he said."));
     AddWidget(path, "Easy Butterfly Fairies", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("EasyButterflyFairies"))
+        .PreFunc([](WidgetInfo& info) {
+            info.options->disabled =
+                IS_RANDO &&
+                OTRGlobals::Instance->gRandoContext->GetOption(RSK_SHUFFLE_BUTTERFLY_FAIRIES).Is(RO_GENERIC_ON);
+            info.options->disabledTooltip = "This setting is forcefully enabled because a randomizer savefile with "
+                                            "\"Butterfly Fairies Shuffle\" is loaded.";
+        })
         .Options(CheckboxOptions().Tooltip(
             "Butterflies will transform into a fairy as soon as you approach them with a Deku Stick, "
             "skipping the need to stand still and let the butterfly land on your stick."));

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -296,6 +296,11 @@ void SohMenu::AddMenuEnhancements() {
         .CVar(CVAR_ENHANCEMENT("BetterOwl"))
         .Options(CheckboxOptions().Tooltip(
             "The default response to Kaepora Gaebora is always that you understood what he said."));
+    AddWidget(path, "Easy Butterfly Fairies", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("EasyButterflyFairies"))
+        .Options(CheckboxOptions().Tooltip(
+            "Butterflies will transform into a fairy as soon as you approach them with a Deku Stick, "
+            "skipping the need to stand still and let the butterfly land on your stick."));
 
     AddWidget(path, "Convenience", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Quit Fishing at Door", WIDGET_CVAR_CHECKBOX)

--- a/soh/src/overlays/actors/ovl_En_Butte/z_en_butte.c
+++ b/soh/src/overlays/actors/ovl_En_Butte/z_en_butte.c
@@ -349,8 +349,6 @@ void EnButte_FollowLink(EnButte* this, PlayState* play) {
                 EnButte_SetupTransformIntoFairy(this);
             }
         }
-    } else {
-        EnButte_SetupTransformIntoFairy(this);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Butte/z_en_butte.c
+++ b/soh/src/overlays/actors/ovl_En_Butte/z_en_butte.c
@@ -338,8 +338,12 @@ void EnButte_FollowLink(EnButte* this, PlayState* play) {
 
     distSqFromHome = Math3D_Dist2DSq(this->actor.world.pos.x, this->actor.world.pos.z, this->actor.home.pos.x,
                                      this->actor.home.pos.z);
-    if (!((player->heldItemAction == PLAYER_IA_DEKU_STICK) && (fabsf(player->actor.speedXZ) < 1.8f) &&
-          (this->swordDownTimer <= 0) && (distSqFromHome < SQ(320.0f)))) {
+    if (CVarGetInteger(CVAR_ENHANCEMENT("EasyButterflyFairies"), 0)) {
+        if (this->actor.xzDistToPlayer < 60.0f) {
+            EnButte_SetupTransformIntoFairy(this);
+        }
+    } else if (!((player->heldItemAction == PLAYER_IA_DEKU_STICK) && (fabsf(player->actor.speedXZ) < 1.8f) &&
+                 (this->swordDownTimer <= 0) && (distSqFromHome < SQ(320.0f)))) {
         EnButte_SetupFlyAround(this);
     } else if (distSqFromHome > SQ(240.0f)) {
         distSqFromSword = Math3D_Dist2DSq(player->meleeWeaponInfo[0].tip.x, player->meleeWeaponInfo[0].tip.z,

--- a/soh/src/overlays/actors/ovl_En_Butte/z_en_butte.c
+++ b/soh/src/overlays/actors/ovl_En_Butte/z_en_butte.c
@@ -338,19 +338,19 @@ void EnButte_FollowLink(EnButte* this, PlayState* play) {
 
     distSqFromHome = Math3D_Dist2DSq(this->actor.world.pos.x, this->actor.world.pos.z, this->actor.home.pos.x,
                                      this->actor.home.pos.z);
-    if (CVarGetInteger(CVAR_ENHANCEMENT("EasyButterflyFairies"), 0)) {
-        if (this->actor.xzDistToPlayer < 60.0f) {
-            EnButte_SetupTransformIntoFairy(this);
+    if (GameInteractor_Should(VB_SPAWN_BUTTERFLY_FAIRY_EASY, true, this)) {
+        if (!((player->heldItemAction == PLAYER_IA_DEKU_STICK) && (fabsf(player->actor.speedXZ) < 1.8f) &&
+              (this->swordDownTimer <= 0) && (distSqFromHome < SQ(320.0f)))) {
+            EnButte_SetupFlyAround(this);
+        } else if (distSqFromHome > SQ(240.0f)) {
+            distSqFromSword = Math3D_Dist2DSq(player->meleeWeaponInfo[0].tip.x, player->meleeWeaponInfo[0].tip.z,
+                                              this->actor.world.pos.x, this->actor.world.pos.z);
+            if (distSqFromSword < SQ(60.0f)) {
+                EnButte_SetupTransformIntoFairy(this);
+            }
         }
-    } else if (!((player->heldItemAction == PLAYER_IA_DEKU_STICK) && (fabsf(player->actor.speedXZ) < 1.8f) &&
-                 (this->swordDownTimer <= 0) && (distSqFromHome < SQ(320.0f)))) {
-        EnButte_SetupFlyAround(this);
-    } else if (distSqFromHome > SQ(240.0f)) {
-        distSqFromSword = Math3D_Dist2DSq(player->meleeWeaponInfo[0].tip.x, player->meleeWeaponInfo[0].tip.z,
-                                          this->actor.world.pos.x, this->actor.world.pos.z);
-        if (distSqFromSword < SQ(60.0f)) {
-            EnButte_SetupTransformIntoFairy(this);
-        }
+    } else {
+        EnButte_SetupTransformIntoFairy(this);
     }
 }
 


### PR DESCRIPTION
Adds a cvar to make it easier to spawn fairies from butterflies. skips the chase sequence.

Without this its pretty painful to spawn the fairies for the shuffle

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7961839196.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7961739887.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7961733704.zip)
<!--- section:artifacts:end -->