### PR TITLE
Bugfix, grotto boulder block respawn from water voidout

### DIFF
--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -2790,7 +2790,8 @@ f32 triforcePieceScale;
 
 void RandomizerOnPlayerUpdateHandler() {
     if ((GET_PLAYER(gPlayState)->stateFlags1 & PLAYER_STATE1_IN_WATER) && !Flags_GetRandomizerInf(RAND_INF_CAN_SWIM) &&
-        CUR_EQUIP_VALUE(EQUIP_TYPE_BOOTS) != EQUIP_VALUE_BOOTS_IRON) {
+        CUR_EQUIP_VALUE(EQUIP_TYPE_BOOTS) != EQUIP_VALUE_BOOTS_IRON &&
+        gPlayState->transitionTrigger == TRANS_TRIGGER_OFF) {
         // if you void out in water temple without swim you get instantly kicked out to prevent softlocks
         if (gPlayState->sceneNum == SCENE_WATER_TEMPLE) {
             GameInteractor::RawAction::TeleportPlayer(
@@ -2816,6 +2817,7 @@ void RandomizerOnPlayerUpdateHandler() {
                 gSaveContext.respawnFlag = 0;
             } else {
                 Play_TriggerVoidOut(gPlayState);
+                Grotto_ForceGrottoReturnOnSpecialEntrance();
             }
         }
     }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -10677,6 +10677,10 @@ void Player_StartMode_Door(PlayState* play, Player* this) {
 }
 
 void Player_StartMode_Grotto(PlayState* play, Player* this) {
+    // If can respawn from water to grotto, need to set normal speed factor for the jump
+    if (IS_RANDO) {
+        sWaterSpeedFactor = 1.0f;
+    }
     func_808389E8(this, &gPlayerAnim_link_normal_jump, 12.0f, play);
     Player_SetupAction(play, this, Player_Action_8084F9C0, 0);
     this->stateFlags1 |= PLAYER_STATE1_IN_CUTSCENE;


### PR DESCRIPTION
Fixes #6587.
`sWaterSpeedFactor`, used to slow velocity and animations in water, is still set to 0.5 when respawning after voiding out in water. This causes the jump out of the grotto to be half of expected velocity.
So, just set it to 1.0 when starting from a grotto if grottos are randomized, as there are no underwater grottos anyway.

I also added a condition to the water voidout start function that the transition trigger should be off, in line with other scene change functions, as the function only has to be run once to start the voidout process.

(I don't understand what causes the possible voidout directly after grotto spawn without big jump but the "default" respawn position is because the `respawnFlag` is set to 0 which means that set respawn data for positioning is not used to position player after init.)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8067595021.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8067463508.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8067413094.zip)
<!--- section:artifacts:end -->