### PR TITLE
Enemy rando, prevent Dark Link and Arwing from spawning in cleared rooms

### DIFF
--- a/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
+++ b/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
@@ -742,6 +742,14 @@ void RegisterEnemyRandomizer() {
     // If Random Gerudo Fighters are defeated, drop some items
     COND_ID_HOOK(OnEnemyDefeat, ACTOR_EN_GELDB, ENEMY_RANDOMIZER_ENABLED, OnGerudoFighterDefeat);
 
+    // Don't spawn Dark Link or Arwings in cleared rooms
+    COND_VB_SHOULD(VB_SPAWN_IN_CLEAR_ROOM, ENEMY_RANDOMIZER_ENABLED, {
+        const s16 actorId = va_arg(args, s16);
+        if (actorId == ACTOR_EN_TORCH2 || actorId == ACTOR_EN_CLEAR_TAG) {
+            *should = true;
+        }
+    });
+
     COND_VB_SHOULD(VB_SPAWN_ACTOR_ENTRY, ENEMY_RANDOMIZER_ENABLED, {
         ActorContext* actorCtx = va_arg(args, ActorContext*);
         ActorEntry* actorEntry = va_arg(args, ActorEntry*);

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -568,6 +568,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // true if actorId is Dark Link or Arwing
+    // ```
+    // #### `args`
+    // - `s16` (actorId)
+    VB_SPAWN_IN_CLEAR_ROOM,
+
+    // #### `result`
+    // ```c
     // !Flags_GetSwitch(play, this->actor.params & 0x3F)
     // ```
     // #### `args`

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -3346,8 +3346,9 @@ Actor* Actor_Spawn(ActorContext* actorCtx, PlayState* play, s16 actorId, f32 pos
         objBankIndex = 0;
     }
 
-    if ((objBankIndex < 0) || (Flags_GetClear(play, play->roomCtx.curRoom.num) &&
-        GameInteractor_Should(VB_SPAWN_IN_CLEAR_ROOM, (dbEntry->category == ACTORCAT_ENEMY), actorId))) {
+    if ((objBankIndex < 0) ||
+        (Flags_GetClear(play, play->roomCtx.curRoom.num) &&
+         GameInteractor_Should(VB_SPAWN_IN_CLEAR_ROOM, (dbEntry->category == ACTORCAT_ENEMY), actorId))) {
         // "No data bank!! <data bank＝%d> (profilep->bank=%d)"
         osSyncPrintf(VT_COL(RED, WHITE) "データバンク無し！！<データバンク＝%d>(profilep->bank=%d)\n" VT_RST,
                      objBankIndex, dbEntry->objectId);

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -3346,8 +3346,8 @@ Actor* Actor_Spawn(ActorContext* actorCtx, PlayState* play, s16 actorId, f32 pos
         objBankIndex = 0;
     }
 
-    if ((objBankIndex < 0) ||
-        ((dbEntry->category == ACTORCAT_ENEMY) && Flags_GetClear(play, play->roomCtx.curRoom.num))) {
+    if ((objBankIndex < 0) || (Flags_GetClear(play, play->roomCtx.curRoom.num) &&
+        GameInteractor_Should(VB_SPAWN_IN_CLEAR_ROOM, (dbEntry->category == ACTORCAT_ENEMY), actorId))) {
         // "No data bank!! <data bank＝%d> (profilep->bank=%d)"
         osSyncPrintf(VT_COL(RED, WHITE) "データバンク無し！！<データバンク＝%d>(profilep->bank=%d)\n" VT_RST,
                      objBankIndex, dbEntry->objectId);


### PR DESCRIPTION
`Actor_Spawn` checks actor category in the actor profile (`dbEntry`). If room is flagged as cleared, `ACTORCAT_ENEMY` will not spawn. However, enemy randomizer can spawn Dark Link and Arwings, which are `ACTORCAT_BOSS` in the actor profile but change to enemy on init in enemy randomizer. This causes them to spawn regardless of clear flag.

Fix: Check for these two actors too when checking whether to spawn.

Tested in GTG first two timer rooms and also checked that Dark Link spawns normally in Water Temple + bosses.
I asked in Discord if there are any other problematic enemies and didn't get any reply on other enemies.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8153947503.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8153888923.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8153854573.zip)
<!--- section:artifacts:end -->