### PR TITLE
Fix crashes and corruption with many custom music tracks (audio heap overflow)

### DIFF
--- a/soh/include/z64audio.h
+++ b/soh/include/z64audio.h
@@ -915,7 +915,8 @@ typedef struct {
     /* 0x2B30 */ AudioCache fontCache;
     /* 0x2C40 */ AudioCache sampleBankCache;
     /* 0x2D50 */ AudioAllocPool permanentPool;
-    /* 0x2D60 */ AudioCacheEntry permanentCache[32];
+    // SOH [Bugfix] 32 -> 512: large custom-music packs overflowed this (see AudioHeap_AllocPermanent).
+    /* 0x2D60 */ AudioCacheEntry permanentCache[512];
     /* 0x2EE0 */ AudioSampleCache persistentSampleCache;
     /* 0x3174 */ AudioSampleCache temporarySampleCache;
     /* 0x3408 */ AudioPoolSplit4 sessionPoolSplit;

--- a/soh/src/code/audio_heap.c
+++ b/soh/src/code/audio_heap.c
@@ -534,6 +534,14 @@ void* AudioHeap_AllocCached(s32 tableType, ptrdiff_t size, s32 cache, s32 id) {
         return ret;
     }
 
+    // SOH [Bugfix] Bound entries[] (see AudioHeap_AllocPermanent); CACHE_EITHER falls back to temporary.
+    if (loadedPool->persistent.numEntries >= ARRAY_COUNT(loadedPool->persistent.entries)) {
+        if (cache == CACHE_EITHER) {
+            return AudioHeap_AllocCached(tableType, size, CACHE_TEMPORARY, id);
+        }
+        return NULL;
+    }
+
     mem = AudioHeap_Alloc(&loadedPool->persistent.pool, size);
     loadedPool->persistent.entries[loadedPool->persistent.numEntries].ptr = mem;
 
@@ -1011,6 +1019,12 @@ void* AudioHeap_AllocPermanent(s32 tableType, s32 id, size_t size) {
 
     index = gAudioContext.permanentPool.count;
 
+    // SOH [Bugfix] Bound permanentCache: large custom-music packs overflowed it and corrupted
+    // gAudioContext (crashed the audio thread). Refuse rather than corrupt memory; callers handle NULL.
+    if (index >= ARRAY_COUNT(gAudioContext.permanentCache)) {
+        return NULL;
+    }
+
     ret = AudioHeap_Alloc(&gAudioContext.permanentPool, size);
     gAudioContext.permanentCache[index].ptr = ret;
     if (ret == NULL) {
@@ -1134,6 +1148,10 @@ SampleCacheEntry* AudioHeap_AllocTemporarySampleCacheEntry(size_t size) {
     }
 
     if (index == -1) {
+        // SOH [Bugfix] Bound entries[] (see AudioHeap_AllocPermanent); callers treat NULL as uncached.
+        if (pool->size >= ARRAY_COUNT(pool->entries)) {
+            return NULL;
+        }
         index = pool->size++;
     }
 
@@ -1210,6 +1228,10 @@ SampleCacheEntry* AudioHeap_AllocPersistentSampleCacheEntry(size_t size) {
     void* mem;
 
     pool = &gAudioContext.persistentSampleCache;
+    // SOH [Bugfix] Bound entries[] (see AudioHeap_AllocPermanent).
+    if (pool->size >= ARRAY_COUNT(pool->entries)) {
+        return NULL;
+    }
     mem = AudioHeap_Alloc(&pool->pool, size);
     if (mem == NULL) {
         return NULL;

--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -1344,8 +1344,9 @@ void AudioLoad_Init(void* heap, size_t heapSize) {
     // calloc: unassigned slots stay NULL for the guard in AudioLoad_SyncInitSeqPlayerInternal().
     sequenceMap = calloc(sequenceMapSize + 0xF, sizeof(char*));
 
-    gAudioContext.seqLoadStatus = malloc(sequenceMapSize);
-    memset(gAudioContext.seqLoadStatus, 5, sequenceMapSize);
+    // SOH [Bugfix] Size to match sequenceMap (+ 0xF); custom ids can exceed sequenceMapSize.
+    gAudioContext.seqLoadStatus = malloc(sequenceMapSize + 0xF);
+    memset(gAudioContext.seqLoadStatus, 5, sequenceMapSize + 0xF);
     for (size_t i = 0; i < seqListSize; i++) {
         SequenceData sDat = ResourceMgr_LoadSeqByName(seqList[i]);
         sequenceMap[sDat.seqNumber] = strdup(seqList[i]);


### PR DESCRIPTION
## Fixes a crash with large custom music packs

Companion to #6916 — that PR fixed one out-of-bounds write (`AudioLoad_SetFontLoadStatus`); this one fixes a separate overflow it doesn't touch.

The audio engine keeps a fixed 32-entry list of permanently-loaded audio (`permanentCache`) and never checks the limit when adding to it. With a large custom pack, every track loads permanently (both its soundfont and its sequence), so the list fills past 32 within a session and each further entry gets written past the end — over neighbouring audio state, eventually the sequence players' script pointers, which crashes the audio thread (#6900, still reproducible after #6916).

### Fix
- Grow the list to 512 and stop cleanly at the limit instead of writing out of bounds.
- Same bounds check on three other cache lists written the same way.
- Size the sequence load-status array to the id range custom tracks actually use.

Vanilla sessions stay well under the limit, so stock behaviour is unchanged. Technical detail is in the commit message.


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8356374353.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8356240178.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8356148088.zip)
<!--- section:artifacts:end -->