### PR TITLE
[Bugfix] - First quiver starting item causes crash

### DIFF
--- a/soh/soh/Enhancements/randomizer/savefile.cpp
+++ b/soh/soh/Enhancements/randomizer/savefile.cpp
@@ -231,7 +231,7 @@ void SetStartingItems() {
 
     uint8_t startBow = Randomizer_GetSettingValue(RSK_STARTING_BOW);
     if (startBow >= 1)
-        Item_Give(NULL, ITEM_QUIVER_30);
+        Item_Give(NULL, ITEM_BOW);
     if (startBow >= 2)
         Item_Give(NULL, ITEM_QUIVER_40);
     if (startBow >= 3)


### PR DESCRIPTION
Just ran into this when trying to verify a bug report
Selecting the lowest capacity quiver as a starting item would result in a crash

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8185586402.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8185461243.zip)
<!--- section:artifacts:end -->