### PR TITLE
Savestates, player serialization

### DIFF
--- a/soh/soh/Enhancements/savestates.cpp
+++ b/soh/soh/Enhancements/savestates.cpp
@@ -50,6 +50,7 @@ extern "C" void EnZf_SaveState(SaveStateCtx* ctx);
 extern "C" void EnZl3_SaveState(SaveStateCtx* ctx);
 extern "C" void ObjectKankyo_SaveState(SaveStateCtx* ctx);
 extern "C" void EnHeishi1_SaveState(SaveStateCtx* ctx);
+extern "C" void Player_SaveState(SaveStateCtx* ctx);
 
 extern "C" void Matrix_SaveState(SaveStateCtx* ctx);
 extern "C" void Lights_SaveState(SaveStateCtx* ctx);
@@ -147,6 +148,7 @@ typedef struct SaveStateInfo {
     std::unique_ptr<uint8_t[]> enZl3State;
     std::unique_ptr<uint8_t[]> objectKankyoState;
     std::unique_ptr<uint8_t[]> enHeishi1State;
+    std::unique_ptr<uint8_t[]> playerState;
 
     u8 transitionActorCount_copy;
     s16 transitionActorIds_copy[256];
@@ -281,6 +283,7 @@ void SaveState::SaveOverlayStaticData(void) {
     SaveOverlayState(info->enZl3State, EnZl3_SaveState);
     SaveOverlayState(info->objectKankyoState, ObjectKankyo_SaveState);
     SaveOverlayState(info->enHeishi1State, EnHeishi1_SaveState);
+    SaveOverlayState(info->playerState, Player_SaveState);
 }
 
 void SaveState::LoadOverlayStaticData(void) {
@@ -326,6 +329,7 @@ void SaveState::LoadOverlayStaticData(void) {
     LoadOverlayState(info->enZl3State, EnZl3_SaveState);
     LoadOverlayState(info->objectKankyoState, ObjectKankyo_SaveState);
     LoadOverlayState(info->enHeishi1State, EnHeishi1_SaveState);
+    LoadOverlayState(info->playerState, Player_SaveState);
 }
 
 void SaveState::SaveTransitionActors(void) {

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -31,6 +31,7 @@
 #include "soh/frame_interpolation.h"
 #include "soh/OTRGlobals.h"
 #include "soh/ResourceManagerHelpers.h"
+#include "soh/Enhancements/savestate_serialize.h"
 
 #include <string.h>
 #include <stdlib.h>
@@ -16597,3 +16598,30 @@ void Player_StartTalking(PlayState* play, Actor* actor) {
         Player_SetTurnAroundCamera(play, CAM_ITEM_TYPE_11);
     }
 }
+
+#define PLAYER_SHIP_SAVESTATE_FIELDS(F) \
+    F(D_80858AA0)                       \
+    F(sSavedCurrentMask)                \
+    F(sInteractWallCheckResult)         \
+    F(sControlInput)                    \
+    F(sNoclipEnabled)                   \
+    F(sControlStickMagnitude)           \
+    F(sControlStickAngle)               \
+    F(sControlStickWorldYaw)            \
+    F(sUpperBodyIsBusy)                 \
+    F(sFloorType)                       \
+    F(sWaterSpeedFactor)                \
+    F(sInvWaterSpeedFactor)             \
+    F(sTouchedWallFlags)                \
+    F(sConveyorSpeed)                   \
+    F(sIsFloorConveyor)                 \
+    F(sConveyorYaw)                     \
+    F(sYDistToFloor)                    \
+    F(sPrevFloorProperty)               \
+    F(sShapeYawToTouchedWall)           \
+    F(sWorldYawToTouchedWall)           \
+    F(sFloorShapePitch)                 \
+    F(sUseHeldItem)                     \
+    F(sHeldItemButtonIsHeldDown)
+
+SHIP_SAVESTATE_DEFINE(Player, PLAYER_SHIP_SAVESTATE_FIELDS)


### PR DESCRIPTION
Player variables added.
Tested with `sNoclipEnabled`: previously, player fell down on loading savestate made in noclip mode if player had it toggled off when loading.

https://github.com/user-attachments/assets/15f47896-3c6e-4f32-be82-89cbab5554d5



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8316926887.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8316699456.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8316652342.zip)
<!--- section:artifacts:end -->