### PR TITLE
fix: seqLoadStatus OOB reads/writes for custom SAF sequences (#5706)

### DIFF
--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -315,13 +315,19 @@ s32 AudioLoad_IsFontLoadComplete(s32 fontId) {
 s32 AudioLoad_IsSeqLoadComplete(s32 seqId) {
     if (seqId == 0xFF) {
         return true;
-    } else if (gAudioContext.seqLoadStatus[seqId] >= 2) {
-        return true;
-    } else if (gAudioContext.seqLoadStatus[AudioLoad_GetRealTableIndex(SEQUENCE_TABLE, seqId)] >= 2) {
-        return true;
-    } else {
-        return false;
     }
+    if ((size_t)seqId >= sequenceMapSize) {
+        // Custom SAF sequence whose seqId exceeds the status table — not async-loading, treat as ready.
+        return true;
+    }
+    if (gAudioContext.seqLoadStatus[seqId] >= 2) {
+        return true;
+    }
+    s32 realId = (s32)AudioLoad_GetRealTableIndex(SEQUENCE_TABLE, seqId);
+    if ((size_t)realId < sequenceMapSize && gAudioContext.seqLoadStatus[realId] >= 2) {
+        return true;
+    }
+    return false;
 }
 
 s32 AudioLoad_IsSampleLoadComplete(s32 sampleBankId) {
@@ -343,7 +349,7 @@ void AudioLoad_SetFontLoadStatus(s32 fontId, s32 status) {
 }
 
 void AudioLoad_SetSeqLoadStatus(s32 seqId, s32 status) {
-    if ((seqId != 0xFF) && (gAudioContext.seqLoadStatus[seqId] != 5)) {
+    if ((seqId != 0xFF) && ((size_t)seqId < sequenceMapSize) && (gAudioContext.seqLoadStatus[seqId] != 5)) {
         gAudioContext.seqLoadStatus[seqId] = status;
     }
 }
@@ -637,7 +643,7 @@ u8* AudioLoad_SyncLoadSeq(s32 seqId) {
     s32 pad;
     s32 didAllocate;
 
-    if (gAudioContext.seqLoadStatus[AudioLoad_GetRealTableIndex(SEQUENCE_TABLE, seqId)] == 1) {
+    if ((size_t)seqId < sequenceMapSize && gAudioContext.seqLoadStatus[seqId] == 1) {
         return NULL;
     }
 


### PR DESCRIPTION
## What this fixes

With a custom music pack (BGM replacement) installed, **battle music often fails to play** — the first enemy encounter might work, but re-approaching enemies frequently gives silence. Fixes #5706.

## Why it happens

The audio engine keeps a small "is this sequence loaded yet?" status array (`seqLoadStatus`). It is sized for the game's *built-in* sequences only.

Custom sequences loaded from a pack are given ID numbers that start *past the end* of that array. But three spots in the loader still index the array with the sequence's ID directly. When the ID belongs to a custom sequence, that index lands **past the end of the array, in unrelated memory** — an out-of-bounds (OOB) access:

- one spot **writes** a status there (corrupting whatever memory happens to sit after the array), and
- two spots **read** a status from there (getting whatever garbage is in that memory).

That garbage read is what breaks battle music: if the leftover byte happens to look like "still loading," the loader gives up early and the sequence player is never started, so no music plays. Because the value depends on whatever was previously in that memory, the failure is intermittent — which is why it usually works the first time and fails on later encounters.

## The fix

Custom sequences aren't tracked in that status array at all — they're served on demand by the resource manager and are always ready. So the fix simply teaches those three spots to recognize an out-of-range ID and skip the array:

- treat an out-of-range ID as "already loaded" instead of reading the array,
- skip the status write for an out-of-range ID,
- skip the "still loading?" check for an out-of-range ID.

This mirrors the already-merged fix for the font status array (#6916), which was the same bug on the sound-font side.

## Test plan

- [ ] With a BGM pack that includes custom battle music, enter a dungeon and trigger an enemy encounter — battle music plays.
- [ ] Back away until it stops, then re-approach — battle music plays again, reliably, on every subsequent encounter.
- [ ] Repeat 5-10 times without a silent encounter.


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8868070727.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8867880399.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8867792417.zip)
<!--- section:artifacts:end -->