### PR TITLE
Desync the great fairy cutscene

### DIFF
--- a/soh/soh/Network/Anchor/Packets/SetFlag.cpp
+++ b/soh/soh/Network/Anchor/Packets/SetFlag.cpp
@@ -69,8 +69,14 @@ void Anchor::HandlePacket_SetFlag(nlohmann::json payload) {
             return;
         }
 
-        // Special case: Ignore Tower Collapse timer start.
+        // Special case: Ignore tower collapse timer start, stored 0x36.
         if (sceneNum == SCENE_GANONS_TOWER_COLLAPSE_EXTERIOR && flagType == FLAG_SCENE_SWITCH && flag == 0x36) {
+            return;
+        }
+
+        // Special case: Ignore Great Fairy cutscenes, stored 0x38.
+        if ((sceneNum == SCENE_GREAT_FAIRYS_FOUNTAIN_MAGIC || sceneNum == SCENE_GREAT_FAIRYS_FOUNTAIN_SPELLS) &&
+            flagType == FLAG_SCENE_SWITCH && flag == 0x38) {
             return;
         }
 


### PR DESCRIPTION
When 2 players are in the fairy fountain and 1 activates the great fairy cutscene, it can force the other player into the cutscene as well, and I've had some crashes arbitrarily too so this guarentees that doesnt happen.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8077951417.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8077909181.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8077900359.zip)
<!--- section:artifacts:end -->