### PR TITLE
Bugfix, restore A alpha on pause menu age change

### DIFF
--- a/soh/soh/Enhancements/SwitchAge.cpp
+++ b/soh/soh/Enhancements/SwitchAge.cpp
@@ -53,6 +53,12 @@ void SwitchAge() {
         Entrance_SetEntranceDiscovered(ENTR_LINKS_HOUSE_CHILD_SPAWN, false);
     }
 
+    // If paused, restore things as if unpausing
+    if (gPlayState->pauseCtx.state != 0) {
+        // Restore A button enabled alpha (disabled if changing on item/equip subscreen, difficult to get re-enable)
+        gSaveContext.buttonStatus[4] = 0;
+    }
+
     static HOOK_ID hookId = 0;
     hookId = REGISTER_VB_SHOULD(VB_INFLICT_VOID_DAMAGE, {
         *should = false;


### PR DESCRIPTION
Fixes #2807.
A button is dimmed on some subscreens (notably item and equipment) during pause. If age is changed during pause, this isn't restored to normal alpha, and can be really difficult to restore (unless you realise you have to change age again on a non-dimmed subscreen).

I do also want to mention that `GameInteractor_Should(VB_TEMP_B_RESTORE_SWORDLESS, true)` is called when exiting the pause menu (see end of z_kaleido_scope_PAL.c) but this is not called when changing age during pause, in case it should be added too.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8066482088.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8066348079.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8066317362.zip)
<!--- section:artifacts:end -->