### PR TITLE
remove z64.h from gameinteractor.h

### DIFF
--- a/soh/soh/Enhancements/AlwaysOnFixes.cpp
+++ b/soh/soh/Enhancements/AlwaysOnFixes.cpp
@@ -2,7 +2,6 @@
 #include "soh/ShipInit.hpp"
 
 extern "C" {
-#include "macros.h"
 #include "functions.h"
 #include "variables.h"
 #include "src/overlays/actors/ovl_En_Go2/z_en_go2.h"
@@ -43,7 +42,7 @@ void RegisterAlwaysOnFixes() {
     // overwrites it and crashes. Re-set segment 12 before drawing.
     COND_VB_SHOULD(VB_ITEMSHIELD_DRAW, true, {
         GraphicsContext* __gfxCtx = gPlayState->state.gfxCtx;
-        gSPSegment(POLY_OPA_DISP++, 0x0C, (uintptr_t)SEGMENTED_TO_VIRTUAL(gCullBackDList));
+        gSPSegment(POLY_OPA_DISP++, 0x0C, (uintptr_t)gCullBackDList);
     });
 
     // Hookshot not spawning softlocks player (child use, memory full). Clear item on no

--- a/soh/soh/Enhancements/Cheats/ClimbEverything.cpp
+++ b/soh/soh/Enhancements/Cheats/ClimbEverything.cpp
@@ -1,5 +1,6 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 static void RegisterClimbEverything() {
     COND_VB_SHOULD(VB_SURFACE_IS_CLIMBABLE, CVarGetInteger(CVAR_CHEAT("ClimbEverything"), 0), { *should = true; });

--- a/soh/soh/Enhancements/Cheats/DekuStick.cpp
+++ b/soh/soh/Enhancements/Cheats/DekuStick.cpp
@@ -1,9 +1,11 @@
 #include "soh/Enhancements/enhancementTypes.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 extern "C" {
 extern PlayState* gPlayState;
+#include "z64.h"
 #include "macros.h"
 }
 

--- a/soh/soh/Enhancements/Cheats/DropsDontDie.cpp
+++ b/soh/soh/Enhancements/Cheats/DropsDontDie.cpp
@@ -1,5 +1,7 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
+#include "z64actor.h"
 
 static void RegisterDropsDontDie() {
     COND_VB_SHOULD(VB_ITEM00_TIMER_TICK, CVarGetInteger(CVAR_CHEAT("DropsDontDie"), 0), {

--- a/soh/soh/Enhancements/Cheats/EasyISG.cpp
+++ b/soh/soh/Enhancements/Cheats/EasyISG.cpp
@@ -1,9 +1,11 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 extern "C" {
-extern PlayState* gPlayState;
+#include "z64.h"
 #include "macros.h"
+extern PlayState* gPlayState;
 }
 
 #define CVAR_EASY_ISG_NAME CVAR_CHEAT("EasyISG")

--- a/soh/soh/Enhancements/Cheats/EasyQPA.cpp
+++ b/soh/soh/Enhancements/Cheats/EasyQPA.cpp
@@ -2,8 +2,9 @@
 #include "soh/ShipInit.hpp"
 
 extern "C" {
-extern PlayState* gPlayState;
+#include "z64.h"
 #include "macros.h"
+extern PlayState* gPlayState;
 }
 
 #define CVAR_EASY_QPA_NAME CVAR_CHEAT("EasyQPA")

--- a/soh/soh/Enhancements/Cheats/FireproofDekuShield.cpp
+++ b/soh/soh/Enhancements/Cheats/FireproofDekuShield.cpp
@@ -1,5 +1,6 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 static void RegisterFireproofDekuShield() {
     COND_VB_SHOULD(VB_BURN_SHIELD, CVarGetInteger(CVAR_CHEAT("FireproofDekuShield"), 0), { *should = false; });

--- a/soh/soh/Enhancements/Cheats/HookshotEverything.cpp
+++ b/soh/soh/Enhancements/Cheats/HookshotEverything.cpp
@@ -1,5 +1,6 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 static void RegisterHookshotEverything() {
     COND_VB_SHOULD(VB_SURFACE_IS_HOOKSHOT, CVarGetInteger(CVAR_CHEAT("HookshotEverything"), 0), { *should = true; });

--- a/soh/soh/Enhancements/Cheats/Infinite/EponaBoost.cpp
+++ b/soh/soh/Enhancements/Cheats/Infinite/EponaBoost.cpp
@@ -1,5 +1,6 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 static void RegisterInfiniteEponaBoost() {
     COND_VB_SHOULD(VB_CONSUME_EPONA_BOOST, CVarGetInteger(CVAR_CHEAT("InfiniteEponaBoost"), 0), { *should = false; });

--- a/soh/soh/Enhancements/Cheats/MoonJump.cpp
+++ b/soh/soh/Enhancements/Cheats/MoonJump.cpp
@@ -1,9 +1,11 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 extern "C" {
-extern PlayState* gPlayState;
+#include "z64.h"
 #include "macros.h"
+extern PlayState* gPlayState;
 }
 
 #define CVAR_MOON_JUMP_NAME CVAR_CHEAT("MoonJumpOnL")

--- a/soh/soh/Enhancements/Cheats/NoClip.cpp
+++ b/soh/soh/Enhancements/Cheats/NoClip.cpp
@@ -1,5 +1,10 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
+
+extern "C" {
+#include "z64actor.h"
+}
 
 static void RegisterNoClip() {
     COND_VB_SHOULD(VB_PERFORM_WALL_COLLISION_CHECK, CVarGetInteger(CVAR_CHEAT("NoClip"), 0), {

--- a/soh/soh/Enhancements/Cheats/NoFishDespawn.cpp
+++ b/soh/soh/Enhancements/Cheats/NoFishDespawn.cpp
@@ -1,5 +1,6 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 static void RegisterNoFishDespawn() {
     COND_VB_SHOULD(VB_FISH_TIMER_TICK, CVarGetInteger(CVAR_CHEAT("NoFishDespawn"), 0), { *should = false; });

--- a/soh/soh/Enhancements/Cheats/NoKeeseGuayTarget.cpp
+++ b/soh/soh/Enhancements/Cheats/NoKeeseGuayTarget.cpp
@@ -1,5 +1,6 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 static constexpr int32_t CVAR_NOKEESEGUAYTARGET_DEFAULT = 0;
 #define CVAR_NOKEESEGUAYTARGET_NAME CVAR_CHEAT("NoKeeseGuayTarget")

--- a/soh/soh/Enhancements/Cheats/NoRedeadFreeze.cpp
+++ b/soh/soh/Enhancements/Cheats/NoRedeadFreeze.cpp
@@ -1,5 +1,6 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 static constexpr int32_t CVAR_NOREDEADFREEZE_DEFAULT = 0;
 #define CVAR_NOREDEADFREEZE_NAME CVAR_CHEAT("NoRedeadFreeze")

--- a/soh/soh/Enhancements/Cheats/UnrestrictedItems.cpp
+++ b/soh/soh/Enhancements/Cheats/UnrestrictedItems.cpp
@@ -1,7 +1,10 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
 
-extern "C" PlayState* gPlayState;
+extern "C" {
+extern PlayState* gPlayState;
+#include "z64.h"
+}
 
 #define CVAR_UNRESTRICTED_ITEMS_NAME CVAR_CHEAT("NoRestrictItems")
 #define CVAR_UNRESTRICTED_ITEMS_DEFAULT 0

--- a/soh/soh/Enhancements/Difficulty/AlwaysWinGoronPot.cpp
+++ b/soh/soh/Enhancements/Difficulty/AlwaysWinGoronPot.cpp
@@ -1,5 +1,6 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 #define CVAR_WIN_GORON_POT_NAME CVAR_ENHANCEMENT("GoronPot")
 #define CVAR_WIN_GORON_POT_VALUE CVarGetInteger(CVAR_WIN_GORON_POT_NAME, 0)

--- a/soh/soh/Enhancements/Difficulty/BonkDamage.cpp
+++ b/soh/soh/Enhancements/Difficulty/BonkDamage.cpp
@@ -3,6 +3,7 @@
 #include "soh/Enhancements/enhancementTypes.h"
 
 extern "C" {
+#include "z64.h"
 #include "functions.h"
 #include "macros.h"
 extern PlayState* gPlayState;

--- a/soh/soh/Enhancements/Difficulty/SwitchTimerMultiplier.cpp
+++ b/soh/soh/Enhancements/Difficulty/SwitchTimerMultiplier.cpp
@@ -1,7 +1,8 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
-
+#include "soh/cvar_prefixes.h"
 extern "C" {
+#include "z64.h"
 extern PlayState* gPlayState;
 }
 

--- a/soh/soh/Enhancements/ExtraModes/BounceOffWalls.cpp
+++ b/soh/soh/Enhancements/ExtraModes/BounceOffWalls.cpp
@@ -2,6 +2,7 @@
 #include "soh/ShipInit.hpp"
 
 extern "C" {
+#include "z64.h"
 #include "macros.h"
 #include "functions.h"
 extern PlayState* gPlayState;

--- a/soh/soh/Enhancements/Fixes/DirtPathFix.cpp
+++ b/soh/soh/Enhancements/Fixes/DirtPathFix.cpp
@@ -2,7 +2,10 @@
 #include "soh/Enhancements/enhancementTypes.h"
 #include "soh/ShipInit.hpp"
 
-extern "C" PlayState* gPlayState;
+extern "C" {
+#include "z64.h"
+extern PlayState* gPlayState;
+}
 
 static constexpr ZFightingFixType CVAR_DIRT_PATH_DEFAULT = ZFIGHT_FIX_DISABLED;
 #define CVAR_DIRT_PATH_NAME CVAR_ENHANCEMENT("SceneSpecificDirtPathFix")

--- a/soh/soh/Enhancements/Fixes/HammerHandFix.cpp
+++ b/soh/soh/Enhancements/Fixes/HammerHandFix.cpp
@@ -3,6 +3,7 @@
 #include "soh/ShipInit.hpp"
 
 extern "C" {
+#include "z64.h"
 #include "macros.h"
 #include "objects/object_link_boy/object_link_boy.h"
 extern SaveContext gSaveContext;

--- a/soh/soh/Enhancements/GameplayStats/BossDefeatTimestamps.cpp
+++ b/soh/soh/Enhancements/GameplayStats/BossDefeatTimestamps.cpp
@@ -1,7 +1,10 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
 
-extern "C" SaveContext gSaveContext;
+extern "C" {
+#include "z64save.h"
+extern SaveContext gSaveContext;
+}
 
 #define BOSS_DEFEAT_TIMESTAMP(actorID, timestamp)                                                     \
     COND_ID_HOOK(OnBossDefeat, actorID, true, [](void* refActor) {                                    \

--- a/soh/soh/Enhancements/Graphics/AgeDependentEquipment.cpp
+++ b/soh/soh/Enhancements/Graphics/AgeDependentEquipment.cpp
@@ -3,6 +3,7 @@
 #include "soh/ResourceManagerHelpers.h"
 
 extern "C" {
+#include "z64.h"
 #include "macros.h"
 #include "objects/object_link_boy/object_link_boy.h"
 #include "objects/object_link_child/object_link_child.h"

--- a/soh/soh/Enhancements/Graphics/AgeDependentMasks.cpp
+++ b/soh/soh/Enhancements/Graphics/AgeDependentMasks.cpp
@@ -4,6 +4,7 @@
 #include "soh/ResourceManagerHelpers.h"
 
 extern "C" {
+#include "z64.h"
 #include "macros.h"
 #include "functions.h"
 #include "objects/object_link_boy/object_link_boy.h"

--- a/soh/soh/Enhancements/Graphics/Disable2DBackgrounds.cpp
+++ b/soh/soh/Enhancements/Graphics/Disable2DBackgrounds.cpp
@@ -2,9 +2,10 @@
 #include "soh/ShipInit.hpp"
 
 extern "C" {
+#include "variables.h"
+#include "z64save.h"
 extern SaveContext gSaveContext;
 extern PlayState* gPlayState;
-#include "variables.h"
 }
 
 #define CVAR_NAME CVAR_ENHANCEMENT("3DSceneRender")

--- a/soh/soh/Enhancements/Graphics/DisableHeatHaze.cpp
+++ b/soh/soh/Enhancements/Graphics/DisableHeatHaze.cpp
@@ -1,5 +1,6 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 void RegisterDisableHeatHaze() {
     COND_VB_SHOULD(VB_HOT_ROOM_DISTORTION, CVarGetInteger(CVAR_SETTING("A11yNoHeatHaze"), 0), { *should = false; });

--- a/soh/soh/Enhancements/Graphics/DisableJabuWobble.cpp
+++ b/soh/soh/Enhancements/Graphics/DisableJabuWobble.cpp
@@ -1,5 +1,6 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 void RegisterDisableJabuWobble() {
     COND_VB_SHOULD(VB_JABU_WOBBLE, CVarGetInteger(CVAR_SETTING("A11yNoJabuWobble"), 0), { *should = false; });

--- a/soh/soh/Enhancements/Graphics/DisableKokiriDrawDistance.cpp
+++ b/soh/soh/Enhancements/Graphics/DisableKokiriDrawDistance.cpp
@@ -1,5 +1,6 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 void RegisterDisableKokiriDrawDistance() {
     COND_VB_SHOULD(VB_FADE_KOKIRI, CVarGetInteger(CVAR_ENHANCEMENT("DisableKokiriDrawDistance"), 0),

--- a/soh/soh/Enhancements/Graphics/DisableSandstorm.cpp
+++ b/soh/soh/Enhancements/Graphics/DisableSandstorm.cpp
@@ -1,7 +1,10 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/ShipInit.hpp"
 
-extern "C" PlayState* gPlayState;
+extern "C" {
+#include "z64.h"
+extern PlayState* gPlayState;
+}
 
 void DisableSandstormAfterTransition(int16_t sceneNum) {
     if (sceneNum == SCENE_HAUNTED_WASTELAND) {

--- a/soh/soh/Enhancements/Graphics/ToTMedallions.cpp
+++ b/soh/soh/Enhancements/Graphics/ToTMedallions.cpp
@@ -3,6 +3,7 @@
 #include "soh/ShipInit.hpp"
 
 extern "C" {
+#include "z64.h"
 #include "align_asset_macro.h"
 #include "macros.h"
 #include "variables.h"

--- a/soh/soh/Enhancements/Graphics/VisualAgony.cpp
+++ b/soh/soh/Enhancements/Graphics/VisualAgony.cpp
@@ -5,6 +5,7 @@
 #include "textures/icon_item_24_static/icon_item_24_static.h"
 
 extern "C" {
+#include "z64.h"
 #include "macros.h"
 #include "variables.h"
 #include "functions.h"

--- a/soh/soh/Enhancements/Items/AdditionalReticles.cpp
+++ b/soh/soh/Enhancements/Items/AdditionalReticles.cpp
@@ -2,10 +2,12 @@
 #include "soh/ShipInit.hpp"
 
 extern "C" {
-extern PlayState* gPlayState;
-extern SaveContext gSaveContext;
+#include "z64.h"
+#include "z64save.h"
 #include "macros.h"
 #include "functions.h"
+extern PlayState* gPlayState;
+extern SaveContext gSaveContext;
 }
 
 #define CVAR_BOW_RETICLE_NAME CVAR_ENHANCEMENT("BowReticle")

--- a/soh/soh/Enhancements/Items/ArrowCycle.cpp
+++ b/soh/soh/Enhancements/Items/ArrowCycle.cpp
@@ -2,6 +2,7 @@
 #include "soh/ShipInit.hpp"
 
 extern "C" {
+#include "z64.h"
 #include "macros.h"
 #include "variables.h"
 #include "functions.h"

--- a/soh/soh/Enhancements/Items/AssignableTunicsAndBoots.cpp
+++ b/soh/soh/Enhancements/Items/AssignableTunicsAndBoots.cpp
@@ -2,6 +2,7 @@
 #include "soh/ShipInit.hpp"
 
 extern "C" {
+#include "z64.h"
 #include "macros.h"
 #include "variables.h"
 

--- a/soh/soh/Enhancements/Items/HookshotReticle.cpp
+++ b/soh/soh/Enhancements/Items/HookshotReticle.cpp
@@ -2,8 +2,8 @@
 #include "soh/ShipInit.hpp"
 
 extern "C" {
+#include "z64.h"
 extern PlayState* gPlayState;
-extern SaveContext gSaveContext;
 #include "macros.h"
 #include "functions.h"
 #include "objects/object_link_boy/object_link_boy.h"

--- a/soh/soh/Enhancements/Items/UnsheatheWithoutSlashing.cpp
+++ b/soh/soh/Enhancements/Items/UnsheatheWithoutSlashing.cpp
@@ -1,5 +1,10 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
+
+extern "C" {
+#include "z64player.h"
+}
 
 #define CVAR_UNSHEATHE_NAME CVAR_ENHANCEMENT("UnsheatheWithoutSlashing")
 #define CVAR_UNSHEATHE_VALUE CVarGetInteger(CVAR_UNSHEATHE_NAME, 0)

--- a/soh/soh/Enhancements/QoL/ResetHotKey.cpp
+++ b/soh/soh/Enhancements/QoL/ResetHotKey.cpp
@@ -6,6 +6,7 @@
 #include "soh/OTRGlobals.h"
 
 extern "C" {
+#include "z64.h"
 #include "macros.h"
 #include "variables.h"
 }

--- a/soh/soh/Enhancements/Restorations/N64WeirdFrames/N64WeirdFrames.cpp
+++ b/soh/soh/Enhancements/Restorations/N64WeirdFrames/N64WeirdFrames.cpp
@@ -1,6 +1,7 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 #include <vector>
 #include <spdlog/spdlog.h>
@@ -8,7 +9,6 @@
 #include "WeirdAnimation.h"
 
 extern "C" {
-#include "macros.h"
 #include "z64player.h"
 
 #include "objects/gameplay_keep/gameplay_keep.h"
@@ -25,6 +25,7 @@ AnimationHeaderCommon* ResourceMgr_LoadAnimByName(const char* path);
 // the start of the animation or past the end of it. In either case you add a list of animations'
 // data that are neighboring before or after the target animation. If more weird frame data is
 // required then add more of the neighboring animations in ROM.
+// TODO use std::array, we don't need the functionality of of std::vector
 static std::vector<WeirdAnimation> weirdAnimations{
     // For weirdshots.
     { gPlayerAnim_link_bow_side_walk,
@@ -134,8 +135,7 @@ void RegisterN64WeirdFrames() {
             animation = reinterpret_cast<LinkAnimationHeader*>(ResourceMgr_LoadAnimByName(*animationName));
         }
 
-        const auto playerAnimHeader =
-            static_cast<LinkAnimationHeader*>(SEGMENTED_TO_VIRTUAL(static_cast<void*>(animation)));
+        const auto playerAnimHeader = static_cast<LinkAnimationHeader*>(static_cast<void*>(animation));
 
         if (frame < 0 || frame >= playerAnimHeader->common.frameCount) {
             const auto direction = frame < 0 ? IndexDirection::BACKWARD : IndexDirection::FORWARD;

--- a/soh/soh/Enhancements/TimeSavers/FasterBeanSkulltula.cpp
+++ b/soh/soh/Enhancements/TimeSavers/FasterBeanSkulltula.cpp
@@ -1,5 +1,6 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 void RegisterFasterBeanSkulltula() {
     COND_VB_SHOULD(VB_SPAWN_BEAN_SKULLTULA, CVarGetInteger(CVAR_ENHANCEMENT("FasterBeanSkull"), 0),

--- a/soh/soh/Enhancements/TimeSavers/FasterBottleEmpty.cpp
+++ b/soh/soh/Enhancements/TimeSavers/FasterBottleEmpty.cpp
@@ -1,5 +1,7 @@
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/ShipInit.hpp"
+#include "z64player.h"
+#include "soh/cvar_prefixes.h"
 
 void RegisterFasterEmptyBottle() {
     COND_VB_SHOULD(VB_EMPTYING_BOTTLE, CVarGetInteger(CVAR_ENHANCEMENT("FasterBottleEmpty"), 0), {

--- a/soh/soh/Enhancements/TimeSavers/FasterHeavyBlockLift.cpp
+++ b/soh/soh/Enhancements/TimeSavers/FasterHeavyBlockLift.cpp
@@ -2,6 +2,7 @@
 #include "soh/ShipInit.hpp"
 
 extern "C" {
+#include "z64.h"
 #include "z64save.h"
 #include "macros.h"
 #include "variables.h"

--- a/soh/soh/Enhancements/TimeSavers/FasterPauseMenu.cpp
+++ b/soh/soh/Enhancements/TimeSavers/FasterPauseMenu.cpp
@@ -3,6 +3,7 @@
 
 extern "C" {
 #include "variables.h"
+#include "z64.h"
 extern PlayState* gPlayState;
 extern void func_808237B4(PlayState* play, Input* input);
 }

--- a/soh/soh/Enhancements/TimeSavers/FasterRupeeAccumulator.cpp
+++ b/soh/soh/Enhancements/TimeSavers/FasterRupeeAccumulator.cpp
@@ -2,6 +2,7 @@
 #include "soh/ShipInit.hpp"
 
 extern "C" {
+#include "z64.h"
 #include "z64save.h"
 #include "macros.h"
 #include "variables.h"

--- a/soh/soh/Enhancements/TimeSavers/SkipAmyPuzzle.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipAmyPuzzle.cpp
@@ -3,6 +3,7 @@
 
 extern "C" {
 #include "functions.h"
+#include "z64save.h"
 extern SaveContext gSaveContext;
 }
 

--- a/soh/soh/Enhancements/TimeSavers/SkipCutscene/SkipOwlTravel.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipCutscene/SkipOwlTravel.cpp
@@ -4,7 +4,9 @@
 #include <cassert>
 
 extern "C" {
+#include "z64.h"
 #include "z64save.h"
+#include "z64scene.h"
 extern PlayState* gPlayState;
 extern SaveContext gSaveContext;
 

--- a/soh/soh/Enhancements/audio/EnemyBGMDisable.cpp
+++ b/soh/soh/Enhancements/audio/EnemyBGMDisable.cpp
@@ -1,5 +1,6 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 static constexpr int32_t CVAR_ENEMYBGMDISABLE_DEFAULT = 0;
 #define CVAR_ENEMYBGMDISABLE_NAME CVAR_AUDIO("EnemyBGMDisable")

--- a/soh/soh/Enhancements/audio/LeeverEnemyBGM.cpp
+++ b/soh/soh/Enhancements/audio/LeeverEnemyBGM.cpp
@@ -1,7 +1,9 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
 
 extern "C" {
+#include "z64.h"
 #include "macros.h"
 }
 

--- a/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
+++ b/soh/soh/Enhancements/cosmetics/CustomLogoTitle.cpp
@@ -4,10 +4,11 @@
 #include "textures/nintendo_rogo_static/nintendo_rogo_static.h"
 #include "assets/objects/gameplay_keep/gameplay_keep.h"
 #include "soh_assets.h"
+#include "soh/cvar_prefixes.h"
 
 extern "C" {
-#include "macros.h"
 #include "z64.h"
+#include "macros.h"
 #include "functions.h"
 #include "variables.h"
 #include "soh/Enhancements/enhancementTypes.h"

--- a/soh/soh/Enhancements/customequipment.cpp
+++ b/soh/soh/Enhancements/customequipment.cpp
@@ -8,6 +8,7 @@
 #include "soh/ResourceManagerHelpers.h"
 
 extern "C" {
+#include "z64.h"
 #include "macros.h"
 #include "functions.h"
 #include "variables.h"

--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -5,7 +5,6 @@
 
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "vanilla-behavior/GIVanillaBehavior.h"
-#include <z64.h>
 
 typedef enum {
     /* 0x00 */ GI_LINK_SIZE_NORMAL,
@@ -55,6 +54,9 @@ typedef enum {
 #ifdef __cplusplus
 extern "C" {
 #endif
+#include <z64actor.h>
+struct Player;
+struct PlayState;
 uint8_t GameInteractor_NoUIActive();
 GILinkSize GameInteractor_GetLinkSize();
 void GameInteractor_SetLinkSize(GILinkSize size);

--- a/soh/soh/Network/Sail/Sail.cpp
+++ b/soh/soh/Network/Sail/Sail.cpp
@@ -5,6 +5,7 @@
 #include <ship/window/gui/ConsoleWindow.h>
 #include <spdlog/spdlog.h>
 #include "soh/ShipUtils.h"
+#include "soh/cvar_prefixes.h"
 
 template <class DstType, class SrcType> bool IsType(const SrcType* src) {
     return dynamic_cast<const DstType*>(src) != nullptr;


### PR DESCRIPTION
I got sick of watching so many files get rebuilt when touching player.h
There is more cleanup to do though. I believe zeldaret moved PlayState so its own header and removed the z64.h mega header.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8254796715.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8254769939.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8254742570.zip)
<!--- section:artifacts:end -->