### PR TITLE
Fixed Barinade Save State

### DIFF
--- a/soh/soh/Enhancements/savestates.cpp
+++ b/soh/soh/Enhancements/savestates.cpp
@@ -16,6 +16,7 @@
 #include "../../src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.h"
 #include "../../src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.h"
 #include "../../src/overlays/actors/ovl_Boss_Tw/z_boss_tw.h"
+#include "../../src/overlays/actors/ovl_Boss_Va/z_boss_va.h"
 #include "../../src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.h"
 #include "../../src/overlays/actors/ovl_En_Fr/z_en_fr.h"
 
@@ -199,6 +200,20 @@ typedef struct SaveStateInfo {
     // z_boss_tw
     uint8_t sTwInitalized_copy;
     BossTwEffect sTwEffects_copy[150];
+
+    // z_boss_va
+    u8 sKillBari_copy;
+    s16 sCsCamera_copy;
+    BossVaEffect sVaEffects_copy[400];
+    u8 sBodyState_copy;
+    u8 sFightPhase_copy;
+    s8 sCsState_copy;
+    s16 sDoorState_copy;
+    u8 sPhase3StopMoving_copy;
+    Vec3s sZapperRot_copy;
+    u16 sPhase2Timer_copy;
+    s8 sPhase4HP_copy;
+    u8 sBodyBari_copy[10];
 
     // z_demo_6k
     Vec3f sDemo6kVelocity_copy;
@@ -586,6 +601,18 @@ void SaveState::SaveOverlayStaticData(void) {
     memcpy(info->sBossGanon2Particles_copy, sBossGanon2Particles, sizeof(sBossGanon2Particles));
     info->sTwInitalized_copy = sTwInitalized;
     memcpy(info->sTwEffects_copy, sTwEffects, sizeof(sTwEffects));
+    info->sKillBari_copy = sKillBari;
+    info->sCsCamera_copy = sCsCamera;
+    memcpy(info->sVaEffects_copy, sVaEffects, sizeof(sVaEffects));
+    info->sBodyState_copy = sBodyState;
+    info->sFightPhase_copy = sFightPhase;
+    info->sCsState_copy = sCsState;
+    info->sDoorState_copy = sDoorState;
+    info->sPhase3StopMoving_copy = sPhase3StopMoving;
+    info->sZapperRot_copy = sZapperRot;
+    info->sPhase2Timer_copy = sPhase2Timer;
+    info->sPhase4HP_copy = sPhase4HP;
+    memcpy(info->sBodyBari_copy, sBodyBari, sizeof(info->sBodyBari_copy));
     info->sDemo6kVelocity_copy = sDemo6kVelocity;
     info->D_8096CE94_copy = D_8096CE94;
     info->demoKekkaiVel_copy = demoKekkaiVel;
@@ -660,6 +687,18 @@ void SaveState::LoadOverlayStaticData(void) {
     memcpy(sBossGanon2Particles, info->sBossGanon2Particles_copy, sizeof(sBossGanon2Particles));
     sTwInitalized = info->sTwInitalized_copy;
     memcpy(sTwEffects, info->sTwEffects_copy, sizeof(sTwEffects));
+    sKillBari = info->sKillBari_copy;
+    sCsCamera = info->sCsCamera_copy;
+    memcpy(sVaEffects, info->sVaEffects_copy, sizeof(sVaEffects));
+    sBodyState = info->sBodyState_copy;
+    sFightPhase = info->sFightPhase_copy;
+    sCsState = info->sCsState_copy;
+    sDoorState = info->sDoorState_copy;
+    sPhase3StopMoving = info->sPhase3StopMoving_copy;
+    sZapperRot = info->sZapperRot_copy;
+    sPhase2Timer = info->sPhase2Timer_copy;
+    sPhase4HP = info->sPhase4HP_copy;
+    memcpy(sBodyBari, info->sBodyBari_copy, sizeof(info->sBodyBari_copy));
     sDemo6kVelocity = info->sDemo6kVelocity_copy;
 
     D_8096CE94 = info->D_8096CE94_copy;

--- a/soh/soh/Enhancements/savestates.cpp
+++ b/soh/soh/Enhancements/savestates.cpp
@@ -717,8 +717,7 @@ void SaveState::LoadOverlayStaticData(void) {
     sUpperRiverSpawned = info->sUpperRiverSpawned_copy;
     sEnPoFieldNumSpawned = info->sEnPoFieldNumSpawned_copy;
     memcpy(sEnPoFieldSpawnPositions, info->sEnPoFieldSpawnPositions_copy, sizeof(sEnPoFieldSpawnPositions));
-    memcpy(sEnPoFieldSpawnSwitchFlags, info->sEnPoFieldSpawnSwitchFlags_copy,
-           sizeof(sEnPoFieldSpawnSwitchFlags));
+    memcpy(sEnPoFieldSpawnSwitchFlags, info->sEnPoFieldSpawnSwitchFlags_copy, sizeof(sEnPoFieldSpawnSwitchFlags));
 
     sTakaraIsInitialized = info->sTakaraIsInitialized_copy;
     D_80B41D90 = info->D_80B41D90_copy;

--- a/soh/soh/Enhancements/savestates.cpp
+++ b/soh/soh/Enhancements/savestates.cpp
@@ -618,7 +618,7 @@ void SaveState::SaveOverlayStaticData(void) {
     info->demoKekkaiVel_copy = demoKekkaiVel;
     info->sSlugGroup_copy = sSlugGroup;
     info->sClearTagIsEffectInitialized_copy = sClearTagIsEffectsInitialized;
-    memcpy(info->sClearTagEffects_copy, sClearTagEffects, sizeof(sClearTagEffects));
+    memcpy(info->sClearTagEffects_copy, sClearTagEffects, sizeof(info->sClearTagEffects_copy));
 
     memcpy(&info->sEnFrPointers_copy, &sEnFrPointers, sizeof(info->sEnFrPointers_copy));
     info->sSpawnNum_copy = sSpawnNum;
@@ -673,7 +673,7 @@ void SaveState::LoadOverlayStaticData(void) {
     sBossGanonGanondorf = info->sBossGanonGanondorf_copy;
     sBossGanonZelda = info->sBossGanonZelda_copy;
     sBossGanonCape = info->sBossGanonCape_copy;
-    memcpy(sBossGanonEffectBuf, info->sBossGanonEffectBuf_copy, sizeof(info->sBossGanonEffectBuf_copy));
+    memcpy(sBossGanonEffectBuf, info->sBossGanonEffectBuf_copy, sizeof(sBossGanonEffectBuf));
 
     D_8090EB20 = info->D_8090EB20_copy;
     D_80910638 = info->D_80910638_copy;
@@ -698,7 +698,7 @@ void SaveState::LoadOverlayStaticData(void) {
     sZapperRot = info->sZapperRot_copy;
     sPhase2Timer = info->sPhase2Timer_copy;
     sPhase4HP = info->sPhase4HP_copy;
-    memcpy(sBodyBari, info->sBodyBari_copy, sizeof(info->sBodyBari_copy));
+    memcpy(sBodyBari, info->sBodyBari_copy, sizeof(sBodyBari));
     sDemo6kVelocity = info->sDemo6kVelocity_copy;
 
     D_8096CE94 = info->D_8096CE94_copy;
@@ -716,9 +716,9 @@ void SaveState::LoadOverlayStaticData(void) {
     sLowerRiverSpawned = info->sLowerRiverSpawned_copy;
     sUpperRiverSpawned = info->sUpperRiverSpawned_copy;
     sEnPoFieldNumSpawned = info->sEnPoFieldNumSpawned_copy;
-    memcpy(sEnPoFieldSpawnPositions, info->sEnPoFieldSpawnPositions_copy, sizeof(info->sEnPoFieldSpawnPositions_copy));
+    memcpy(sEnPoFieldSpawnPositions, info->sEnPoFieldSpawnPositions_copy, sizeof(sEnPoFieldSpawnPositions));
     memcpy(sEnPoFieldSpawnSwitchFlags, info->sEnPoFieldSpawnSwitchFlags_copy,
-           sizeof(info->sEnPoFieldSpawnSwitchFlags_copy));
+           sizeof(sEnPoFieldSpawnSwitchFlags));
 
     sTakaraIsInitialized = info->sTakaraIsInitialized_copy;
     D_80B41D90 = info->D_80B41D90_copy;

--- a/soh/soh/Enhancements/savestates_extern.inc
+++ b/soh/soh/Enhancements/savestates_extern.inc
@@ -130,6 +130,20 @@ extern "C" BossGanon2Effect sBossGanon2Particles[100];
 extern "C" uint8_t sTwInitalized;
 extern "C" BossTwEffect sTwEffects[150];
 
+// z_boss_va
+extern "C" u8 sKillBari;
+extern "C" s16 sCsCamera;
+extern "C" BossVaEffect sVaEffects[400];
+extern "C" u8 sBodyState;
+extern "C" u8 sFightPhase;
+extern "C" s8 sCsState;
+extern "C" s16 sDoorState;
+extern "C" u8 sPhase3StopMoving;
+extern "C" Vec3s sZapperRot;
+extern "C" u16 sPhase2Timer;
+extern "C" s8 sPhase4HP;
+extern "C" u8 sBodyBari[10];
+
 // z_demo_6k
 extern "C" Vec3f sDemo6kVelocity;
 

--- a/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -35,23 +35,6 @@
 #define PHASE_4 15
 #define PHASE_DEATH 18
 
-typedef struct BossVaEffect {
-    /* 0x00 */ Vec3f pos;
-    /* 0x0C */ Vec3f velocity;
-    /* 0x18 */ Vec3f accel;
-    /* 0x24 */ u8 type;
-    /* 0x26 */ u16 timer;
-    /* 0x28 */ s16 mode;
-    /* 0x2A */ Vec3s rot;
-    /* 0x30 */ s16 primColor[4];
-    /* 0x38 */ s16 envColor[4];
-    /* 0x40 */ f32 scale;
-    /* 0x44 */ f32 scaleMod;
-    /* 0x48 */ Vec3f offset;
-    /* 0x54 */ struct BossVa* parent;
-    u32 epoch;
-} BossVaEffect; // size = 0x58
-
 typedef enum {
     /* 0 */ VA_NONE,
     /* 1 */ VA_LARGE_SPARK,
@@ -385,25 +368,25 @@ static DamageTable sDamageTable[] = {
 };
 
 static Vec3f sZeroVec = { 0.0f, 0.0f, 0.0f };
-static u8 sKillBari = 0;
-static u8 sBodyBari[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-static s16 sCsCamera = 0;
+u8 sKillBari = 0;
+u8 sBodyBari[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+s16 sCsCamera = 0;
 
-static BossVaEffect sVaEffects[400];
-static u8 sBodyState;
-static u8 sFightPhase;
-static s8 sCsState;
+BossVaEffect sVaEffects[400];
+u8 sBodyState;
+u8 sFightPhase;
+s8 sCsState;
 static Vec3f sCameraEye;
 static Vec3f sCameraAt;
 static Vec3f sCameraNextEye;
 static Vec3f sCameraNextAt;
 static Vec3f sCameraEyeMaxVel;
 static Vec3f sCameraAtMaxVel;
-static s16 sDoorState;
-static u8 sPhase3StopMoving;
-static Vec3s sZapperRot;
-static u16 sPhase2Timer;
-static s8 sPhase4HP;
+s16 sDoorState;
+u8 sPhase3StopMoving;
+Vec3s sZapperRot;
+u16 sPhase2Timer;
+s8 sPhase4HP;
 
 void BossVa_SetupAction(BossVa* this, BossVaActionFunc func) {
     this->actionFunc = func;

--- a/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.h
+++ b/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.h
@@ -8,6 +8,23 @@ struct BossVa;
 
 typedef void (*BossVaActionFunc)(struct BossVa*, PlayState*);
 
+typedef struct BossVaEffect {
+    /* 0x00 */ Vec3f pos;
+    /* 0x0C */ Vec3f velocity;
+    /* 0x18 */ Vec3f accel;
+    /* 0x24 */ u8 type;
+    /* 0x26 */ u16 timer;
+    /* 0x28 */ s16 mode;
+    /* 0x2A */ Vec3s rot;
+    /* 0x30 */ s16 primColor[4];
+    /* 0x38 */ s16 envColor[4];
+    /* 0x40 */ f32 scale;
+    /* 0x44 */ f32 scaleMod;
+    /* 0x48 */ Vec3f offset;
+    /* 0x54 */ struct BossVa* parent;
+    u32 epoch;
+} BossVaEffect; // size = 0x58
+
 typedef struct BossVa {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;


### PR DESCRIPTION
No longer seems to be crashing and correctly states the entire room. Barinade was made of clones of himself (even the door).

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8165196770.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8165043050.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8165022854.zip)
<!--- section:artifacts:end -->