### PR TITLE
Force skipping GF cutscene in rando

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/TimeSavers/timesaver_hook_handlers.cpp
@@ -808,6 +808,9 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                     Flags_SetRandomizerInf(flag);
                     gSaveContext.healthAccumulator = MAX_HEALTH;
                     Magic_Fill(gPlayState);
+                    // Also prevent the cutscene from playing, technically we could let it play in rando but we'd
+                    // need to VB prevent the item gives that happen during the cutscene.
+                    *should = false;
                 } else {
                     // If we're in vanilla, set the flag _if_ we were eligble, so that anchor can send the reward in
                     // co-op


### PR DESCRIPTION
I incorrectly assumed I had made the GF cutscenes compatible with rando, as I did on 2ship, so in https://github.com/HarbourMasters/Shipwright/commit/942134669aae714d0879d3c00995b76712990d15 I left the cutscenes enabled in rando. this wasn't the case and it was awarding both the rando item and the vanilla reward.

force skipping the cutscene fixes this. eventually we could make the cutscene rando compatible but not worth the effort really.