### PR TITLE
Optional 3rd-Person Mouse Camera Controls

### DIFF
--- a/soh/soh/Enhancements/controls/Mouse.cpp
+++ b/soh/soh/Enhancements/controls/Mouse.cpp
@@ -34,7 +34,7 @@ void Mouse_UpdateAll() {
 }
 
 void Mouse_HandleThirdPerson(f32* newCamX, f32* newCamY) {
-    if (MOUSE_ENABLED) {
+    if (MOUSE_ENABLED && !CVarGetInteger(CVAR_SETTING("DisableThirdPersonMouse"), 0)) {
         *newCamX -= mouseCoordRel.x * 40.0f;
         *newCamY -= mouseCoordRel.y * 40.0f;
     }

--- a/soh/soh/Enhancements/controls/Mouse.cpp
+++ b/soh/soh/Enhancements/controls/Mouse.cpp
@@ -84,7 +84,7 @@ static s32 mouseQuickspinY[5] = {};
 static u8 quickspinCount = 0;
 
 void Mouse_UpdateQuickspinCount() {
-    if (MOUSE_ENABLED) {
+    if (MOUSE_ENABLED && !CVarGetInteger(CVAR_SETTING("DisableThirdPersonMouse"), 0)) {
         quickspinCount = (quickspinCount + 1) % 5;
         mouseQuickspinX[quickspinCount] = mouseCoord.x;
         mouseQuickspinY[quickspinCount] = mouseCoord.y;
@@ -97,7 +97,7 @@ bool Mouse_HandleQuickspin(bool* should, s8* iter2, s8* sp3C) {
     s8 temp1;
     s8 temp2;
     s32 i;
-    if (!MOUSE_ENABLED) {
+    if (!MOUSE_ENABLED || CVarGetInteger(CVAR_SETTING("DisableThirdPersonMouse"), 0)) {
         return *should = false;
     }
 

--- a/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
+++ b/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
@@ -19,6 +19,7 @@ using namespace UIWidgets;
 static WidgetInfo freeLook;
 static WidgetInfo mouseControl;
 static WidgetInfo mouseAutoCapture;
+static WidgetInfo mouseDisableThirdPerson;
 static WidgetInfo rightStickOcarina;
 static WidgetInfo dpadOcarina;
 static WidgetInfo dpadPause;
@@ -1377,6 +1378,10 @@ void SohInputEditorWindow::DrawCameraControlPanel() {
     ImGui::SetCursorPos(ImVec2(cursor.x + 5, cursor.y + 5));
     SohGui::mSohMenu->MenuDrawItem(mouseAutoCapture, static_cast<uint32_t>(ImGui::GetContentRegionAvail().x),
                                    THEME_COLOR);
+    cursor = ImGui::GetCursorPos();
+    ImGui::SetCursorPos(ImVec2(cursor.x + 5, cursor.y + 5));
+    SohGui::mSohMenu->MenuDrawItem(mouseDisableThirdPerson, static_cast<uint32_t>(ImGui::GetContentRegionAvail().x),
+                                   THEME_COLOR);
 
     Ship::GuiWindow::BeginGroupPanel("Aiming/First-Person Camera", ImGui::GetContentRegionAvail());
     CVarCheckbox("Right Stick Aiming", CVAR_SETTING("Controls.RightStickAim"),
@@ -1908,6 +1913,18 @@ void RegisterInputEditorWidgets() {
                               "hide the cursor "
                               "and capture mouse input when closing the menu."));
     SohGui::mSohMenu->AddSearchWidget({ mouseAutoCapture, "Settings", "Controls", "Camera Controls" });
+
+    mouseDisableThirdPerson = { .name = "Disable Third-Person Camera Control",
+                                .type = WidgetType::WIDGET_CVAR_CHECKBOX };
+    mouseDisableThirdPerson.CVar(CVAR_SETTING("DisableThirdPersonMouse"))
+        .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_SETTING("EnableMouse"), 0); })
+        .Options(CheckboxOptions()
+                     .Color(THEME_COLOR)
+                     .Tooltip("Stops the mouse from moving the third-person camera, while still allowing mouse "
+                              "control for first-person aiming, the shield, and quickspins.\n"
+                              "Primarily useful when mapping a controller's gyro to mouse controls, so gyro "
+                              "movement doesn't constantly drag the third-person camera around."));
+    SohGui::mSohMenu->AddSearchWidget({ mouseDisableThirdPerson, "Settings", "Controls", "Camera Controls" });
 
     rightStickOcarina = { .name = "Right Stick Ocarina Playback", .type = WidgetType::WIDGET_CVAR_CHECKBOX };
     rightStickOcarina.CVar(CVAR_SETTING("CustomOcarina.RightStick")).Options(CheckboxOptions().Color(THEME_COLOR));

--- a/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
+++ b/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
@@ -1914,16 +1914,18 @@ void RegisterInputEditorWidgets() {
                               "and capture mouse input when closing the menu."));
     SohGui::mSohMenu->AddSearchWidget({ mouseAutoCapture, "Settings", "Controls", "Camera Controls" });
 
-    mouseDisableThirdPerson = { .name = "Disable Third-Person Camera Control",
+    mouseDisableThirdPerson = { .name = "Disable Third-Person Mouse Controls",
                                 .type = WidgetType::WIDGET_CVAR_CHECKBOX };
     mouseDisableThirdPerson.CVar(CVAR_SETTING("DisableThirdPersonMouse"))
-        .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger(CVAR_SETTING("EnableMouse"), 0); })
+        .PreFunc([](WidgetInfo& info) {
+            // ResetDisables() clears disabledTooltip each frame before this runs, so set it here alongside disabled.
+            info.options->disabled = !CVarGetInteger(CVAR_SETTING("EnableMouse"), 0);
+            info.options->disabledTooltip = "Forced off because Mouse Controls are disabled.";
+        })
         .Options(CheckboxOptions()
                      .Color(THEME_COLOR)
-                     .Tooltip("Stops the mouse from moving the third-person camera, while still allowing mouse "
-                              "control for first-person aiming, the shield, and quickspins.\n"
-                              "Primarily useful when mapping a controller's gyro to mouse controls, so gyro "
-                              "movement doesn't constantly drag the third-person camera around."));
+                     .Tooltip("Stops the mouse from moving the third-person camera and from triggering quickspins, "
+                              "while still allowing mouse control for first-person aiming and the shield."));
     SohGui::mSohMenu->AddSearchWidget({ mouseDisableThirdPerson, "Settings", "Controls", "Camera Controls" });
 
     rightStickOcarina = { .name = "Right Stick Ocarina Playback", .type = WidgetType::WIDGET_CVAR_CHECKBOX };

--- a/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
+++ b/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
@@ -1918,7 +1918,6 @@ void RegisterInputEditorWidgets() {
                                 .type = WidgetType::WIDGET_CVAR_CHECKBOX };
     mouseDisableThirdPerson.CVar(CVAR_SETTING("DisableThirdPersonMouse"))
         .PreFunc([](WidgetInfo& info) {
-            // ResetDisables() clears disabledTooltip each frame before this runs, so set it here alongside disabled.
             info.options->disabled = !CVarGetInteger(CVAR_SETTING("EnableMouse"), 0);
             info.options->disabledTooltip = "Forced off because Mouse Controls are disabled.";
         })


### PR DESCRIPTION
For controllers like Steam Controllers, gyro typically gets mapped to mouse controls to replicate the same behavior.
However, doing so also causes the third-person camera to spin around whenever the controller moves if the camera is on.

So, this is just to add an option allowing third-person mouse camera to be disabled while still allowing it to be controlled by a control stick & keep 1st-person mouse controls enabled.

Menu Example:
<img width="942" height="285" alt="image" src="https://github.com/user-attachments/assets/3024165c-c458-4972-895b-7c1b49eed61b" />
<img width="1067" height="442" alt="image" src="https://github.com/user-attachments/assets/47888af7-9b86-4058-b206-8b72c1d16711" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8216709426.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8216628131.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8216619563.zip)
<!--- section:artifacts:end -->