### PR TITLE
fix master sword in sheath custom equip not loading

### DIFF
--- a/soh/soh/Enhancements/customequipment.cpp
+++ b/soh/soh/Enhancements/customequipment.cpp
@@ -55,7 +55,7 @@ static Gfx* LoadCustomGfx(const char* path) {
     if (!path)
         return nullptr;
     path = ResolveCustomFPSHand(path);
-    if (!ResourceMgr_FileAltExists(path) || !ResourceGetIsCustomByName(path))
+    if (!ResourceMgr_FileAltExists(path) && !ResourceGetIsCustomByName(path))
         return nullptr;
     return ResourceMgr_LoadGfxByName(path);
 }


### PR DESCRIPTION
fixes regression from #6862

`LoadCustomGfx`'s check being gated by OR condition broke `gCustomMasterSwordInSheathDL`, i can only assume this is because the sheathed sword DL is the "default" state called by link's skeleton. that condition in customequipment.cpp is not the cause of the log spam that pr aimed to fix so it was unneeded

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8258495476.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8258438910.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8258427908.zip)
<!--- section:artifacts:end -->