### PR TITLE
fix(audio): bounds-check fontId to stop OOB crash with large SAF packs

### DIFF
--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -297,6 +297,8 @@ void AudioLoad_InitSampleDmaBuffers(s32 arg0) {
     gAudioContext.sampleDmaReuseQueue2WrPos = gAudioContext.sampleDmaCount - gAudioContext.sampleDmaListSize1;
 }
 
+// 2S2H [Port] Completely reworked from decomp: SAF custom fontIds can exceed the native table; bounds-check against
+// fontMapSize to avoid OOB reads.
 s32 AudioLoad_IsFontLoadComplete(s32 fontId) {
     if (fontId == 0xFF) {
         return true;

--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -298,17 +298,16 @@ void AudioLoad_InitSampleDmaBuffers(s32 arg0) {
 }
 
 s32 AudioLoad_IsFontLoadComplete(s32 fontId) {
-    return true;
     if (fontId == 0xFF) {
         return true;
-
-    } else if (gAudioContext.fontLoadStatus[fontId] >= 2) {
-        return true;
-    } else if (gAudioContext.fontLoadStatus[AudioLoad_GetRealTableIndex(FONT_TABLE, fontId)] >= 2) {
-        return true;
-    } else {
-        return false;
     }
+    // Resolve indirection (identity for FONT_TABLE today, but kept for parity with other tables).
+    fontId = (s32)AudioLoad_GetRealTableIndex(FONT_TABLE, (u32)fontId);
+    if ((size_t)fontId >= fontMapSize) {
+        // No entry in the font map — SAF sequence with no associated soundfont, treat as ready.
+        return true;
+    }
+    return gAudioContext.fontLoadStatus[fontId] >= 2;
 }
 
 s32 AudioLoad_IsSeqLoadComplete(s32 seqId) {
@@ -336,7 +335,7 @@ s32 AudioLoad_IsSampleLoadComplete(s32 sampleBankId) {
 }
 
 void AudioLoad_SetFontLoadStatus(s32 fontId, s32 status) {
-    if ((fontId != 0xFF) && (gAudioContext.fontLoadStatus[fontId] != 5)) {
+    if ((fontId != 0xFF) && ((size_t)fontId < fontMapSize) && (gAudioContext.fontLoadStatus[fontId] != 5)) {
         gAudioContext.fontLoadStatus[fontId] = status;
     }
 }

--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -297,7 +297,7 @@ void AudioLoad_InitSampleDmaBuffers(s32 arg0) {
     gAudioContext.sampleDmaReuseQueue2WrPos = gAudioContext.sampleDmaCount - gAudioContext.sampleDmaListSize1;
 }
 
-// 2S2H [Port] Completely reworked from decomp: SAF custom fontIds can exceed the native table; bounds-check against
+// SOH [Port] Completely reworked from decomp: SAF custom fontIds can exceed the native table; bounds-check against
 // fontMapSize to avoid OOB reads.
 s32 AudioLoad_IsFontLoadComplete(s32 fontId) {
     if (fontId == 0xFF) {


### PR DESCRIPTION
## Problem

Semi-random crashes when loading SAF (Streamed Audio Format) mods with ~50+ songs (#6900). The crash trace lands in `AudioLoad_SetFontLoadStatus` called from `AudioSeq_SequencePlayerProcessSequence`.

## Root cause

`AudioLoad_IsFontLoadComplete` contained a stub `return true` that bypassed all load-status checks, so `AudioSeq_SequencePlayerProcessSequence` always proceeded to call `AudioLoad_SetFontLoadStatus(seqPlayer->defaultFont, 2)`. For large packs, `defaultFont` holds a custom sequence index that exceeds the `fontMapSize`-sized `fontLoadStatus` array, writing past the heap allocation and corrupting memory.

## Fix

- Remove the stub so the real load-status logic runs.
- Add `(size_t)fontId >= fontMapSize` guards in both `AudioLoad_IsFontLoadComplete` and `AudioLoad_SetFontLoadStatus`. Out-of-range IDs (custom SAF sequences that carry no associated soundfont) are treated as ready in the check and silently skipped in the write — preserving playback while eliminating the OOB access.

## Testing

Manually verified with an existing SAF pack that sequences still play. The OOB write (and resulting heap corruption) is eliminated by construction once the bounds check is in place.

Closes #6900

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8267946346.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8267849037.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8267840551.zip)
<!--- section:artifacts:end -->