### PR TITLE
BetterSaveMenu: Less redundant override and run exit and load hooks

### DIFF
--- a/soh/include/z64save.h
+++ b/soh/include/z64save.h
@@ -255,6 +255,7 @@ typedef struct ShipSaveContextData {
     u8 filenameLanguage;
     //TODO: Move non-rando specific flags to a new sohInf and move the remaining randomizerInf to ShipRandomizerSaveContextData
     u16 randomizerInf[(RAND_INF_MAX + 15) / 16];
+    u8 resetToSpawn;
 } ShipSaveContextData;
 
 #pragma endregion

--- a/soh/soh/Enhancements/QoL/BetterSaveMenu.cpp
+++ b/soh/soh/Enhancements/QoL/BetterSaveMenu.cpp
@@ -165,14 +165,16 @@ void HandleSaveMenu(bool* should, PlayState* play) {
                     gSaveContext.natureAmbienceId = 0xFF;
                     GameInteractor_ExecuteOnLoadGame(gSaveContext.fileNum);
                     if (gSaveContext.ship.resetToSpawn) {
-                      if (LINK_IS_CHILD) {
-                        gSaveContext.entranceIndex = Entrance_OverrideNextIndex(ENTR_LINKS_HOUSE_CHILD_SPAWN); // Child Overworld Spawn
-                      } else {
-                        // Adult Overworld Spawn. Normally 0x5F4 (ENTR_TEMPLE_OF_TIME_WARP_PAD), but 0x282
-                        // (ENTR_HYRULE_FIELD_10) has been repurposed to differentiate from Prelude which also uses 0x5F4
-                        gSaveContext.entranceIndex = Entrance_OverrideNextIndex(ENTR_HYRULE_FIELD_10);
-                      }
-                      gSaveContext.ship.resetToSpawn = 0;
+                        if (LINK_IS_CHILD) {
+                            gSaveContext.entranceIndex =
+                                Entrance_OverrideNextIndex(ENTR_LINKS_HOUSE_CHILD_SPAWN); // Child Overworld Spawn
+                        } else {
+                            // Adult Overworld Spawn. Normally 0x5F4 (ENTR_TEMPLE_OF_TIME_WARP_PAD), but 0x282
+                            // (ENTR_HYRULE_FIELD_10) has been repurposed to differentiate from Prelude which also uses
+                            // 0x5F4
+                            gSaveContext.entranceIndex = Entrance_OverrideNextIndex(ENTR_HYRULE_FIELD_10);
+                        }
+                        gSaveContext.ship.resetToSpawn = 0;
                     }
                 }
             }

--- a/soh/soh/Enhancements/QoL/BetterSaveMenu.cpp
+++ b/soh/soh/Enhancements/QoL/BetterSaveMenu.cpp
@@ -1,6 +1,7 @@
 #include "soh/Enhancements/custom-message/CustomMessageManager.h"
 #include "soh/Enhancements/custom-message/CustomMessageTypes.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/Enhancements/randomizer/randomizer_entrance.h"
 #include "soh/ShipInit.hpp"
 
@@ -121,14 +122,6 @@ void HandleSaveMenu(bool* should, PlayState* play) {
                                                &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                         Play_SaveSceneFlags(play);
                         Sram_OpenSave();
-                        if (!IsSceneDungeon(gSaveContext.savedSceneNum)) {
-                            if (IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_OVERWORLD_SPAWNS)) {
-                                if (LINK_AGE_IN_YEARS == YEARS_ADULT) {
-                                    gSaveContext.entranceIndex = ENTR_HYRULE_FIELD_10;
-                                }
-                                gSaveContext.entranceIndex = Entrance_OverrideNextIndex(gSaveContext.entranceIndex);
-                            }
-                        }
                         pauseCtx->promptChoice = 0;
                         pauseCtx->unk_1EC = 7;
                         break;
@@ -138,14 +131,7 @@ void HandleSaveMenu(bool* should, PlayState* play) {
                                                &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                         Play_SaveSceneFlags(play);
                         Sram_OpenSave();
-                        gSaveContext.entranceIndex = (LINK_AGE_IN_YEARS == YEARS_CHILD) ? ENTR_LINKS_HOUSE_CHILD_SPAWN
-                                                                                        : ENTR_TEMPLE_OF_TIME_WARP_PAD;
-                        if (IS_RANDO && Randomizer_GetSettingValue(RSK_SHUFFLE_OVERWORLD_SPAWNS)) {
-                            if (LINK_AGE_IN_YEARS == YEARS_ADULT) {
-                                gSaveContext.entranceIndex = ENTR_HYRULE_FIELD_10;
-                            }
-                            gSaveContext.entranceIndex = Entrance_OverrideNextIndex(gSaveContext.entranceIndex);
-                        }
+                        gSaveContext.ship.resetToSpawn = 1;
                         pauseCtx->promptChoice = 0;
                         pauseCtx->unk_1EC = 7;
                         break;
@@ -157,6 +143,7 @@ void HandleSaveMenu(bool* should, PlayState* play) {
                 interfaceCtx->unk_244 += 10;
                 if (interfaceCtx->unk_244 >= 255) {
                     interfaceCtx->unk_244 = 255;
+                    GameInteractor_ExecuteOnExitGame(gSaveContext.fileNum);
                     pauseCtx->state = 0;
                     R_UPDATE_RATE = 3;
                     R_PAUSE_MENU_MODE = 0;
@@ -176,6 +163,17 @@ void HandleSaveMenu(bool* should, PlayState* play) {
                     SET_NEXT_GAMESTATE(&play->state, Play_Init, PlayState);
                     gSaveContext.seqId = static_cast<uint8_t>(NA_BGM_DISABLED);
                     gSaveContext.natureAmbienceId = 0xFF;
+                    GameInteractor_ExecuteOnLoadGame(gSaveContext.fileNum);
+                    if (gSaveContext.ship.resetToSpawn) {
+                      if (LINK_IS_CHILD) {
+                        gSaveContext.entranceIndex = Entrance_OverrideNextIndex(ENTR_LINKS_HOUSE_CHILD_SPAWN); // Child Overworld Spawn
+                      } else {
+                        // Adult Overworld Spawn. Normally 0x5F4 (ENTR_TEMPLE_OF_TIME_WARP_PAD), but 0x282
+                        // (ENTR_HYRULE_FIELD_10) has been repurposed to differentiate from Prelude which also uses 0x5F4
+                        gSaveContext.entranceIndex = Entrance_OverrideNextIndex(ENTR_HYRULE_FIELD_10);
+                      }
+                      gSaveContext.ship.resetToSpawn = 0;
+                    }
                 }
             }
             break;


### PR DESCRIPTION
Added in running the OnExitGame and OnLoadGame hooks. Running these hooks fixes some interactions this menu had on the Check Tracker and the Available Checks system. OnLoadGame overwrote the menu's changes to the next entrance override which were needed for Return to Spawn to work correctly, so I needed to add a new gSaveContext flag for it so that the menu code can set the spawn entrance after all the other entrance overriding code has executed. This also allows any future changes to `Entrance_SetSavewarpEntrance` to take effect when using this menu.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8608913874.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8608816845.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8608812152.zip)
<!--- section:artifacts:end -->