### PR TITLE
Bugfix, add Dodongo fire in enemy randomizer

### DIFF
--- a/soh/src/overlays/effects/ovl_Effect_Ss_D_Fire/z_eff_ss_d_fire.c
+++ b/soh/src/overlays/effects/ovl_Effect_Ss_D_Fire/z_eff_ss_d_fire.c
@@ -31,7 +31,7 @@ u32 EffectSsDFire_Init(PlayState* play, u32 index, EffectSs* this, void* initPar
     EffectSsDFireInitParams* initParams = (EffectSsDFireInitParams*)initParamsx;
     s32 objBankIndex = Object_GetIndex(&play->objectCtx, OBJECT_DODONGO);
 
-    if (objBankIndex >= 0) {
+    if (objBankIndex >= 0 || CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), false)) {
         this->pos = initParams->pos;
         this->velocity = initParams->velocity;
         this->accel = initParams->accel;
@@ -73,7 +73,8 @@ void EffectSsDFire_Draw(PlayState* play, u32 index, EffectSs* this) {
 
     OPEN_DISPS(gfxCtx);
 
-    if (Object_GetIndex(&play->objectCtx, OBJECT_DODONGO) > -1) {
+    if (Object_GetIndex(&play->objectCtx, OBJECT_DODONGO) > -1 ||
+        CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), false)) {
         gSegments[6] = VIRTUAL_TO_PHYSICAL(object);
         gSPSegment(POLY_XLU_DISP++, 0x06, object);
         scale = this->rScale / 100.0f;


### PR DESCRIPTION
Fixes one issue of #2099.
Dodongo fire effect `Effect_Ss_D_Fire` is dependent on `OBJECT_DODONGO` on console and checks for it on init and draw. Just skip this check if enemy randomizer.

<img width="534" height="359" alt="dodongos fire" src="https://github.com/user-attachments/assets/419b6eaf-e7a2-4852-9fcd-211d71e1cac7" />

Yes I need this many hearts for a casual playthrough.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8068186787.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8068054700.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8068029546.zip)
<!--- section:artifacts:end -->