### PR TITLE
Fix: Respect the Better Save Menu enable toggle

### DIFF
--- a/soh/soh/Enhancements/QoL/BetterSaveMenu.cpp
+++ b/soh/soh/Enhancements/QoL/BetterSaveMenu.cpp
@@ -191,30 +191,32 @@ void RegisterBetterSave() {
     continueOverworldMsg.Format();
     continueDungeonMsg.Format();
 
-    REGISTER_VB_SHOULD(VB_LOAD_SAVE_MENU, {
+    COND_VB_SHOULD(VB_LOAD_SAVE_MENU, CVAR_BETTERSAVE_VALUE, {
         PlayState* play = va_arg(args, PlayState*);
         HandleSaveMenu(should, play);
     });
 
-    REGISTER_VB_SHOULD(VB_DRAW_SAVE_MENU, { *should = false; });
+    COND_VB_SHOULD(VB_DRAW_SAVE_MENU, CVAR_BETTERSAVE_VALUE, { *should = false; });
 
-    COND_ID_HOOK(OnOpenText, TEXT_SAVE_MSG, true, [](uint16_t* textId, bool* loadFromMessageTable) {
+    COND_ID_HOOK(OnOpenText, TEXT_SAVE_MSG, CVAR_BETTERSAVE_VALUE, [](uint16_t* textId, bool* loadFromMessageTable) {
         saveMsg.LoadIntoFont();
         *loadFromMessageTable = false;
         return;
     });
 
-    COND_ID_HOOK(OnOpenText, TEXT_CONTINUE_DUNGEON_MSG, true, [](uint16_t* textId, bool* loadFromMessageTable) {
-        continueDungeonMsg.LoadIntoFont();
-        *loadFromMessageTable = false;
-        return;
-    });
+    COND_ID_HOOK(OnOpenText, TEXT_CONTINUE_DUNGEON_MSG, CVAR_BETTERSAVE_VALUE,
+                 [](uint16_t* textId, bool* loadFromMessageTable) {
+                     continueDungeonMsg.LoadIntoFont();
+                     *loadFromMessageTable = false;
+                     return;
+                 });
 
-    COND_ID_HOOK(OnOpenText, TEXT_CONTINUE_OVERWORLD_MSG, true, [](uint16_t* textId, bool* loadFromMessageTable) {
-        continueOverworldMsg.LoadIntoFont();
-        *loadFromMessageTable = false;
-        return;
-    });
+    COND_ID_HOOK(OnOpenText, TEXT_CONTINUE_OVERWORLD_MSG, CVAR_BETTERSAVE_VALUE,
+                 [](uint16_t* textId, bool* loadFromMessageTable) {
+                     continueOverworldMsg.LoadIntoFont();
+                     *loadFromMessageTable = false;
+                     return;
+                 });
 }
 
 static RegisterShipInitFunc initFunc(RegisterBetterSave, { CVAR_BETTERSAVE });


### PR DESCRIPTION
RegisterBetterSave registered its VB_LOAD_SAVE_MENU and VB_DRAW_SAVE_MENU hooks unconditionally, and hardcoded the save/continue text overrides to `true`, so the feature applied regardless of the enable checkbox and toggling it off did nothing. CVAR_BETTERSAVE_VALUE was defined but never read.

Gate all five hooks on CVAR_BETTERSAVE_VALUE (COND_VB_SHOULD for the two vanilla-behavior hooks, the condition arg for the three OnOpenText hooks). RegisterShipInitFunc already re-runs RegisterBetterSave when CVAR_BETTERSAVE changes, so the COND_* macros unregister the hooks when it is off and re-register them when it is on.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8553115879.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8553012871.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8552991308.zip)
<!--- section:artifacts:end -->