### PR TITLE
Fix some issues found with the BetterSaveMenu

### DIFF
--- a/soh/soh/Enhancements/QoL/BetterSaveMenu.cpp
+++ b/soh/soh/Enhancements/QoL/BetterSaveMenu.cpp
@@ -164,9 +164,11 @@ void HandleSaveMenu(bool* should, PlayState* play) {
                     // Reset frame counter to prevent autosave on respawn
                     play->gameplayFrames = 0;
                     gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK;
-                    gSaveContext.health = CVarGetInteger(CVAR_ENHANCEMENT("FullHealthSpawn"), 0)
-                                              ? gSaveContext.healthCapacity
-                                              : STARTING_HEALTH;
+                    if (gSaveContext.health < STARTING_HEALTH) {
+                        gSaveContext.health = CVarGetInteger(CVAR_ENHANCEMENT("FullHealthSpawn"), 0)
+                                                  ? gSaveContext.healthCapacity
+                                                  : STARTING_HEALTH;
+                    }
                     Audio_QueueSeqCmd(0xF << 28 | SEQ_PLAYER_BGM_MAIN << 24 | 0xA);
                     gSaveContext.healthAccumulator = 0;
                     gSaveContext.magicState = MAGIC_STATE_IDLE;
@@ -176,6 +178,8 @@ void HandleSaveMenu(bool* should, PlayState* play) {
                     gSaveContext.magicLevel = gSaveContext.magic = 0;
                     play->state.running = false;
                     SET_NEXT_GAMESTATE(&play->state, Play_Init, PlayState);
+                    gSaveContext.seqId = static_cast<uint8_t>(NA_BGM_DISABLED);
+                    gSaveContext.natureAmbienceId = 0xFF;
                 }
             }
             break;

--- a/soh/soh/Enhancements/QoL/BetterSaveMenu.cpp
+++ b/soh/soh/Enhancements/QoL/BetterSaveMenu.cpp
@@ -165,11 +165,6 @@ void HandleSaveMenu(bool* should, PlayState* play) {
                     // Reset frame counter to prevent autosave on respawn
                     play->gameplayFrames = 0;
                     gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK;
-                    if (gSaveContext.health < STARTING_HEALTH) {
-                        gSaveContext.health = CVarGetInteger(CVAR_ENHANCEMENT("FullHealthSpawn"), 0)
-                                                  ? gSaveContext.healthCapacity
-                                                  : STARTING_HEALTH;
-                    }
                     Audio_QueueSeqCmd(0xF << 28 | SEQ_PLAYER_BGM_MAIN << 24 | 0xA);
                     gSaveContext.healthAccumulator = 0;
                     gSaveContext.magicState = MAGIC_STATE_IDLE;

--- a/soh/soh/Enhancements/QoL/BetterSaveMenu.cpp
+++ b/soh/soh/Enhancements/QoL/BetterSaveMenu.cpp
@@ -76,7 +76,8 @@ void HandleSaveMenu(bool* should, PlayState* play) {
                                            &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                     Play_PerformSave(play);
                     pauseCtx->unk_1EC = 4;
-                    if (IsSceneDungeon(gSaveContext.savedSceneNum)) {
+                    if (IsSceneDungeon(gSaveContext.savedSceneNum) ||
+                        CVarGetInteger(CVAR_ENHANCEMENT("RememberSaveLocation"), 0)) {
                         Message_StartTextbox(play, TEXT_CONTINUE_DUNGEON_MSG, NULL);
                     } else {
                         Message_StartTextbox(play, TEXT_CONTINUE_OVERWORLD_MSG, NULL);


### PR DESCRIPTION
Fixes the following issues found with the better save manager:

1. #6960, I didn't gate resetting the health behind the current hearts being less than starting hearts, so resetting via the new menu would always set you to 3 hearts, or full if you had the enhancement for that on. This was equivalent to the game over state, where I originally copied it from, and took effect after the `Sram_OpenSave` call. Eventually realized the `Sram_OpenSave` call already handled this and anything I did here to set it would be redundant.
2. There was a bug where if you reset, either via the Reset or Return to Spawn options, to the same scene you were already in, the music was gone/very quiet and Link's SFX were not playing until you changed scenes. Found a few extra lines that were only getting called in `FileChoose_LoadGame` that set some sequence ids on the save context, setting those manually fixed it. I did take the time to check the other things in SaveContext that were being set here, as far as I can tell none of those others were needed (timers were resetting properly already, etc.)
3. Improved the interaction with the "Remember Save Location" setting. Before, it was a bit unclear, as the "Return to Spawn" option while in the overworld wouldn't actually return you to spawn with that on. Instead, I set it up so that if "Remember Save Location" is on, it uses the "In Dungeon" version of the Better Save Menu everywhere. That not only fixes the misleading text, it also adds the feature of using "Remember Save Location", and being able to one-off return to spawn without needing to toggle the option.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8536383320.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8536151354.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8536105444.zip)
<!--- section:artifacts:end -->