### PR TITLE
Disable starting wallet when child wallet is shuffled

### DIFF
--- a/soh/soh/Enhancements/randomizer/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/settings.cpp
@@ -834,6 +834,14 @@ void Settings::CreateOptions() {
     OPT_BOOL(RSK_SHUFFLE_MASTER_SWORD, "Shuffle Master Sword", CVAR_RANDOMIZER_SETTING("ShuffleMasterSword"), mOptionDescriptions[RSK_SHUFFLE_MASTER_SWORD]);
     OPT_BOOL(RSK_SWORDLESS_EPONA_ITEMS, "Swordless Epona Items", CVAR_RANDOMIZER_SETTING("SwordlessEponaItems"), mOptionDescriptions[RSK_SWORDLESS_EPONA_ITEMS]);
     OPT_BOOL(RSK_SHUFFLE_CHILD_WALLET, "Shuffle Child's Wallet", CVAR_RANDOMIZER_SETTING("ShuffleChildWallet"), mOptionDescriptions[RSK_SHUFFLE_CHILD_WALLET], IMFLAG_NONE);
+    OPT_CALLBACK(RSK_SHUFFLE_CHILD_WALLET, {
+        if (CVarGetInteger(CVAR_RANDOMIZER_SETTING("ShuffleChildWallet"), 0)) {
+            CVarSetInteger(CVAR_RANDOMIZER_SETTING("StartingWallet"), 0);
+            mOptions[RSK_STARTING_WALLET].Disable("Disabled because Shuffle Child's Wallet is on.");
+        } else {
+            mOptions[RSK_STARTING_WALLET].Enable();
+        }
+    });
     OPT_BOOL(RSK_INCLUDE_TYCOON_WALLET, "Include Tycoon Wallet", CVAR_RANDOMIZER_SETTING("IncludeTycoonWallet"), mOptionDescriptions[RSK_INCLUDE_TYCOON_WALLET]);
     OPT_BOOL(RSK_SHUFFLE_OCARINA, "Shuffle Ocarinas", CVAR_RANDOMIZER_SETTING("ShuffleOcarinas"), mOptionDescriptions[RSK_SHUFFLE_OCARINA]);
     OPT_CALLBACK(RSK_SHUFFLE_OCARINA, {
@@ -2618,6 +2626,9 @@ void Context::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocation
     }
     if (mOptions[RSK_SHUFFLE_GRAB]) {
         mOptions[RSK_STARTING_STRENGTH].Set(0);
+    }
+    if (mOptions[RSK_SHUFFLE_CHILD_WALLET]) {
+        mOptions[RSK_STARTING_WALLET].Set(0);
     }
 
     if (mOptions[RSK_ZORAS_FOUNTAIN].IsNot(RO_ZF_OPEN) &&

--- a/soh/soh/SohGui/SohMenuStartingItems.cpp
+++ b/soh/soh/SohGui/SohMenuStartingItems.cpp
@@ -177,7 +177,7 @@ void DrawStartingItemsMenu(WidgetInfo& info) {
     ImGui::SameLine();
     StartingItemToggle(RSK_STARTING_GERUDO_CARD, ITEM_GERUDO_CARD);
 
-    // Starting Strength/Scale have no effect when Grab/Swim are shuffled; the generator
+    // Starting Strength/Scale/Wallet have no effect when Grab/Swim/Child's Wallet are shuffled; the generator
     // force-disables them (settings.cpp), so gray them out to match.
     bool grabShuffled =
         CVarGetInteger(Rando::Settings::GetInstance()->GetOption(RSK_SHUFFLE_GRAB).GetCVarName().c_str(), 0) != 0;
@@ -199,7 +199,15 @@ void DrawStartingItemsMenu(WidgetInfo& info) {
     ImGui::SameLine();
     StartingItemTiered(RSK_STARTING_MAGIC_METER, { ITEM_MAGIC_SMALL, ITEM_MAGIC_LARGE });
     ImGui::SameLine();
+    bool childsWalletShuffled =
+        CVarGetInteger(Rando::Settings::GetInstance()->GetOption(RSK_SHUFFLE_CHILD_WALLET).GetCVarName().c_str(), 0) !=
+        0;
+    ImGui::BeginDisabled(childsWalletShuffled);
     StartingItemTiered(RSK_STARTING_WALLET, { ITEM_WALLET_ADULT, ITEM_WALLET_GIANT });
+    ImGui::EndDisabled();
+    if (childsWalletShuffled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+        ImGui::SetTooltip("Disabled because Shuffle Child's Wallet is on.");
+    }
 
     ImGui::SeparatorText("Items");
     bool stickBagShuffled =


### PR DESCRIPTION
Match behavior for swim/grab

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7998222496.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7998129898.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/7998105819.zip)
<!--- section:artifacts:end -->