### PR TITLE
Bugfix, make entrance tracker track decoupled blue warps

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_entrance_tracker.cpp
@@ -941,8 +941,10 @@ void EntranceTrackerWindow::DrawElement() {
                     continue;
                 }
 
-                // RANDOTODO: Only show blue warps if bluewarp shuffle is on
-                if (original->metaTag.ends_with("bw") || override->metaTag.ends_with("bw")) {
+                // Only show blue warps if bluewarp shuffle is on
+                if ((original->metaTag.ends_with("bw") || override->metaTag.ends_with("bw")) &&
+                    OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_DECOUPLED_ENTRANCES) ==
+                        RO_GENERIC_OFF) {
                     continue;
                 }
 


### PR DESCRIPTION
Fixes #6711.
Blue warps were previously always ignored by the tracker, now only ignored if decoupled entrances are off.
Tested on Gohma and KD blue warps with boss randomizer.
Entrance rando players, please check it out and see if decoupled entrances is ok criterion.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8172259199.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8172000069.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8171986231.zip)
<!--- section:artifacts:end -->