### PR TITLE
unregister dark link skel on actor deletion

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
+++ b/soh/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
@@ -7,6 +7,7 @@
 #include "z_en_torch2.h"
 #include "objects/object_torch2/object_torch2.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS                                                                                 \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | \
@@ -172,6 +173,8 @@ void EnTorch2_Destroy(Actor* thisx, PlayState* play) {
     s32 pad;
     Player* this = (Player*)thisx;
 
+    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
+    ResourceMgr_UnregisterSkeleton(&this->upperSkelAnime);
     Effect_Delete(play, this->meleeWeaponEffectIndex);
     func_800F5B58();
     Collider_DestroyCylinder(play, &this->cylinder);


### PR DESCRIPTION
same idea as https://github.com/HarbourMasters/2ship2harkinian/pull/1800

doesnt cause crashes when alt toggling in vanilla but potentially could in enemy rando. could be jumping the gun here idk yet but figured it cant hurt

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8445352020.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8445333535.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8445293090.zip)
<!--- section:artifacts:end -->