### PR TITLE
Ensure great fairy rewards are synced in vanilla

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/TimeSavers/timesaver_hook_handlers.cpp
@@ -796,14 +796,27 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                 }
             }
 
-            if (flag != RAND_INF_MAX &&
-                (IS_RANDO || CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions"), IS_RANDO))) {
-                if (IS_RANDO || *should) {
+            if (flag != RAND_INF_MAX) {
+                if (IS_RANDO) {
+                    // If we're in rando, set the flag and fill magic/health. The flag will trigger the check later with
+                    // the queue Notably, we ignore the vanilla *should value because in rando we don't care about the
+                    // requirements
                     Flags_SetRandomizerInf(flag);
                     gSaveContext.healthAccumulator = MAX_HEALTH;
                     Magic_Fill(gPlayState);
+                } else {
+                    // If we're in vanilla, set the flag _if_ we were eligble, so that anchor can send the reward in
+                    // co-op
+                    if (*should) {
+                        Flags_SetRandomizerInf(flag);
+                        // If we're in vanilla and skipping the cutscene, fill health/magic, and prevent the cutscene
+                        if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipMiscInteractions"), IS_RANDO)) {
+                            gSaveContext.healthAccumulator = MAX_HEALTH;
+                            Magic_Fill(gPlayState);
+                            *should = false;
+                        }
+                    }
                 }
-                *should = false;
             }
 
             break;

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_RawAction.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_RawAction.cpp
@@ -243,11 +243,6 @@ void GameInteractor::RawAction::SetFlag(int16_t flagType, int16_t flag) {
             gSaveContext.eventInf[flag >> 4] |= (1 << (flag & 0xF));
             break;
         case FlagType::FLAG_RANDOMIZER_INF:
-            if (!IS_RANDO) {
-                LUSLOG_ERROR("Tried to set randomizerInf flag outside of rando (%d)", flag);
-                assert(false);
-                break;
-            }
             gSaveContext.ship.randomizerInf[flag >> 4] |= (1 << (flag & 0xF));
             break;
         case FlagType::FLAG_GS_TOKEN:

--- a/soh/soh/Network/Anchor/HookHandlers.cpp
+++ b/soh/soh/Network/Anchor/HookHandlers.cpp
@@ -118,7 +118,7 @@ void Anchor::RegisterHooks() {
     COND_HOOK(OnFlagSet, isConnected, [&](s16 flagType, s16 flag) {
         SendPacket_SetFlag(SCENE_ID_MAX, flagType, flag);
 
-        // // If we're not in rando, we have to sync some of the great fairy rewards manually
+        // If we're not in rando, we have to sync some of the great fairy rewards manually
         if (!IS_RANDO) {
             if (flagType == FLAG_RANDOMIZER_INF) {
                 switch (flag) {

--- a/soh/soh/Network/Anchor/HookHandlers.cpp
+++ b/soh/soh/Network/Anchor/HookHandlers.cpp
@@ -115,8 +115,26 @@ void Anchor::RegisterHooks() {
         }
     });
 
-    COND_HOOK(OnFlagSet, isConnected,
-              [&](s16 flagType, s16 flag) { SendPacket_SetFlag(SCENE_ID_MAX, flagType, flag); });
+    COND_HOOK(OnFlagSet, isConnected, [&](s16 flagType, s16 flag) {
+        SendPacket_SetFlag(SCENE_ID_MAX, flagType, flag);
+
+        // // If we're not in rando, we have to sync some of the great fairy rewards manually
+        if (!IS_RANDO) {
+            if (flagType == FLAG_RANDOMIZER_INF) {
+                switch (flag) {
+                    case RAND_INF_DMT_GREAT_FAIRY_REWARD:
+                        SendPacket_GiveItem(1, RG_MAGIC_SINGLE);
+                        break;
+                    case RAND_INF_DMC_GREAT_FAIRY_REWARD:
+                        SendPacket_GiveItem(1, RG_MAGIC_DOUBLE);
+                        break;
+                    case RAND_INF_OGC_GREAT_FAIRY_REWARD:
+                        SendPacket_GiveItem(1, RG_DOUBLE_DEFENSE);
+                        break;
+                }
+            }
+        }
+    });
 
     COND_HOOK(OnFlagUnset, isConnected,
               [&](s16 flagType, s16 flag) { SendPacket_UnsetFlag(SCENE_ID_MAX, flagType, flag); });


### PR DESCRIPTION
These great fairy flags are already used outside of rando to enable the cutscene skips & item gives, so not that far fetched to also use them for anchor.

Currently in anchor vanilla, the fairy rewards are granted in a way that is not handled so they are just left out of sync.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8077766483.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8077729264.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8077714986.zip)
<!--- section:artifacts:end -->