### PR TITLE
cleanup redundant code + fix waist dl

### DIFF
--- a/soh/soh/resource/type/Skeleton.cpp
+++ b/soh/soh/resource/type/Skeleton.cpp
@@ -108,7 +108,7 @@ void SkeletonPatcher::ClearSkeletons() {
 void SkeletonPatcher::UpdateSkeletons() {
     auto resourceMgr = Ship::Context::GetRawInstance()->GetResourceManager();
     bool isAlt = resourceMgr->IsAltAssetsEnabled();
-    for (auto skel : skeletons) {
+    for (auto& skel : skeletons) {
         Skeleton* newSkel =
             (Skeleton*)resourceMgr
                 ->LoadResource((isAlt ? Ship::IResource::gAltAssetPrefix : "") + skel.vanillaSkeletonPath, true)
@@ -124,7 +124,7 @@ void SkeletonPatcher::UpdateSkeletons() {
 }
 
 void SkeletonPatcher::UpdateCustomSkeletons() {
-    for (auto skel : skeletons) {
+    for (auto& skel : skeletons) {
         if (!skel.isLocalPlayer) {
             continue;
         }
@@ -152,48 +152,36 @@ void SkeletonPatcher::UpdateTunicSkeletons(SkeletonPatchInfo& skel) {
 
     // Check if we even need updating
     s32 skelID = ageID << 4 | tunicID;
-    if (skelID == skel.lastSkeletonId)
+    if (skelID == skel.lastSkeletonId) {
         return;
-    skel.lastSkeletonId = skelID;
+    }
 
     // Check if this is one of Link's skeletons
     if (ageID == 2) {
         // Check what Link's current tunic is
         switch (tunicID) {
             case PLAYER_TUNIC_KOKIRI:
-                if (skel.lastSkeletonId == (ageID << 4 | PLAYER_TUNIC_KOKIRI))
-                    return;
                 skeletonPath = std::string(gLinkAdultKokiriTunicSkel).substr(sOtr.length());
                 break;
             case PLAYER_TUNIC_GORON:
-                if (skel.lastSkeletonId == (ageID << 4 | PLAYER_TUNIC_GORON))
-                    return;
                 skeletonPath = std::string(gLinkAdultGoronTunicSkel).substr(sOtr.length());
                 break;
             case PLAYER_TUNIC_ZORA:
-                if (skel.lastSkeletonId == (ageID << 4 | PLAYER_TUNIC_ZORA))
-                    return;
                 skeletonPath = std::string(gLinkAdultZoraTunicSkel).substr(sOtr.length());
                 break;
             default:
                 return;
         }
-    } else if (skelID == 1) {
+    } else if (ageID == 1) {
         // Check what Link's current tunic is
         switch (tunicID) {
             case PLAYER_TUNIC_KOKIRI:
-                if (skel.lastSkeletonId == (ageID << 4 | PLAYER_TUNIC_KOKIRI))
-                    return;
                 skeletonPath = std::string(gLinkChildKokiriTunicSkel).substr(sOtr.length());
                 break;
             case PLAYER_TUNIC_GORON:
-                if (skel.lastSkeletonId == (ageID << 4 | PLAYER_TUNIC_GORON))
-                    return;
                 skeletonPath = std::string(gLinkChildGoronTunicSkel).substr(sOtr.length());
                 break;
             case PLAYER_TUNIC_ZORA:
-                if (skel.lastSkeletonId == (ageID << 4 | PLAYER_TUNIC_ZORA))
-                    return;
                 skeletonPath = std::string(gLinkChildZoraTunicSkel).substr(sOtr.length());
                 break;
             default:
@@ -202,6 +190,7 @@ void SkeletonPatcher::UpdateTunicSkeletons(SkeletonPatchInfo& skel) {
     }
 
     UpdateCustomSkeletonFromPath(skeletonPath, skel);
+    skel.lastSkeletonId = skelID;
 }
 
 void SkeletonPatcher::UpdateCustomSkeletonFromPath(const std::string& skeletonPath, SkeletonPatchInfo& skel) {

--- a/soh/soh/resource/type/Skeleton.h
+++ b/soh/soh/resource/type/Skeleton.h
@@ -79,7 +79,7 @@ struct SkeletonPatchInfo {
     SkelAnime* skelAnime;
     std::string vanillaSkeletonPath;
 
-    u8 lastSkeletonId;
+    u8 lastSkeletonId = 0xFF;
     bool isLocalPlayer;
 };
 


### PR DESCRIPTION
fixes a regression from #6862 

cleaned up some redundant code, the extra guards in between tunic checks were unneeded as the higher up:
```
if (skelID == skel.lastSkeletonId)
    return;
```
was doing the trick just fine.

logic error `else if (skelID == 1)` as well, this should be checking `ageID` instead, to ensure child tunics swap as intended.

the main thing here though was that `skel.lastSkeletonId = skelID;` was placed too early, before `UpdateCustomSkeletonFromPath`, causing the waist DL to not update with the tunics, instead using the default kokiri tunic waist DL

incorrect:
<img width="558" height="426" alt="image" src="https://github.com/user-attachments/assets/3d311a43-7448-4325-865e-4d0c031d3e3f" />
correct:
<img width="583" height="448" alt="image" src="https://github.com/user-attachments/assets/d3c0380c-117c-467d-9e46-359c21277eb2" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8326438297.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8326310995.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8326281142.zip)
<!--- section:artifacts:end -->