### PR TITLE
Actor viewer, add hex id and params

### DIFF
--- a/soh/soh/Enhancements/debugger/actorViewer.cpp
+++ b/soh/soh/Enhancements/debugger/actorViewer.cpp
@@ -40,7 +40,7 @@ typedef struct {
 
 std::array<const char*, 12> acMapping = {
     "Switch",      "Background (Prop type 1)",
-    "Player",      "Bomb",
+    "Player",      "Bomb/Bombchu",
     "NPC",         "Enemy",
     "Prop type 2", "Item/Action",
     "Misc.",       "Boss",
@@ -958,9 +958,9 @@ void ActorViewerWindow::DrawElement() {
                     [&]() {
                         ImGui::Text("Name: %s", ActorDB::Instance->RetrieveEntry(display->id).name.c_str());
                         ImGui::Text("Description: %s", GetActorDescription(display->id).c_str());
-                        ImGui::Text("Category: %s", acMapping[display->category]);
-                        ImGui::Text("ID: %d", display->id);
-                        ImGui::Text("Parameters: %d", display->params);
+                        ImGui::Text("Category: %s (%d)", acMapping[display->category], display->category);
+                        ImGui::Text("ID: %d (0x%x)", display->id, display->id);
+                        ImGui::Text("Parameters: %d (0x%x)", display->params, display->params);
                         ImGui::Text("Actor List Index: %d", GetActorListIndex(display));
                     },
                     "Selected Actor");


### PR DESCRIPTION
Added hex to actor id and params in the actor viewer so user doesn't need to convert.
Also added category number as it can be easier remembering from description -> number -> enum name. Maybe it would be better placed in the drop down menu?
The explosives category also includes bombchus, added that too.

<img width="271" height="267" alt="actorviewer hex" src="https://github.com/user-attachments/assets/7c8bac36-e510-4187-a4b5-dd34f5b25346" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8080997229.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8080948333.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8080939352.zip)
<!--- section:artifacts:end -->