### PR TITLE
Fix KZ red ice check when red ice is removed by glitch

### DIFF
--- a/soh/soh/Enhancements/randomizer/ShuffleRedIce.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleRedIce.cpp
@@ -118,6 +118,12 @@ void BgIceShelter_RandomizerSpawnCollectible(Actor* actor) {
     }
 }
 
+void BgIceShelter_KingZoraSpawnCollectible(void* actor) {
+    if (!Flags_GetRandomizerInf(RAND_INF_ZD_KING_ZORA_RED_ICE) && Flags_GetInfTable(INFTABLE_138)) {
+        Flags_SetRandomizerInf(RAND_INF_ZD_KING_ZORA_RED_ICE);
+    }
+}
+
 static CheckIdentity IdentifyRedIce(s32 sceneNum, s32 posX, s32 posZ) {
     struct CheckIdentity redIceIdentity;
     uint32_t redIceSceneNum = sceneNum;
@@ -176,6 +182,9 @@ void RegisterShuffleRedIce() {
             }
         }
     });
+
+    // Give King Zora red ice item if ice was removed with glitch
+    COND_ID_HOOK(OnActorInit, ACTOR_EN_KZ, shouldRegister, BgIceShelter_KingZoraSpawnCollectible);
 }
 
 void Rando::StaticData::RegisterRedIceLocations() {


### PR DESCRIPTION
Removing the red ice by glitch prevents spawning entirely upon re-entering the room, which also bypasses any current rando identity check. Adds a check of the spawn flag on KZ init to add the item to the queue if it hasn't been collected.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7956491998.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7956302990.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7956272695.zip)
<!--- section:artifacts:end -->