### PR TITLE
1 Cache + Fix logical errors

### DIFF
--- a/soh/soh/Enhancements/customequipment.cpp
+++ b/soh/soh/Enhancements/customequipment.cpp
@@ -51,10 +51,7 @@ static Gfx* LoadGfxByName(const char* path) {
 }
 
 static Gfx* LoadCustomGfx(const char* path) {
-    if (!path)
-        return nullptr;
-    path = ResolveCustomFPSHand(path);
-    if (!ResourceGetIsCustomByName(path) && !ResourceMgr_FileAltExists(path))
+    if (!path || !ResourceMgr_FileAltExists(path) || !ResourceGetIsCustomByName(path))
         return nullptr;
     return ResourceMgr_LoadGfxByName(path);
 }

--- a/soh/soh/Enhancements/customequipment.cpp
+++ b/soh/soh/Enhancements/customequipment.cpp
@@ -51,7 +51,10 @@ static Gfx* LoadGfxByName(const char* path) {
 }
 
 static Gfx* LoadCustomGfx(const char* path) {
-    if (!path || !ResourceMgr_FileAltExists(path) || !ResourceGetIsCustomByName(path))
+    if (!path)
+        return nullptr;
+    path = ResolveCustomFPSHand(path);
+    if (!ResourceMgr_FileAltExists(path) || !ResourceGetIsCustomByName(path))
         return nullptr;
     return ResourceMgr_LoadGfxByName(path);
 }

