### PR TITLE
Enhancement, add SoT blocks to one point cutscene skip

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/TimeSavers/timesaver_hook_handlers.cpp
@@ -702,8 +702,7 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
         }
         case VB_PLAY_TIMEBLOCK_CS: {
             if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.OnePoint"), IS_RANDO)) {
-                // Turn camera as if SoT block cutscene
-                func_800C0808(gPlayState, 0, GET_PLAYER(gPlayState), CAM_SET_CS_ATTENTION);
+                // Todo: Preferable if possible to turn camera as if SoT block cutscene
                 *should = false;
             }
             break;

--- a/soh/soh/Enhancements/TimeSavers/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/TimeSavers/timesaver_hook_handlers.cpp
@@ -700,6 +700,14 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
             }
             break;
         }
+        case VB_PLAY_TIMEBLOCK_CS: {
+            if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.OnePoint"), IS_RANDO)) {
+                // Turn camera as if SoT block cutscene
+                func_800C0808(gPlayState, 0, GET_PLAYER(gPlayState), CAM_SET_CS_ATTENTION);
+                *should = false;
+            }
+            break;
+        }
         case VB_PLAY_GORON_FREE_CS: {
             if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.Story"), IS_RANDO)) {
                 *should = false;

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -1744,6 +1744,14 @@ typedef enum {
     VB_PLAY_CARPENTER_FREE_CS,
 
     // #### `result`
+    // ```c
+    // true if one point cutscene skip not enabled, or not randomizer
+    // ```
+    // #### `args`
+    // - none
+    VB_PLAY_TIMEBLOCK_CS,
+
+    // #### `result`
     // Close enough & various cutscene checks
     // ```c
     // (func_80AEC5FC(this, play)) && (!Play_InCsMode(play)) &&

--- a/soh/src/overlays/actors/ovl_Obj_Timeblock/z_obj_timeblock.c
+++ b/soh/src/overlays/actors/ovl_Obj_Timeblock/z_obj_timeblock.c
@@ -220,6 +220,7 @@ void ObjTimeblock_Normal(ObjTimeblock* this, PlayState* play) {
         this->demoEffectTimer = 160;
 
         if (GameInteractor_Should(VB_PLAY_TIMEBLOCK_CS, true, this)) {
+            // Possibly points the camera to this actor
             OnePointCutscene_Attention(play, &this->dyna.actor);
         }
 

--- a/soh/src/overlays/actors/ovl_Obj_Timeblock/z_obj_timeblock.c
+++ b/soh/src/overlays/actors/ovl_Obj_Timeblock/z_obj_timeblock.c
@@ -6,6 +6,7 @@
 
 #include "z_obj_timeblock.h"
 #include "objects/object_timeblock/object_timeblock.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS                                                                                               \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_UPDATE_DURING_OCARINA | \
@@ -218,8 +219,10 @@ void ObjTimeblock_Normal(ObjTimeblock* this, PlayState* play) {
         ObjTimeblock_SpawnDemoEffect(this, play);
         this->demoEffectTimer = 160;
 
-        // Possibly points the camera to this actor
-        OnePointCutscene_Attention(play, &this->dyna.actor);
+        if (GameInteractor_Should(VB_PLAY_TIMEBLOCK_CS, true, this)) {
+            OnePointCutscene_Attention(play, &this->dyna.actor);
+        }
+
         // "◯◯◯◯ Time Block Attention Camera (frame counter  %d)\n"
         osSyncPrintf("◯◯◯◯ Time Block 注目カメラ (frame counter  %d)\n", play->state.frames);
 
@@ -277,7 +280,11 @@ void ObjTimeblock_AltBehaviorVisible(ObjTimeblock* this, PlayState* play) {
         this->demoEffectFirstPartTimer = 12;
         ObjTimeblock_SpawnDemoEffect(this, play);
         this->demoEffectTimer = 160;
-        OnePointCutscene_Attention(play, &this->dyna.actor);
+
+        if (GameInteractor_Should(VB_PLAY_TIMEBLOCK_CS, true, this)) {
+            OnePointCutscene_Attention(play, &this->dyna.actor);
+        }
+
         // "Time Block Attention Camera (frame counter)"
         osSyncPrintf("◯◯◯◯ Time Block 注目カメラ (frame counter  %d)\n", play->state.frames);
         ObjTimeblock_ToggleSwitchFlag(play, this->dyna.actor.params & 0x3F);

--- a/soh/src/overlays/actors/ovl_Obj_Warp2block/z_obj_warp2block.c
+++ b/soh/src/overlays/actors/ovl_Obj_Warp2block/z_obj_warp2block.c
@@ -6,6 +6,7 @@
 
 #include "z_obj_warp2block.h"
 #include "objects/object_timeblock/object_timeblock.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "vt.h"
 
 #define FLAGS                                                                                               \
@@ -280,7 +281,7 @@ void func_80BA2610(ObjWarp2block* this, PlayState* play) {
     if ((func_80BA2304(this, play) != 0) && (this->unk_16C <= 0)) {
         ObjWarp2block_Spawn(this, play);
         this->unk_16C = 0xA0;
-        if (!CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.OnePoint"), !IS_RANDO)) {
+        if (GameInteractor_Should(VB_PLAY_TIMEBLOCK_CS, true, this)) {
             OnePointCutscene_Attention(play, &this->dyna.actor);
         }
         this->unk_170 = 0xC;

--- a/soh/src/overlays/actors/ovl_Obj_Warp2block/z_obj_warp2block.c
+++ b/soh/src/overlays/actors/ovl_Obj_Warp2block/z_obj_warp2block.c
@@ -280,7 +280,9 @@ void func_80BA2610(ObjWarp2block* this, PlayState* play) {
     if ((func_80BA2304(this, play) != 0) && (this->unk_16C <= 0)) {
         ObjWarp2block_Spawn(this, play);
         this->unk_16C = 0xA0;
-        OnePointCutscene_Attention(play, &this->dyna.actor);
+        if (!CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.OnePoint"), !IS_RANDO)) {
+            OnePointCutscene_Attention(play, &this->dyna.actor);
+        }
         this->unk_170 = 0xC;
     }
 


### PR DESCRIPTION
Fixes #4703.

The skip does redirect the camera like the cutscene would to prevent disorientation.
https://www.youtube.com/watch?v=RJVqCsatpjg

There's apparently an "alt" type of SoT blocks (certain params on spawn) that have their own action functions. I didn't go looking for them but just added the same skip to their cutscene call.

I tested on SoT blocks in GTG and at Dampe/Windmill. If there are any blocks that need their cutscene retained for some reason it can of course be added.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8173201465.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8173192443.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8173148110.zip)
<!--- section:artifacts:end -->