--- a/soh/soh/ResourceManagerHelpers.cpp
+++ b/soh/soh/ResourceManagerHelpers.cpp
@@ -76,8 +76,7 @@ static const char* ResourceMgr_ResolveLinkTunicDListPath(const char* path) {
     const std::string candidate =
         fmt::format("__OTR__objects/{}_{}/{}", objectFolder, tunicSuffix, originalPath + objectPrefix.size());
 
-    if (!ResourceGetIsCustomByName(candidate.c_str()) && !ResourceMgr_FileExists(candidate.c_str()) &&
-        !(ResourceMgr_IsAltAssetsEnabled() && ResourceMgr_FileAltExists(candidate.c_str()))) {
+    if (!ResourceMgr_IsAltAssetsEnabled() || !ResourceMgr_FileAltExists(candidate.c_str()) || !ResourceGetIsCustomByName(candidate.c_str())) {
         return path;
     }
 
@@ -602,33 +601,37 @@ extern "C" AnimationHeaderCommon* ResourceMgr_LoadAnimByName(const char* path) {
     bool isAlt = ResourceMgr_IsAltAssetsEnabled();
 
     if (isAlt) {
-        std::string pathStr = std::string(path);
-        static const std::string sOtr = "__OTR__";
+        if (ResourceMgr_FileAltExists(path)) {
+            std::string pathStr = std::string(path);
+            static const std::string sOtr = "__OTR__";
 
-        if (pathStr.starts_with(sOtr)) {
-            pathStr = pathStr.substr(sOtr.length());
-        }
-
-        // Try alt/ first
-        pathStr = Ship::IResource::gAltAssetPrefix + pathStr;
-        AnimationHeaderCommon* animHeader = (AnimationHeaderCommon*)ResourceGetDataByName(pathStr.c_str());
-
-        // If alt loaded successfully, verify it has valid data
-        if (animHeader != NULL) {
-            // Check for valid frame count (> 0)
-            if (animHeader->frameCount > 0) {
-                // For Normal animations: check frameData (comes after frameCount in AnimationHeader)
-                // For Link animations: check segment (comes after frameCount in LinkAnimationHeader)
-                // We check both to be safe - if either is valid, the animation is usable
-                AnimationHeader* normalAnim = (AnimationHeader*)animHeader;
-                LinkAnimationHeader* linkAnim = (LinkAnimationHeader*)animHeader;
-
-                // Valid if Normal animation has frameData OR Link animation has segment
-                if (normalAnim->frameData != NULL || linkAnim->segment != NULL) {
-                    return animHeader;
-                }
+            if (pathStr.starts_with(sOtr)) {
+                pathStr = pathStr.substr(sOtr.length());
             }
-            // Alt loaded but is invalid (broken), fall through to original path
+
+            // Try alt/ first
+            pathStr = Ship::IResource::gAltAssetPrefix + pathStr;
+
+
+            AnimationHeaderCommon* animHeader = (AnimationHeaderCommon*)ResourceGetDataByName(pathStr.c_str());
+
+            // If alt loaded successfully, verify it has valid data
+            if (animHeader != NULL) {
+                // Check for valid frame count (> 0)
+                if (animHeader->frameCount > 0) {
+                    // For Normal animations: check frameData (comes after frameCount in AnimationHeader)
+                    // For Link animations: check segment (comes after frameCount in LinkAnimationHeader)
+                    // We check both to be safe - if either is valid, the animation is usable
+                    AnimationHeader* normalAnim = (AnimationHeader*)animHeader;
+                    LinkAnimationHeader* linkAnim = (LinkAnimationHeader*)animHeader;
+
+                    // Valid if Normal animation has frameData OR Link animation has segment
+                    if (normalAnim->frameData != NULL || linkAnim->segment != NULL) {
+                        return animHeader;
+                    }
+                }
+                // Alt loaded but is invalid (broken), fall through to original path
+            }
         }
 
         // Fall back to original path

--- a/soh/soh/ResourceManagerHelpers.cpp
+++ b/soh/soh/ResourceManagerHelpers.cpp
@@ -76,7 +76,8 @@ static const char* ResourceMgr_ResolveLinkTunicDListPath(const char* path) {
     const std::string candidate =
         fmt::format("__OTR__objects/{}_{}/{}", objectFolder, tunicSuffix, originalPath + objectPrefix.size());
 
-    if (!ResourceMgr_IsAltAssetsEnabled() || !ResourceMgr_FileAltExists(candidate.c_str()) || !ResourceGetIsCustomByName(candidate.c_str())) {
+    if (!ResourceMgr_IsAltAssetsEnabled() || !ResourceMgr_FileAltExists(candidate.c_str()) ||
+        !ResourceGetIsCustomByName(candidate.c_str())) {
         return path;
     }
 
@@ -611,7 +612,6 @@ extern "C" AnimationHeaderCommon* ResourceMgr_LoadAnimByName(const char* path) {
 
             // Try alt/ first
             pathStr = Ship::IResource::gAltAssetPrefix + pathStr;
-
 
             AnimationHeaderCommon* animHeader = (AnimationHeaderCommon*)ResourceGetDataByName(pathStr.c_str());
 

--- a/soh/soh/resource/type/Skeleton.cpp
+++ b/soh/soh/resource/type/Skeleton.cpp
@@ -161,17 +161,17 @@ void SkeletonPatcher::UpdateTunicSkeletons(SkeletonPatchInfo& skel) {
         // Check what Link's current tunic is
         switch (tunicID) {
             case PLAYER_TUNIC_KOKIRI:
-                if (skel.lastSkeletonId == 4)
+                if (skel.lastSkeletonId == (ageID << 4 | PLAYER_TUNIC_KOKIRI))
                     return;
                 skeletonPath = std::string(gLinkAdultKokiriTunicSkel).substr(sOtr.length());
                 break;
             case PLAYER_TUNIC_GORON:
-                if (skel.lastSkeletonId == 5)
+                if (skel.lastSkeletonId == (ageID << 4 | PLAYER_TUNIC_GORON))
                     return;
                 skeletonPath = std::string(gLinkAdultGoronTunicSkel).substr(sOtr.length());
                 break;
             case PLAYER_TUNIC_ZORA:
-                if (skel.lastSkeletonId == 6)
+                if (skel.lastSkeletonId == (ageID << 4 | PLAYER_TUNIC_ZORA))
                     return;
                 skeletonPath = std::string(gLinkAdultZoraTunicSkel).substr(sOtr.length());
                 break;
@@ -182,12 +182,18 @@ void SkeletonPatcher::UpdateTunicSkeletons(SkeletonPatchInfo& skel) {
         // Check what Link's current tunic is
         switch (tunicID) {
             case PLAYER_TUNIC_KOKIRI:
+                if (skel.lastSkeletonId == (ageID << 4 | PLAYER_TUNIC_KOKIRI))
+                    return;
                 skeletonPath = std::string(gLinkChildKokiriTunicSkel).substr(sOtr.length());
                 break;
             case PLAYER_TUNIC_GORON:
+                if (skel.lastSkeletonId == (ageID << 4 | PLAYER_TUNIC_GORON))
+                    return;
                 skeletonPath = std::string(gLinkChildGoronTunicSkel).substr(sOtr.length());
                 break;
             case PLAYER_TUNIC_ZORA:
+                if (skel.lastSkeletonId == (ageID << 4 | PLAYER_TUNIC_ZORA))
+                    return;
                 skeletonPath = std::string(gLinkChildZoraTunicSkel).substr(sOtr.length());
                 break;
             default:

--- a/soh/soh/resource/type/Skeleton.cpp
+++ b/soh/soh/resource/type/Skeleton.cpp
@@ -135,28 +135,48 @@ void SkeletonPatcher::UpdateCustomSkeletons() {
 
 void SkeletonPatcher::UpdateTunicSkeletons(SkeletonPatchInfo& skel) {
     std::string skeletonPath = "";
+    s32 tunicID = TUNIC_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_TUNIC));
+    s32 ageID = 0;
 
     // Check if this is one of Link's skeletons
     if (sOtr + skel.vanillaSkeletonPath == std::string(gLinkAdultSkel)) {
+        // Adult skeleton
+        ageID = 2;
+    } else if (sOtr + skel.vanillaSkeletonPath == std::string(gLinkChildSkel)) {
+        // Child skeleton
+        ageID = 1;
+    } else {
+        // Incompatible?
+        return;
+    }
+
+    // Check if we even need updating
+    s32 skelID = ageID << 4 | tunicID;
+    if (skelID == skel.lastSkeletonId) return;
+    skel.lastSkeletonId = skelID;
+
+    // Check if this is one of Link's skeletons
+    if (ageID == 2) {
         // Check what Link's current tunic is
-        switch (TUNIC_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_TUNIC))) {
+        switch (tunicID) {
             case PLAYER_TUNIC_KOKIRI:
+                if (skel.lastSkeletonId == 4) return;
                 skeletonPath = std::string(gLinkAdultKokiriTunicSkel).substr(sOtr.length());
                 break;
             case PLAYER_TUNIC_GORON:
+                if (skel.lastSkeletonId == 5) return;
                 skeletonPath = std::string(gLinkAdultGoronTunicSkel).substr(sOtr.length());
                 break;
             case PLAYER_TUNIC_ZORA:
+                if (skel.lastSkeletonId == 6) return;
                 skeletonPath = std::string(gLinkAdultZoraTunicSkel).substr(sOtr.length());
                 break;
             default:
                 return;
         }
-
-        UpdateCustomSkeletonFromPath(skeletonPath, skel);
-    } else if (sOtr + skel.vanillaSkeletonPath == std::string(gLinkChildSkel)) {
+    } else if (skelID == 1) {
         // Check what Link's current tunic is
-        switch (TUNIC_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_TUNIC))) {
+        switch (tunicID) {
             case PLAYER_TUNIC_KOKIRI:
                 skeletonPath = std::string(gLinkChildKokiriTunicSkel).substr(sOtr.length());
                 break;
@@ -169,9 +189,9 @@ void SkeletonPatcher::UpdateTunicSkeletons(SkeletonPatchInfo& skel) {
             default:
                 return;
         }
-
-        UpdateCustomSkeletonFromPath(skeletonPath, skel);
     }
+
+    UpdateCustomSkeletonFromPath(skeletonPath, skel);
 }
 
 void SkeletonPatcher::UpdateCustomSkeletonFromPath(const std::string& skeletonPath, SkeletonPatchInfo& skel) {

--- a/soh/soh/resource/type/Skeleton.cpp
+++ b/soh/soh/resource/type/Skeleton.cpp
@@ -152,7 +152,8 @@ void SkeletonPatcher::UpdateTunicSkeletons(SkeletonPatchInfo& skel) {
 
     // Check if we even need updating
     s32 skelID = ageID << 4 | tunicID;
-    if (skelID == skel.lastSkeletonId) return;
+    if (skelID == skel.lastSkeletonId)
+        return;
     skel.lastSkeletonId = skelID;
 
     // Check if this is one of Link's skeletons
@@ -160,15 +161,18 @@ void SkeletonPatcher::UpdateTunicSkeletons(SkeletonPatchInfo& skel) {
         // Check what Link's current tunic is
         switch (tunicID) {
             case PLAYER_TUNIC_KOKIRI:
-                if (skel.lastSkeletonId == 4) return;
+                if (skel.lastSkeletonId == 4)
+                    return;
                 skeletonPath = std::string(gLinkAdultKokiriTunicSkel).substr(sOtr.length());
                 break;
             case PLAYER_TUNIC_GORON:
-                if (skel.lastSkeletonId == 5) return;
+                if (skel.lastSkeletonId == 5)
+                    return;
                 skeletonPath = std::string(gLinkAdultGoronTunicSkel).substr(sOtr.length());
                 break;
             case PLAYER_TUNIC_ZORA:
-                if (skel.lastSkeletonId == 6) return;
+                if (skel.lastSkeletonId == 6)
+                    return;
                 skeletonPath = std::string(gLinkAdultZoraTunicSkel).substr(sOtr.length());
                 break;
             default:

--- a/soh/soh/resource/type/Skeleton.h
+++ b/soh/soh/resource/type/Skeleton.h
@@ -78,6 +78,8 @@ class Skeleton : public Ship::Resource<SkeletonData> {
 struct SkeletonPatchInfo {
     SkelAnime* skelAnime;
     std::string vanillaSkeletonPath;
+
+    u8 lastSkeletonId;
     bool isLocalPlayer;
 };
 


### PR DESCRIPTION
So this fixes some logical errors with loading the resources so its checking they exist before trying to test-load them... It also added a cache for the alt skeleton by tunic type so we arent constantly trying to reassign the tunic (This change in particular may prevent instant model swapping depending how the model swap with custom content is handled if loaded in a menu like NEI does)... Current system was just spamming that check over and over and trying to reload skeletons constantly so I opted for detecting if the tunic actually changes THEN allow a recheck here, otherwise exit out early. The  skeleton.cpp and skeleton.h files can be reverted if suspected that will interfere with intended custom model usage.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8089518916.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8089463762.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8089456076.zip)
<!--- section:artifacts:end -->