### PR TITLE
Hookify Skeleton Unregisters

### DIFF
--- a/soh/include/z64actor_enum.h
+++ b/soh/include/z64actor_enum.h
@@ -12,6 +12,14 @@ enum ActorID {
     /* 0x0192 */ ACTOR_ID_MAX // originally "ACTOR_DLF_MAX"
 };
 
+// Actors added by Ship. They start past ACTOR_ID_MAX so it keeps working as the vanilla bound and as
+// the "no actor" sentinel (see location_list.cpp). ActorDB hands out ids from ACTOR_ID_EXTRA_MAX up
+// to anything registering dynamically at runtime.
+enum ActorIDExtra {
+    /* 0x0193 */ ACTOR_EN_PARTNER = ACTOR_ID_MAX + 1,
+    ACTOR_ID_EXTRA_MAX
+};
+
 #undef DEFINE_ACTOR
 #undef DEFINE_ACTOR_INTERNAL
 #undef DEFINE_ACTOR_UNSET

--- a/soh/soh/ActorDB.cpp
+++ b/soh/soh/ActorDB.cpp
@@ -514,10 +514,10 @@ ActorDB::Entry& ActorDB::AddEntry(const std::string& name, const std::string& de
     return entry;
 }
 
-// Adds an actor with the new ActorDBInit struct. The id assigned to the actor is dynamic. Use the return Entry or
+// Adds an actor with the new ActorDBInit struct. Leaving init.id unset assigns a dynamic id, use the returned Entry or
 // RetrieveId to get it.
 ActorDB::Entry& ActorDB::AddEntry(const ActorDBInit& init) {
-    Entry& entry = AddEntry(init.name, init.desc, nextFreeId);
+    Entry& entry = AddEntry(init.name, init.desc, init.id < 0 ? nextFreeId : (size_t)init.id);
 
     entry.entry.category = init.category;
     entry.entry.flags = init.flags;

--- a/soh/soh/ActorDB.h
+++ b/soh/soh/ActorDB.h
@@ -27,6 +27,7 @@ typedef struct {
 struct ActorDBInit {
     std::string name;
     std::string desc;
+    int id = -1; // -1 assigns the next free id, otherwise an ActorIDExtra
     int category = 0;
     u32 flags = 0;
     int objectId = 0;
@@ -70,7 +71,7 @@ class ActorDB {
 
     std::vector<Entry> db;
     std::unordered_map<std::string, int> nameTable;
-    size_t nextFreeId = 0;
+    size_t nextFreeId = ACTOR_ID_EXTRA_MAX;
 };
 
 #else

--- a/soh/soh/Enhancements/ActorSkeletonUnregister.c
+++ b/soh/soh/Enhancements/ActorSkeletonUnregister.c
@@ -1,0 +1,517 @@
+#include <stddef.h>
+#include <stdint.h>
+
+#include "soh/ResourceManagerHelpers.h"
+
+#include "z64.h"
+#include "include/z64player.h"
+#include "src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.h"
+#include "src/overlays/actors/ovl_Boss_Sst/z_boss_sst.h"
+#include "src/overlays/actors/ovl_Demo_Ik/z_demo_ik.h"
+#include "src/overlays/actors/ovl_Demo_Im/z_demo_im.h"
+#include "src/overlays/actors/ovl_Door_Warp1/z_door_warp1.h"
+#include "src/overlays/actors/ovl_Door_Killer/z_door_killer.h"
+#include "src/overlays/actors/ovl_En_Am/z_en_am.h"
+#include "src/overlays/actors/ovl_En_Ani/z_en_ani.h"
+#include "src/overlays/actors/ovl_En_Anubice/z_en_anubice.h"
+#include "src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.h"
+#include "src/overlays/actors/ovl_En_Bb/z_en_bb.h"
+#include "src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h"
+#include "src/overlays/actors/ovl_En_Bili/z_en_bili.h"
+#include "src/overlays/actors/ovl_En_Bird/z_en_bird.h"
+#include "src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.h"
+#include "src/overlays/actors/ovl_En_Brob/z_en_brob.h"
+#include "src/overlays/actors/ovl_En_Butte/z_en_butte.h"
+#include "src/overlays/actors/ovl_En_Bw/z_en_bw.h"
+#include "src/overlays/actors/ovl_En_Cow/z_en_cow.h"
+#include "src/overlays/actors/ovl_En_Crow/z_en_crow.h"
+#include "src/overlays/actors/ovl_En_Cs/z_en_cs.h"
+#include "src/overlays/actors/ovl_En_Daiku/z_en_daiku.h"
+#include "src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.h"
+#include "src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.h"
+#include "src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.h"
+#include "src/overlays/actors/ovl_En_Dh/z_en_dh.h"
+#include "src/overlays/actors/ovl_En_Dha/z_en_dha.h"
+#include "src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.h"
+#include "src/overlays/actors/ovl_En_Dns/z_en_dns.h"
+#include "src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.h"
+#include "src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.h"
+#include "src/overlays/actors/ovl_En_Dodojr/z_en_dodojr.h"
+#include "src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.h"
+#include "src/overlays/actors/ovl_En_Dog/z_en_dog.h"
+#include "src/overlays/actors/ovl_En_Door/z_en_door.h"
+#include "src/overlays/actors/ovl_En_Ds/z_en_ds.h"
+#include "src/overlays/actors/ovl_En_Eiyer/z_en_eiyer.h"
+#include "src/overlays/actors/ovl_En_Elf/z_en_elf.h"
+#include "src/overlays/actors/ovl_En_Fd/z_en_fd.h"
+#include "src/overlays/actors/ovl_En_Firefly/z_en_firefly.h"
+#include "src/overlays/actors/ovl_En_Fish/z_en_fish.h"
+#include "src/overlays/actors/ovl_En_Floormas/z_en_floormas.h"
+#include "src/overlays/actors/ovl_En_Fr/z_en_fr.h"
+#include "src/overlays/actors/ovl_En_Fu/z_en_fu.h"
+#include "src/overlays/actors/ovl_En_Fw/z_en_fw.h"
+#include "src/overlays/actors/ovl_En_Gb/z_en_gb.h"
+#include "src/overlays/actors/ovl_En_Ge1/z_en_ge1.h"
+#include "src/overlays/actors/ovl_En_Ge2/z_en_ge2.h"
+#include "src/overlays/actors/ovl_En_Ge3/z_en_ge3.h"
+#include "src/overlays/actors/ovl_En_GeldB/z_en_geldb.h"
+#include "src/overlays/actors/ovl_En_Gm/z_en_gm.h"
+#include "src/overlays/actors/ovl_En_Go2/z_en_go2.h"
+#include "src/overlays/actors/ovl_En_Goma/z_en_goma.h"
+#include "src/overlays/actors/ovl_En_Guest/z_en_guest.h"
+#include "src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.h"
+#include "src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.h"
+#include "src/overlays/actors/ovl_En_Heishi3/z_en_heishi3.h"
+#include "src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.h"
+#include "src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.h"
+#include "src/overlays/actors/ovl_En_Hs/z_en_hs.h"
+#include "src/overlays/actors/ovl_En_Hs2/z_en_hs2.h"
+#include "src/overlays/actors/ovl_En_Hy/z_en_hy.h"
+#include "src/overlays/actors/ovl_En_Ik/z_en_ik.h"
+#include "src/overlays/actors/ovl_En_In/z_en_in.h"
+#include "src/overlays/actors/ovl_En_Insect/z_en_insect.h"
+#include "src/overlays/actors/ovl_En_Jj/z_en_jj.h"
+#include "src/overlays/actors/ovl_En_Js/z_en_js.h"
+#include "src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.h"
+#include "src/overlays/actors/ovl_En_Ko/z_en_ko.h"
+#include "src/overlays/actors/ovl_En_Kz/z_en_kz.h"
+#include "src/overlays/actors/ovl_En_Mb/z_en_mb.h"
+#include "src/overlays/actors/ovl_En_Md/z_en_md.h"
+#include "src/overlays/actors/ovl_En_Mk/z_en_mk.h"
+#include "src/overlays/actors/ovl_En_Mm/z_en_mm.h"
+#include "src/overlays/actors/ovl_En_Mm2/z_en_mm2.h"
+#include "src/overlays/actors/ovl_En_Ms/z_en_ms.h"
+#include "src/overlays/actors/ovl_En_Nb/z_en_nb.h"
+#include "src/overlays/actors/ovl_En_Niw/z_en_niw.h"
+#include "src/overlays/actors/ovl_En_Niw_Girl/z_en_niw_girl.h"
+#include "src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.h"
+#include "src/overlays/actors/ovl_En_Okuta/z_en_okuta.h"
+#include "src/overlays/actors/ovl_En_Owl/z_en_owl.h"
+#include "src/overlays/actors/ovl_En_Peehat/z_en_peehat.h"
+#include "src/overlays/actors/ovl_En_Po_Desert/z_en_po_desert.h"
+#include "src/overlays/actors/ovl_En_Po_Field/z_en_po_field.h"
+#include "src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.h"
+#include "src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.h"
+#include "src/overlays/actors/ovl_En_Poh/z_en_poh.h"
+#include "src/overlays/actors/ovl_En_Rd/z_en_rd.h"
+#include "src/overlays/actors/ovl_En_Reeba/z_en_reeba.h"
+#include "src/overlays/actors/ovl_En_Ru1/z_en_ru1.h"
+#include "src/overlays/actors/ovl_En_Ru2/z_en_ru2.h"
+#include "src/overlays/actors/ovl_En_Sa/z_en_sa.h"
+#include "src/overlays/actors/ovl_En_Shopnuts/z_en_shopnuts.h"
+#include "src/overlays/actors/ovl_En_Skb/z_en_skb.h"
+#include "src/overlays/actors/ovl_En_Skj/z_en_skj.h"
+#include "src/overlays/actors/ovl_En_Ssh/z_en_ssh.h"
+#include "src/overlays/actors/ovl_En_St/z_en_st.h"
+#include "src/overlays/actors/ovl_En_Sth/z_en_sth.h"
+#include "src/overlays/actors/ovl_En_Sw/z_en_sw.h"
+#include "src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.h"
+#include "src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.h"
+#include "src/overlays/actors/ovl_En_Ta/z_en_ta.h"
+#include "src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.h"
+#include "src/overlays/actors/ovl_En_Test/z_en_test.h"
+#include "src/overlays/actors/ovl_En_Tite/z_en_tite.h"
+#include "src/overlays/actors/ovl_En_Tk/z_en_tk.h"
+#include "src/overlays/actors/ovl_En_Torch2/z_en_torch2.h"
+#include "src/overlays/actors/ovl_En_Toryo/z_en_toryo.h"
+#include "src/overlays/actors/ovl_En_Tr/z_en_tr.h"
+#include "src/overlays/actors/ovl_En_Vali/z_en_vali.h"
+#include "src/overlays/actors/ovl_En_Vm/z_en_vm.h"
+#include "src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.h"
+#include "src/overlays/actors/ovl_En_Weiyer/z_en_weiyer.h"
+#include "src/overlays/actors/ovl_En_Wf/z_en_wf.h"
+#include "src/overlays/actors/ovl_En_Xc/z_en_xc.h"
+#include "src/overlays/actors/ovl_En_Zf/z_en_zf.h"
+#include "src/overlays/actors/ovl_En_Zl3/z_en_zl3.h"
+#include "src/overlays/actors/ovl_En_Zl4/z_en_zl4.h"
+#include "src/overlays/actors/ovl_En_Zo/z_en_zo.h"
+
+#define UNREGISTER_SKEL(type, field) \
+    ResourceMgr_UnregisterSkeleton((SkelAnime*)((uintptr_t)(actor) + offsetof(type, field)))
+
+void UnregisterActorSkeletons(Actor* actor) {
+    switch (actor->id) {
+        case ACTOR_BG_DY_YOSEIZO:
+            UNREGISTER_SKEL(BgDyYoseizo, skelAnime);
+            break;
+        case ACTOR_BOSS_SST:
+            UNREGISTER_SKEL(BossSst, skelAnime);
+            break;
+        case ACTOR_DEMO_IK:
+            UNREGISTER_SKEL(DemoIk, skelAnime);
+            break;
+        case ACTOR_DEMO_IM:
+            UNREGISTER_SKEL(DemoIm, skelAnime);
+            break;
+        case ACTOR_DOOR_WARP1: {
+            DoorWarp1* doorWarp = (DoorWarp1*)actor;
+            switch (doorWarp->actor.params) {
+                case WARP_DUNGEON_ADULT:
+                case WARP_BLUE_CRYSTAL:
+                case WARP_PURPLE_CRYSTAL:
+                    SkelAnime_Free(&doorWarp->skelAnime, gPlayState);
+                    break;
+                default:
+                    break;
+            }
+            break;
+        }
+        case ACTOR_DOOR_KILLER:
+            UNREGISTER_SKEL(DoorKiller, skelAnime);
+            break;
+        case ACTOR_EN_AM:
+            UNREGISTER_SKEL(EnAm, skelAnime);
+            break;
+        case ACTOR_EN_ANI:
+            UNREGISTER_SKEL(EnAni, skelAnime);
+            break;
+        case ACTOR_EN_ANUBICE:
+            UNREGISTER_SKEL(EnAnubice, skelAnime);
+            break;
+        case ACTOR_EN_ATTACK_NIW:
+            UNREGISTER_SKEL(EnAttackNiw, skelAnime);
+            break;
+        case ACTOR_EN_BB:
+            UNREGISTER_SKEL(EnBb, skelAnime);
+            break;
+        case ACTOR_EN_BIGOKUTA:
+            UNREGISTER_SKEL(EnBigokuta, skelAnime);
+            break;
+        case ACTOR_EN_BILI:
+            UNREGISTER_SKEL(EnBili, skelAnime);
+            break;
+        case ACTOR_EN_BIRD:
+            SkelAnime_Free(&((EnBird*)actor)->skelAnime, gPlayState);
+            break;
+        case ACTOR_EN_BOM_BOWL_MAN:
+            UNREGISTER_SKEL(EnBomBowlMan, skelAnime);
+            break;
+        case ACTOR_EN_BROB:
+            UNREGISTER_SKEL(EnBrob, skelAnime);
+            break;
+        case ACTOR_EN_BUTTE:
+            UNREGISTER_SKEL(EnButte, skelAnime);
+            break;
+        case ACTOR_EN_BW:
+            UNREGISTER_SKEL(EnBw, skelAnime);
+            break;
+        case ACTOR_EN_COW:
+            UNREGISTER_SKEL(EnCow, skelAnime);
+            break;
+        case ACTOR_EN_CROW:
+            UNREGISTER_SKEL(EnCrow, skelAnime);
+            break;
+        case ACTOR_EN_CS:
+            UNREGISTER_SKEL(EnCs, skelAnime);
+            break;
+        case ACTOR_EN_DAIKU:
+            UNREGISTER_SKEL(EnDaiku, skelAnime);
+            break;
+        case ACTOR_EN_DAIKU_KAKARIKO:
+            UNREGISTER_SKEL(EnDaikuKakariko, skelAnime);
+            break;
+        case ACTOR_EN_DEKUBABA:
+            UNREGISTER_SKEL(EnDekubaba, skelAnime);
+            break;
+        case ACTOR_EN_DEKUNUTS:
+            UNREGISTER_SKEL(EnDekunuts, skelAnime);
+            break;
+        case ACTOR_EN_DH:
+            UNREGISTER_SKEL(EnDh, skelAnime);
+            break;
+        case ACTOR_EN_DHA:
+            UNREGISTER_SKEL(EnDha, skelAnime);
+            break;
+        case ACTOR_EN_DIVING_GAME:
+            UNREGISTER_SKEL(EnDivingGame, skelAnime);
+            break;
+        case ACTOR_EN_DNS:
+            UNREGISTER_SKEL(EnDns, skelAnime);
+            break;
+        case ACTOR_EN_DNT_JIJI:
+            UNREGISTER_SKEL(EnDntJiji, skelAnime);
+            break;
+        case ACTOR_EN_DNT_NOMAL:
+            UNREGISTER_SKEL(EnDntNomal, skelAnime);
+            break;
+        case ACTOR_EN_DODOJR:
+            UNREGISTER_SKEL(EnDodojr, skelAnime);
+            break;
+        case ACTOR_EN_DODONGO:
+            UNREGISTER_SKEL(EnDodongo, skelAnime);
+            break;
+        case ACTOR_EN_DOG:
+            UNREGISTER_SKEL(EnDog, skelAnime);
+            break;
+        case ACTOR_EN_DOOR:
+            UNREGISTER_SKEL(EnDoor, skelAnime);
+            break;
+        case ACTOR_EN_DS:
+            UNREGISTER_SKEL(EnDs, skelAnime);
+            break;
+        case ACTOR_EN_EIYER:
+            UNREGISTER_SKEL(EnEiyer, skelanime);
+            break;
+        case ACTOR_EN_ELF:
+            UNREGISTER_SKEL(EnElf, skelAnime);
+            break;
+        case ACTOR_EN_FD:
+            UNREGISTER_SKEL(EnFd, skelAnime);
+            break;
+        case ACTOR_EN_FIREFLY:
+            UNREGISTER_SKEL(EnFirefly, skelAnime);
+            break;
+        case ACTOR_EN_FISH:
+            UNREGISTER_SKEL(EnFish, skelAnime);
+            break;
+        case ACTOR_EN_FLOORMAS:
+            UNREGISTER_SKEL(EnFloormas, skelAnime);
+            break;
+        case ACTOR_EN_FR:
+            UNREGISTER_SKEL(EnFr, skelAnime);
+            UNREGISTER_SKEL(EnFr, skelAnimeButterfly);
+            break;
+        case ACTOR_EN_FU:
+            UNREGISTER_SKEL(EnFu, skelanime);
+            break;
+        case ACTOR_EN_FW:
+            UNREGISTER_SKEL(EnFw, skelAnime);
+            break;
+        case ACTOR_EN_GB:
+            UNREGISTER_SKEL(EnGb, skelAnime);
+            break;
+        case ACTOR_EN_GE1:
+            UNREGISTER_SKEL(EnGe1, skelAnime);
+            break;
+        case ACTOR_EN_GE2:
+            UNREGISTER_SKEL(EnGe2, skelAnime);
+            break;
+        case ACTOR_EN_GE3:
+            UNREGISTER_SKEL(EnGe3, skelAnime);
+            break;
+        case ACTOR_EN_GELDB:
+            UNREGISTER_SKEL(EnGeldB, skelAnime);
+            break;
+        case ACTOR_EN_GM:
+            UNREGISTER_SKEL(EnGm, skelAnime);
+            break;
+        case ACTOR_EN_GO2:
+            UNREGISTER_SKEL(EnGo2, skelAnime);
+            break;
+        case ACTOR_EN_GOMA:
+            UNREGISTER_SKEL(EnGoma, skelanime);
+            break;
+        case ACTOR_EN_GUEST:
+            UNREGISTER_SKEL(EnGuest, skelAnime);
+            break;
+        case ACTOR_EN_HEISHI1:
+            UNREGISTER_SKEL(EnHeishi1, skelAnime);
+            break;
+        case ACTOR_EN_HEISHI2:
+            UNREGISTER_SKEL(EnHeishi2, skelAnime);
+            break;
+        case ACTOR_EN_HEISHI3:
+            UNREGISTER_SKEL(EnHeishi3, skelAnime);
+            break;
+        case ACTOR_EN_HEISHI4:
+            UNREGISTER_SKEL(EnHeishi4, skelAnime);
+            break;
+        case ACTOR_EN_HINTNUTS:
+            UNREGISTER_SKEL(EnHintnuts, skelAnime);
+            break;
+        case ACTOR_EN_HS:
+            UNREGISTER_SKEL(EnHs, skelAnime);
+            break;
+        case ACTOR_EN_HS2:
+            UNREGISTER_SKEL(EnHs2, skelAnime);
+            break;
+        case ACTOR_EN_HY:
+            UNREGISTER_SKEL(EnHy, skelAnime);
+            break;
+        case ACTOR_EN_IK:
+            UNREGISTER_SKEL(EnIk, skelAnime);
+            break;
+        case ACTOR_EN_IN:
+            UNREGISTER_SKEL(EnIn, skelAnime);
+            break;
+        case ACTOR_EN_INSECT:
+            UNREGISTER_SKEL(EnInsect, skelAnime);
+            break;
+        case ACTOR_EN_JJ:
+            UNREGISTER_SKEL(EnJj, skelAnime);
+            break;
+        case ACTOR_EN_JS:
+            UNREGISTER_SKEL(EnJs, skelAnime);
+            break;
+        case ACTOR_EN_KAREBABA:
+            UNREGISTER_SKEL(EnKarebaba, skelAnime);
+            break;
+        case ACTOR_EN_KO:
+            UNREGISTER_SKEL(EnKo, skelAnime);
+            break;
+        case ACTOR_EN_KZ:
+            UNREGISTER_SKEL(EnKz, skelanime);
+            break;
+        case ACTOR_EN_MB:
+            UNREGISTER_SKEL(EnMb, skelAnime);
+            break;
+        case ACTOR_EN_MD:
+            UNREGISTER_SKEL(EnMd, skelAnime);
+            break;
+        case ACTOR_EN_MK:
+            UNREGISTER_SKEL(EnMk, skelAnime);
+            break;
+        case ACTOR_EN_MM:
+            UNREGISTER_SKEL(EnMm, skelAnime);
+            break;
+        case ACTOR_EN_MM2:
+            UNREGISTER_SKEL(EnMm2, skelAnime);
+            break;
+        case ACTOR_EN_MS:
+            UNREGISTER_SKEL(EnMs, skelAnime);
+            break;
+        case ACTOR_EN_NB:
+            UNREGISTER_SKEL(EnNb, skelAnime);
+            break;
+        case ACTOR_EN_NIW:
+            UNREGISTER_SKEL(EnNiw, skelAnime);
+            break;
+        case ACTOR_EN_NIW_GIRL:
+            UNREGISTER_SKEL(EnNiwGirl, skelAnime);
+            break;
+        case ACTOR_EN_NIW_LADY:
+            UNREGISTER_SKEL(EnNiwLady, skelAnime);
+            break;
+        case ACTOR_EN_OKUTA:
+            if (actor->params == 0) {
+                UNREGISTER_SKEL(EnOkuta, skelAnime);
+            }
+            break;
+        case ACTOR_EN_OWL:
+            UNREGISTER_SKEL(EnOwl, skelAnime);
+            UNREGISTER_SKEL(EnOwl, skelAnime2);
+            break;
+        case ACTOR_EN_PEEHAT:
+            UNREGISTER_SKEL(EnPeehat, skelAnime);
+            break;
+        case ACTOR_EN_PO_DESERT:
+            UNREGISTER_SKEL(EnPoDesert, skelAnime);
+            break;
+        case ACTOR_EN_PO_FIELD:
+            UNREGISTER_SKEL(EnPoField, skelAnime);
+            break;
+        case ACTOR_EN_PO_RELAY:
+            UNREGISTER_SKEL(EnPoRelay, skelAnime);
+            break;
+        case ACTOR_EN_PO_SISTERS:
+            UNREGISTER_SKEL(EnPoSisters, skelAnime);
+            break;
+        case ACTOR_EN_POH:
+            UNREGISTER_SKEL(EnPoh, skelAnime);
+            break;
+        case ACTOR_EN_RD:
+            UNREGISTER_SKEL(EnRd, skelAnime);
+            break;
+        case ACTOR_EN_REEBA:
+            UNREGISTER_SKEL(EnReeba, skelanime);
+            break;
+        case ACTOR_EN_RU1:
+            UNREGISTER_SKEL(EnRu1, skelAnime);
+            break;
+        case ACTOR_EN_RU2:
+            UNREGISTER_SKEL(EnRu2, skelAnime);
+            break;
+        case ACTOR_EN_SA:
+            UNREGISTER_SKEL(EnSa, skelAnime);
+            break;
+        case ACTOR_EN_SHOPNUTS:
+            UNREGISTER_SKEL(EnShopnuts, skelAnime);
+            break;
+        case ACTOR_EN_SKB:
+            UNREGISTER_SKEL(EnSkb, skelAnime);
+            break;
+        case ACTOR_EN_SKJ:
+            UNREGISTER_SKEL(EnSkj, skelAnime);
+            break;
+        case ACTOR_EN_SSH:
+            UNREGISTER_SKEL(EnSsh, skelAnime);
+            break;
+        case ACTOR_EN_ST:
+            UNREGISTER_SKEL(EnSt, skelAnime);
+            break;
+        case ACTOR_EN_STH:
+            UNREGISTER_SKEL(EnSth, skelAnime);
+            break;
+        case ACTOR_EN_SW:
+            UNREGISTER_SKEL(EnSw, skelAnime);
+            break;
+        case ACTOR_EN_SYATEKI_MAN:
+            UNREGISTER_SKEL(EnSyatekiMan, skelAnime);
+            break;
+        case ACTOR_EN_SYATEKI_NIW:
+            UNREGISTER_SKEL(EnSyatekiNiw, skelAnime);
+            break;
+        case ACTOR_EN_TA:
+            UNREGISTER_SKEL(EnTa, skelAnime);
+            break;
+        case ACTOR_EN_TAKARA_MAN:
+            UNREGISTER_SKEL(EnTakaraMan, skelAnime);
+            break;
+        case ACTOR_EN_TEST:
+            UNREGISTER_SKEL(EnTest, skelAnime);
+            UNREGISTER_SKEL(EnTest, upperSkelanime);
+            break;
+        case ACTOR_EN_TITE:
+            UNREGISTER_SKEL(EnTite, skelAnime);
+            break;
+        case ACTOR_EN_TK:
+            UNREGISTER_SKEL(EnTk, skelAnime);
+            break;
+        case ACTOR_EN_TORCH2:
+            UNREGISTER_SKEL(Player, skelAnime);
+            UNREGISTER_SKEL(Player, upperSkelAnime);
+            break;
+        case ACTOR_EN_TORYO:
+            UNREGISTER_SKEL(EnToryo, skelAnime);
+            break;
+        case ACTOR_EN_TR:
+            UNREGISTER_SKEL(EnTr, skelAnime);
+            break;
+        case ACTOR_EN_VALI:
+            UNREGISTER_SKEL(EnVali, skelAnime);
+            break;
+        case ACTOR_EN_VM:
+            UNREGISTER_SKEL(EnVm, skelAnime);
+            break;
+        case ACTOR_EN_WALLMAS:
+            UNREGISTER_SKEL(EnWallmas, skelAnime);
+            break;
+        case ACTOR_EN_WEIYER:
+            UNREGISTER_SKEL(EnWeiyer, skelAnime);
+            break;
+        case ACTOR_EN_WF:
+            UNREGISTER_SKEL(EnWf, skelAnime);
+            break;
+        case ACTOR_EN_XC:
+            UNREGISTER_SKEL(EnXc, skelAnime);
+            break;
+        case ACTOR_EN_ZF:
+            UNREGISTER_SKEL(EnZf, skelAnime);
+            break;
+        case ACTOR_EN_ZL3:
+            UNREGISTER_SKEL(EnZl3, skelAnime);
+            break;
+        case ACTOR_EN_ZL4:
+            UNREGISTER_SKEL(EnZl4, skelAnime);
+            break;
+        case ACTOR_EN_ZO:
+            UNREGISTER_SKEL(EnZo, skelAnime);
+            break;
+        case ACTOR_PLAYER:
+            UNREGISTER_SKEL(Player, skelAnime);
+            UNREGISTER_SKEL(Player, upperSkelAnime);
+            break;
+        default:
+            break;
+    }
+}

--- a/soh/soh/Enhancements/ActorSkeletonUnregister.c
+++ b/soh/soh/Enhancements/ActorSkeletonUnregister.c
@@ -20,6 +20,7 @@
 #include "src/overlays/actors/ovl_En_Bili/z_en_bili.h"
 #include "src/overlays/actors/ovl_En_Bird/z_en_bird.h"
 #include "src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.h"
+#include "src/overlays/actors/ovl_En_Box/z_en_box.h"
 #include "src/overlays/actors/ovl_En_Brob/z_en_brob.h"
 #include "src/overlays/actors/ovl_En_Butte/z_en_butte.h"
 #include "src/overlays/actors/ovl_En_Bw/z_en_bw.h"
@@ -87,6 +88,7 @@
 #include "src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.h"
 #include "src/overlays/actors/ovl_En_Okuta/z_en_okuta.h"
 #include "src/overlays/actors/ovl_En_Owl/z_en_owl.h"
+#include "src/overlays/actors/ovl_En_Partner/z_en_partner.h"
 #include "src/overlays/actors/ovl_En_Peehat/z_en_peehat.h"
 #include "src/overlays/actors/ovl_En_Po_Desert/z_en_po_desert.h"
 #include "src/overlays/actors/ovl_En_Po_Field/z_en_po_field.h"
@@ -126,6 +128,9 @@
 #include "src/overlays/actors/ovl_En_Zl4/z_en_zl4.h"
 #include "src/overlays/actors/ovl_En_Zo/z_en_zo.h"
 
+// Use SkelAnime_Free only for the actors that pass NULL joint/morph tables to SkelAnime_Init, so the
+// tables really are arena allocations. Everything else keeps its tables inside the actor struct, and
+// freeing those interior pointers corrupts the zelda arena. Those actors want UNREGISTER_SKEL.
 #define UNREGISTER_SKEL(type, field) \
     ResourceMgr_UnregisterSkeleton((SkelAnime*)((uintptr_t)(actor) + offsetof(type, field)))
 
@@ -185,6 +190,9 @@ void UnregisterActorSkeletons(Actor* actor) {
             break;
         case ACTOR_EN_BOM_BOWL_MAN:
             UNREGISTER_SKEL(EnBomBowlMan, skelAnime);
+            break;
+        case ACTOR_EN_BOX:
+            UNREGISTER_SKEL(EnBox, skelanime);
             break;
         case ACTOR_EN_BROB:
             UNREGISTER_SKEL(EnBrob, skelAnime);
@@ -390,6 +398,9 @@ void UnregisterActorSkeletons(Actor* actor) {
         case ACTOR_EN_OWL:
             UNREGISTER_SKEL(EnOwl, skelAnime);
             UNREGISTER_SKEL(EnOwl, skelAnime2);
+            break;
+        case ACTOR_EN_PARTNER:
+            UNREGISTER_SKEL(EnPartner, skelAnime);
             break;
         case ACTOR_EN_PEEHAT:
             UNREGISTER_SKEL(EnPeehat, skelAnime);

--- a/soh/soh/Enhancements/AlwaysOnFixes.cpp
+++ b/soh/soh/Enhancements/AlwaysOnFixes.cpp
@@ -98,8 +98,10 @@ void RegisterAlwaysOnFixes() {
         }
     });
 
-    COND_HOOK(OnActorDestroy, true,
-              [](void* refActor) { UnregisterActorSkeletons(reinterpret_cast<Actor*>(refActor)); });
+    // ShouldActorDestroy rather than OnActorDestroy: the latter only fires from Actor_Delete, but
+    // Actor_UpdateAll and func_80031B14 both run Actor_Destroy without deleting.
+    COND_HOOK(ShouldActorDestroy, true,
+              [](void* refActor, bool* result) { UnregisterActorSkeletons(reinterpret_cast<Actor*>(refActor)); });
 
     COND_ID_HOOK(OnActorDestroy, ACTOR_EN_TEST, true, [](void* refActor) {
         Actor* actor = reinterpret_cast<Actor*>(refActor);

--- a/soh/soh/Enhancements/AlwaysOnFixes.cpp
+++ b/soh/soh/Enhancements/AlwaysOnFixes.cpp
@@ -8,6 +8,7 @@ extern "C" {
 #include "include/z64camera.h"
 #include "src/overlays/actors/ovl_En_Test/z_en_test.h"
 #include "src/overlays/actors/ovl_En_Horse/z_en_horse.h"
+void UnregisterActorSkeletons(struct Actor* actor);
 extern void Player_UseItem(PlayState*, Player*, s32);
 extern PlayState* gPlayState;
 }
@@ -96,6 +97,9 @@ void RegisterAlwaysOnFixes() {
             *should = true;
         }
     });
+
+    COND_HOOK(OnActorDestroy, true,
+              [](void* refActor) { UnregisterActorSkeletons(reinterpret_cast<Actor*>(refActor)); });
 
     COND_ID_HOOK(OnActorDestroy, ACTOR_EN_TEST, true, [](void* refActor) {
         Actor* actor = reinterpret_cast<Actor*>(refActor);

--- a/soh/soh/Enhancements/ExtraModes/IvanCoop.cpp
+++ b/soh/soh/Enhancements/ExtraModes/IvanCoop.cpp
@@ -12,13 +12,14 @@ extern PlayState* gPlayState;
 #define CVAR_NAME CVAR_ENHANCEMENT("IvanCoopModeEnabled")
 #define CVAR_VALUE CVarGetInteger(CVAR_NAME, 0)
 
-static s16 ivanActorId = -1;
+static bool addedToActorDB = false;
 
 static void AddToActorDB() {
-    if (ivanActorId == -1) {
+    if (!addedToActorDB) {
         ActorDBInit entry = {
             "En_Partner",
             "Ivan",
+            ACTOR_EN_PARTNER,
             ACTORCAT_ITEMACTION,
             (ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_DRAW_CULLING_DISABLED | ACTOR_FLAG_HOOKSHOT_PULLS_PLAYER |
              ACTOR_FLAG_CAN_PRESS_SWITCHES),
@@ -30,14 +31,13 @@ static void AddToActorDB() {
             (ActorFunc)EnPartner_Draw,
             nullptr,
         };
-        ivanActorId = ActorDB::Instance->AddEntry(entry).entry.id;
+        ActorDB::Instance->AddEntry(entry);
+        addedToActorDB = true;
     }
 }
 
 static Actor* FindIvan(ActorContext* actorCtx) {
-    if (ivanActorId == -1)
-        return nullptr;
-    return Actor_Find(actorCtx, ivanActorId, ACTORCAT_ITEMACTION);
+    return Actor_Find(actorCtx, ACTOR_EN_PARTNER, ACTORCAT_ITEMACTION);
 }
 
 static void SpawnIvan() {
@@ -54,7 +54,7 @@ static void SpawnIvan() {
     AddToActorDB();
 
     PosRot& world = player->actor.world;
-    Actor_Spawn(&gPlayState->actorCtx, gPlayState, ivanActorId, world.pos.x,
+    Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_PARTNER, world.pos.x,
                 world.pos.y + Player_GetHeight(player) + 5.0f, world.pos.z, 0, world.rot.y, 0, 1);
 }
 

--- a/soh/soh/Enhancements/debugger/actorViewer.cpp
+++ b/soh/soh/Enhancements/debugger/actorViewer.cpp
@@ -797,6 +797,9 @@ std::vector<u16> GetActorsWithDescriptionContainingString(std::string s) {
     std::vector<u16> actors;
     for (int i = 0; i < ActorDB::Instance->GetEntryCount(); i += 1) {
         ActorDB::Entry actorEntry = ActorDB::Instance->RetrieveEntry(i);
+        if (!actorEntry.entry.valid) {
+            continue;
+        }
         std::string desc = actorEntry.desc;
         for (size_t j = 0; j < desc.length(); j += 1) {
             desc[j] = std::tolower(desc[j], loc);
@@ -1161,8 +1164,7 @@ void ActorViewerWindow::DrawElement() {
             if (Button("Spawn as Child", ButtonOptions().Color(THEME_COLOR))) {
                 Actor* parent = display;
                 if (parent != NULL) {
-                    if (newActor.id >= 0 && newActor.id < ACTOR_ID_MAX &&
-                        ActorDB::Instance->RetrieveEntry(newActor.id).entry.valid) {
+                    if (ActorDB::Instance->RetrieveEntry(newActor.id).entry.valid) {
                         Actor_SpawnAsChild(&gPlayState->actorCtx, parent, gPlayState, newActor.id, newActor.pos.x,
                                            newActor.pos.y, newActor.pos.z, newActor.rot.x, newActor.rot.y,
                                            newActor.rot.z, newActor.params);

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_HookTable.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_HookTable.h
@@ -38,6 +38,7 @@ DEFINE_HOOK(OnActorSpawn, (void* actor));
 DEFINE_HOOK(ShouldActorUpdate, (void* actor, bool* result));
 DEFINE_HOOK(OnActorUpdate, (void* actor));
 DEFINE_HOOK(OnActorKill, (void* actor));
+DEFINE_HOOK(ShouldActorDestroy, (void* actor, bool* result));
 DEFINE_HOOK(OnActorDestroy, (void* actor));
 DEFINE_HOOK(OnEnemyDefeat, (void* actor));
 DEFINE_HOOK(OnBossDefeat, (void* actor));

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
@@ -172,6 +172,16 @@ void GameInteractor_ExecuteOnActorKill(void* actor) {
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnActorKill>(actor);
 }
 
+bool GameInteractor_ShouldActorDestroy(void* actor) {
+    bool result = true;
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::ShouldActorDestroy>(actor, &result);
+    GameInteractor::Instance->ExecuteHooksForID<GameInteractor::ShouldActorDestroy>(((Actor*)actor)->id, actor,
+                                                                                    &result);
+    GameInteractor::Instance->ExecuteHooksForPtr<GameInteractor::ShouldActorDestroy>((uintptr_t)actor, actor, &result);
+    GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::ShouldActorDestroy>(actor, &result);
+    return result;
+}
+
 void GameInteractor_ExecuteOnActorDestroy(void* actor) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnActorDestroy>(actor);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnActorDestroy>(((Actor*)actor)->id, actor);

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
@@ -38,6 +38,7 @@ void GameInteractor_ExecuteOnActorSpawn(void* actor);
 bool GameInteractor_ShouldActorUpdate(void* actor);
 void GameInteractor_ExecuteOnActorUpdate(void* actor);
 void GameInteractor_ExecuteOnActorKill(void* actor);
+bool GameInteractor_ShouldActorDestroy(void* actor);
 void GameInteractor_ExecuteOnActorDestroy(void* actor);
 void GameInteractor_ExecuteOnEnemyDefeat(void* actor);
 void GameInteractor_ExecuteOnBossDefeat(void* actor);

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -1270,7 +1270,9 @@ void Actor_Init(Actor* actor, PlayState* play) {
 
 void Actor_Destroy(Actor* actor, PlayState* play) {
     if (actor->destroy != NULL) {
-        actor->destroy(actor, play);
+        if (GameInteractor_ShouldActorDestroy(actor)) {
+            actor->destroy(actor, play);
+        }
         actor->destroy = NULL;
     } else {
         // "No Actor class destruct [%s]"

--- a/soh/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
+++ b/soh/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
@@ -97,7 +97,7 @@ void BgDyYoseizo_Init(Actor* thisx, PlayState* play2) {
     this->actionFunc = BgDyYoseizo_CheckMagicAcquired;
 }
 
-void BgDyYoseizo_Destroy(Actor* this, PlayState* play) {
+void BgDyYoseizo_Destroy(Actor* thisx, PlayState* play) {
 }
 
 static Color_RGB8 sParticlePrimColors[] = {

--- a/soh/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
+++ b/soh/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
@@ -11,7 +11,6 @@
 #include "scenes/indoors/yousei_izumi_yoko/yousei_izumi_yoko_scene.h"
 #include "scenes/indoors/daiyousei_izumi/daiyousei_izumi_scene.h"
 #include "soh/frame_interpolation.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_DRAW_CULLING_DISABLED | ACTOR_FLAG_UPDATE_DURING_OCARINA)
@@ -98,9 +97,7 @@ void BgDyYoseizo_Init(Actor* thisx, PlayState* play2) {
     this->actionFunc = BgDyYoseizo_CheckMagicAcquired;
 }
 
-void BgDyYoseizo_Destroy(Actor* thisx, PlayState* play) {
-    BgDyYoseizo* this = (BgDyYoseizo*)thisx;
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
+void BgDyYoseizo_Destroy(Actor* this, PlayState* play) {
 }
 
 static Color_RGB8 sParticlePrimColors[] = {

--- a/soh/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/soh/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -11,7 +11,6 @@
 #include "overlays/actors/ovl_Bg_Sst_Floor/z_bg_sst_floor.h"
 #include "overlays/actors/ovl_Door_Warp1/z_door_warp1.h"
 #include "soh/frame_interpolation.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/Enhancements/savestate_serialize.h"
@@ -366,8 +365,6 @@ void BossSst_Destroy(Actor* thisx, PlayState* play) {
     Collider_DestroyJntSph(play, &this->colliderJntSph);
     Collider_DestroyCylinder(play, &this->colliderCyl);
     Audio_StopSfxByPos(&this->center);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void BossSst_HeadSetupLurk(BossSst* this) {

--- a/soh/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.c
+++ b/soh/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.c
@@ -1,7 +1,6 @@
 #include "z_demo_ik.h"
 #include "vt.h"
 #include "objects/object_ik/object_ik.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS ACTOR_FLAG_UPDATE_CULLING_DISABLED
 
@@ -25,9 +24,6 @@ void DemoIk_Type1Draw(DemoIk* this, PlayState* play);
 void DemoIk_Type2Draw(DemoIk* this, PlayState* play);
 
 void DemoIk_Destroy(Actor* thisx, PlayState* play) {
-    DemoIk* this = (DemoIk*)thisx;
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void DemoIk_BgCheck(DemoIk* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
+++ b/soh/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
@@ -11,7 +11,6 @@
 #include "objects/object_im/object_im.h"
 #include "vt.h"
 #include "soh/OTRGlobals.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
@@ -1149,8 +1148,6 @@ void DemoIm_Init(Actor* thisx, PlayState* play) {
 void DemoIm_Destroy(Actor* thisx, PlayState* play) {
     DemoIm* this = (DemoIm*)thisx;
     DemoIm_DestroyCollider(thisx, play);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 DemoIm_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s* rot, void* thisx) {

--- a/soh/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
+++ b/soh/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
@@ -11,7 +11,6 @@
 #include "objects/object_haka_door/object_haka_door.h"
 #include "objects/object_door_killer/object_door_killer.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS ACTOR_FLAG_UPDATE_CULLING_DISABLED
 
@@ -205,8 +204,6 @@ void DoorKiller_Destroy(Actor* thisx, PlayState* play) {
     if ((thisx->params & 0xFF) == DOOR_KILLER_DOOR) {
         Collider_DestroyCylinder(play, &this->colliderCylinder);
         Collider_DestroyJntSph(play, &this->colliderJntSph);
-
-        ResourceMgr_UnregisterSkeleton(&this->skelAnime);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
+++ b/soh/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
@@ -100,16 +100,6 @@ void DoorWarp1_Destroy(Actor* thisx, PlayState* play) {
     for (i = 0; i < 3; i++) {
         play->envCtx.adjAmbientColor[i] = play->envCtx.adjFogColor[i] = play->envCtx.adjLight1Color[i] = 0;
     }
-
-    switch (this->actor.params) {
-        case WARP_DUNGEON_ADULT:
-        case WARP_BLUE_CRYSTAL:
-        case WARP_PURPLE_CRYSTAL:
-            SkelAnime_Free(&this->skelAnime, play);
-            break;
-        default:
-            break;
-    }
 }
 
 void DoorWarp1_SetupWarp(DoorWarp1* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Am/z_en_am.c
+++ b/soh/src/overlays/actors/ovl_En_Am/z_en_am.c
@@ -8,7 +8,6 @@
 #include "objects/object_am/object_am.h"
 #include "overlays/actors/ovl_En_Bom/z_en_bom.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS                                                                                 \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | \
@@ -252,8 +251,6 @@ void EnAm_Destroy(Actor* thisx, PlayState* play) {
     Collider_DestroyCylinder(play, &this->hurtCollider);
     Collider_DestroyCylinder(play, &this->blockCollider);
     //! @bug Quad collider is not destroyed (though destroy doesnt really do anything anyway)
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnAm_SpawnEffects(EnAm* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Ani/z_en_ani.c
+++ b/soh/src/overlays/actors/ovl_En_Ani/z_en_ani.c
@@ -6,7 +6,6 @@
 
 #include "z_en_ani.h"
 #include "objects/object_ani/object_ani.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
@@ -97,8 +96,6 @@ void EnAni_Destroy(Actor* thisx, PlayState* play) {
     EnAni* this = (EnAni*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 EnAni_SetText(EnAni* this, PlayState* play, u16 textId) {

--- a/soh/src/overlays/actors/ovl_En_Anubice/z_en_anubice.c
+++ b/soh/src/overlays/actors/ovl_En_Anubice/z_en_anubice.c
@@ -10,7 +10,6 @@
 #include "overlays/actors/ovl_Bg_Hidan_Curtain/z_bg_hidan_curtain.h"
 #include "vt.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -169,8 +168,6 @@ void EnAnubice_Destroy(Actor* thisx, PlayState* play) {
             tag->anubis = NULL;
         }
     }
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnAnubice_FindFlameCircles(EnAnubice* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
+++ b/soh/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
@@ -7,7 +7,6 @@
 #include "z_en_attack_niw.h"
 #include "objects/object_niw/object_niw.h"
 #include "overlays/actors/ovl_En_Niw/z_en_niw.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS ACTOR_FLAG_UPDATE_CULLING_DISABLED
 
@@ -74,8 +73,6 @@ void EnAttackNiw_Destroy(Actor* thisx, PlayState* play) {
             cucco->unk_296--;
         }
     }
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void func_809B5268(EnAttackNiw* this, PlayState* play, s16 arg2) {

--- a/soh/src/overlays/actors/ovl_En_Bb/z_en_bb.c
+++ b/soh/src/overlays/actors/ovl_En_Bb/z_en_bb.c
@@ -8,7 +8,6 @@
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "objects/object_Bb/object_Bb.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS                                                                                 \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | \
@@ -407,8 +406,6 @@ void EnBb_Destroy(Actor* thisx, PlayState* play) {
     EnBb* this = (EnBb*)thisx;
 
     Collider_DestroyJntSph(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnBb_SetupFlameTrail(EnBb* this) {

--- a/soh/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
+++ b/soh/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
@@ -1,7 +1,6 @@
 #include "z_en_bigokuta.h"
 #include "objects/object_bigokuta/object_bigokuta.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS                                                                                 \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | \
@@ -200,8 +199,6 @@ void EnBigokuta_Destroy(Actor* thisx, PlayState* play) {
     for (i = 0; i < ARRAY_COUNT(this->cylinder); i++) {
         Collider_DestroyCylinder(play, &this->cylinder[i]);
     }
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void func_809BCE3C(EnBigokuta* this) {

--- a/soh/src/overlays/actors/ovl_En_Bili/z_en_bili.c
+++ b/soh/src/overlays/actors/ovl_En_Bili/z_en_bili.c
@@ -7,7 +7,6 @@
 #include "z_en_bili.h"
 #include "objects/object_bl/object_bl.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_IGNORE_QUAKE | ACTOR_FLAG_CAN_ATTACH_TO_ARROW)
@@ -139,8 +138,6 @@ void EnBili_Destroy(Actor* thisx, PlayState* play) {
     EnBili* this = (EnBili*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 // Setup Action Functions

--- a/soh/src/overlays/actors/ovl_En_Bird/z_en_bird.c
+++ b/soh/src/overlays/actors/ovl_En_Bird/z_en_bird.c
@@ -62,9 +62,6 @@ void EnBird_Init(Actor* thisx, PlayState* play) {
 }
 
 void EnBird_Destroy(Actor* thisx, PlayState* play) {
-    EnBird* this = (EnBird*)thisx;
-
-    SkelAnime_Free(&this->skelAnime, play);
 }
 
 void EnBird_SetupIdle(EnBird* this, s16 params) {

--- a/soh/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
+++ b/soh/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
@@ -4,7 +4,6 @@
 #include "overlays/actors/ovl_En_Ex_Item/z_en_ex_item.h"
 #include "objects/object_bg/object_bg.h"
 #include "soh/OTRGlobals.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
@@ -95,9 +94,6 @@ void EnBomBowlMan_Init(Actor* thisx, PlayState* play2) {
 }
 
 void EnBomBowlMan_Destroy(Actor* thisx, PlayState* play) {
-    EnBomBowlMan* this = (EnBomBowlMan*)thisx;
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnBomBowMan_SetupWaitAsleep(EnBomBowlMan* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Box/z_en_box.c
+++ b/soh/src/overlays/actors/ovl_En_Box/z_en_box.c
@@ -211,8 +211,6 @@ void EnBox_Destroy(Actor* thisx, PlayState* play) {
     EnBox* this = (EnBox*)thisx;
 
     DynaPoly_DeleteBgActor(play, &play->colCtx.dyna, this->dyna.bgId);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelanime);
 }
 
 void EnBox_RandomDustKinematic(EnBox* this, Vec3f* pos, Vec3f* velocity, Vec3f* accel) {

--- a/soh/src/overlays/actors/ovl_En_Brob/z_en_brob.c
+++ b/soh/src/overlays/actors/ovl_En_Brob/z_en_brob.c
@@ -6,7 +6,6 @@
 
 #include "z_en_brob.h"
 #include "objects/object_brob/object_brob.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE)
 
@@ -103,8 +102,6 @@ void EnBrob_Destroy(Actor* thisx, PlayState* play) {
     DynaPoly_DeleteBgActor(play, &play->colCtx.dyna, this->dyna.bgId);
     Collider_DestroyCylinder(play, &this->colliders[0]);
     Collider_DestroyCylinder(play, &this->colliders[1]);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnBrob_SetupIdle(EnBrob* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Butte/z_en_butte.c
+++ b/soh/src/overlays/actors/ovl_En_Butte/z_en_butte.c
@@ -8,7 +8,6 @@
 #include "overlays/actors/ovl_En_Elf/z_en_elf.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "objects/gameplay_field_keep/gameplay_field_keep.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS 0
@@ -180,8 +179,6 @@ void EnButte_Destroy(Actor* thisx, PlayState* play2) {
     EnButte* this = (EnButte*)thisx;
 
     Collider_DestroyJntSph(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void func_809CD56C(EnButte* this) {

--- a/soh/src/overlays/actors/ovl_En_Bw/z_en_bw.c
+++ b/soh/src/overlays/actors/ovl_En_Bw/z_en_bw.c
@@ -8,7 +8,6 @@
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "objects/object_bw/object_bw.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/savestate_serialize.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
@@ -168,8 +167,6 @@ void EnBw_Destroy(Actor* thisx, PlayState* play) {
 
     Collider_DestroyCylinder(play, &this->collider1);
     Collider_DestroyCylinder(play, &this->collider2);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void func_809CE884(EnBw* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Cow/z_en_cow.c
+++ b/soh/src/overlays/actors/ovl_En_Cow/z_en_cow.c
@@ -6,7 +6,6 @@
 
 #include "z_en_cow.h"
 #include "objects/object_cow/object_cow.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
@@ -157,8 +156,6 @@ void EnCow_Destroy(Actor* thisx, PlayState* play) {
         Collider_DestroyCylinder(play, &this->colliders[0]);
         Collider_DestroyCylinder(play, &this->colliders[1]);
     }
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnCow_UpdateAnimation(EnCow* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Crow/z_en_crow.c
+++ b/soh/src/overlays/actors/ovl_En_Crow/z_en_crow.c
@@ -1,7 +1,6 @@
 #include "z_en_crow.h"
 #include "objects/object_crow/object_crow.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_IGNORE_QUAKE | ACTOR_FLAG_CAN_ATTACH_TO_ARROW)
@@ -127,8 +126,6 @@ void EnCrow_Destroy(Actor* thisx, PlayState* play) {
     EnCrow* this = (EnCrow*)thisx;
 
     Collider_DestroyJntSph(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 // Setup Action functions

--- a/soh/src/overlays/actors/ovl_En_Cs/z_en_cs.c
+++ b/soh/src/overlays/actors/ovl_En_Cs/z_en_cs.c
@@ -1,7 +1,6 @@
 #include "z_en_cs.h"
 #include "objects/object_cs/object_cs.h"
 #include "objects/object_link_child/object_link_child.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
 
@@ -162,8 +161,6 @@ void EnCs_Destroy(Actor* thisx, PlayState* play) {
     EnCs* this = (EnCs*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 EnCs_GetTalkState(EnCs* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Daiku/z_en_daiku.c
+++ b/soh/src/overlays/actors/ovl_En_Daiku/z_en_daiku.c
@@ -2,7 +2,6 @@
 #include "overlays/actors/ovl_En_GeldB/z_en_geldb.h"
 #include "objects/object_daiku/object_daiku.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -220,8 +219,6 @@ void EnDaiku_Destroy(Actor* thisx, PlayState* play) {
     EnDaiku* this = (EnDaiku*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 EnDaiku_UpdateTalking(EnDaiku* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.c
+++ b/soh/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.c
@@ -6,7 +6,6 @@
 
 #include "z_en_daiku_kakariko.h"
 #include "objects/object_daiku/object_daiku.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -208,8 +207,6 @@ void EnDaikuKakariko_Destroy(Actor* thisx, PlayState* play) {
     EnDaikuKakariko* this = (EnDaikuKakariko*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 EnDaikuKakariko_GetTalkState(EnDaikuKakariko* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
+++ b/soh/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
@@ -3,7 +3,6 @@
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "overlays/effects/ovl_Effect_Ss_Hahen/z_eff_ss_hahen.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE)
 
@@ -280,8 +279,6 @@ void EnDekubaba_Destroy(Actor* thisx, PlayState* play) {
     EnDekubaba* this = (EnDekubaba*)thisx;
 
     Collider_DestroyJntSph(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnDekubaba_DisableHitboxes(EnDekubaba* this) {

--- a/soh/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.c
+++ b/soh/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.c
@@ -8,7 +8,6 @@
 #include "overlays/effects/ovl_Effect_Ss_Hahen/z_eff_ss_hahen.h"
 #include "objects/object_dekunuts/object_dekunuts.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE)
 
@@ -138,8 +137,6 @@ void EnDekunuts_Destroy(Actor* thisx, PlayState* play) {
 
     if (this->actor.params != DEKUNUTS_FLOWER) {
         Collider_DestroyCylinder(play, &this->collider);
-
-        ResourceMgr_UnregisterSkeleton(&this->skelAnime);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Dh/z_en_dh.c
+++ b/soh/src/overlays/actors/ovl_En_Dh/z_en_dh.c
@@ -1,7 +1,6 @@
 #include "z_en_dh.h"
 #include "objects/object_dh/object_dh.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS                                                                                 \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | \
@@ -168,8 +167,6 @@ void EnDh_Destroy(Actor* thisx, PlayState* play) {
     func_800F5B58();
     Collider_DestroyCylinder(play, &this->collider1);
     Collider_DestroyJntSph(play, &this->collider2);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnDh_SpawnDebris(PlayState* play, EnDh* this, Vec3f* spawnPos, f32 spread, s32 arg4, f32 accelXZ, f32 scale) {

--- a/soh/src/overlays/actors/ovl_En_Dha/z_en_dha.c
+++ b/soh/src/overlays/actors/ovl_En_Dha/z_en_dha.c
@@ -7,7 +7,6 @@
 #include "z_en_dha.h"
 #include "overlays/actors/ovl_En_Dh/z_en_dh.h"
 #include "objects/object_dh/object_dh.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -178,8 +177,6 @@ void EnDha_Destroy(Actor* thisx, PlayState* play) {
     EnDha* this = (EnDha*)thisx;
 
     Collider_DestroyJntSph(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnDha_SetupWait(EnDha* this) {

--- a/soh/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
+++ b/soh/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
@@ -8,7 +8,6 @@
 #include "overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.h"
 #include "objects/object_zo/object_zo.h"
 #include "vt.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
@@ -110,8 +109,6 @@ void EnDivingGame_Destroy(Actor* thisx, PlayState* play) {
         gSaveContext.timerState = TIMER_STATE_OFF;
     }
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnDivingGame_SpawnRuppy(EnDivingGame* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Dns/z_en_dns.c
+++ b/soh/src/overlays/actors/ovl_En_Dns/z_en_dns.c
@@ -9,7 +9,6 @@
 #include "vt.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/OTRGlobals.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
 
@@ -160,8 +159,6 @@ void EnDns_Destroy(Actor* thisx, PlayState* play) {
     EnDns* this = (EnDns*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnDns_ChangeAnim(EnDns* this, u8 index) {

--- a/soh/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
+++ b/soh/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
@@ -9,7 +9,6 @@
 #include "overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.h"
 #include "overlays/effects/ovl_Effect_Ss_Hahen/z_eff_ss_hahen.h"
 #include "vt.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
@@ -97,8 +96,6 @@ void EnDntJiji_Destroy(Actor* thisx, PlayState* play) {
     EnDntJiji* this = (EnDntJiji*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnDntJiji_SetFlower(EnDntJiji* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
+++ b/soh/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
@@ -12,7 +12,6 @@
 #include "overlays/effects/ovl_Effect_Ss_Hahen/z_eff_ss_hahen.h"
 #include "objects/object_hintnuts/object_hintnuts.h"
 #include "vt.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_DRAW_CULLING_DISABLED)
@@ -169,8 +168,6 @@ void EnDntNomal_Destroy(Actor* thisx, PlayState* play) {
     } else {
         Collider_DestroyCylinder(play, &this->bodyCyl);
     }
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnDntNomal_WaitForObject(EnDntNomal* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Dodojr/z_en_dodojr.c
+++ b/soh/src/overlays/actors/ovl_En_Dodojr/z_en_dodojr.c
@@ -8,7 +8,6 @@
 #include "overlays/actors/ovl_En_Bom/z_en_bom.h"
 #include "objects/object_dodojr/object_dodojr.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE)
 
@@ -90,8 +89,6 @@ void EnDodojr_Destroy(Actor* thisx, PlayState* play) {
     EnDodojr* this = (EnDodojr*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnDodojr_DoSwallowedBombEffects(EnDodojr* this) {

--- a/soh/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
+++ b/soh/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
@@ -3,7 +3,6 @@
 #include "overlays/actors/ovl_En_Bombf/z_en_bombf.h"
 #include "objects/object_dodongo/object_dodongo.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -354,8 +353,6 @@ void EnDodongo_Destroy(Actor* thisx, PlayState* play) {
     Collider_DestroyTris(play, &this->colliderHard);
     Collider_DestroyJntSph(play, &this->colliderBody);
     Collider_DestroyQuad(play, &this->colliderAT);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnDodongo_SetupIdle(EnDodongo* this) {

--- a/soh/src/overlays/actors/ovl_En_Dog/z_en_dog.c
+++ b/soh/src/overlays/actors/ovl_En_Dog/z_en_dog.c
@@ -6,7 +6,6 @@
 
 #include "z_en_dog.h"
 #include "objects/object_dog/object_dog.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS 0
 
@@ -301,8 +300,6 @@ void EnDog_Init(Actor* thisx, PlayState* play) {
 void EnDog_Destroy(Actor* thisx, PlayState* play) {
     EnDog* this = (EnDog*)thisx;
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnDog_FollowPath(EnDog* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Door/z_en_door.c
+++ b/soh/src/overlays/actors/ovl_En_Door/z_en_door.c
@@ -10,7 +10,6 @@
 #include "objects/object_hidan_objects/object_hidan_objects.h"
 #include "objects/object_mizu_objects/object_mizu_objects.h"
 #include "objects/object_haka_door/object_haka_door.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS ACTOR_FLAG_UPDATE_CULLING_DISABLED
@@ -147,8 +146,6 @@ void EnDoor_Destroy(Actor* thisx, PlayState* play) {
     if (transitionEntry->id < 0) {
         transitionEntry->id = -transitionEntry->id;
     }
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnDoor_SetupType(EnDoor* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Ds/z_en_ds.c
+++ b/soh/src/overlays/actors/ovl_En_Ds/z_en_ds.c
@@ -7,7 +7,6 @@
 #include "z_en_ds.h"
 #include "objects/object_ds/object_ds.h"
 #include "soh/OTRGlobals.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
@@ -52,9 +51,6 @@ void EnDs_Init(Actor* thisx, PlayState* play) {
 }
 
 void EnDs_Destroy(Actor* thisx, PlayState* play) {
-    EnDs* this = (EnDs*)thisx;
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnDs_Talk(EnDs* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Eiyer/z_en_eiyer.c
+++ b/soh/src/overlays/actors/ovl_En_Eiyer/z_en_eiyer.c
@@ -1,7 +1,6 @@
 #include "z_en_eiyer.h"
 #include "objects/object_ei/object_ei.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE)
 
@@ -172,8 +171,6 @@ void EnEiyer_Init(Actor* thisx, PlayState* play) {
 void EnEiyer_Destroy(Actor* thisx, PlayState* play) {
     EnEiyer* this = (EnEiyer*)thisx;
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelanime);
 }
 
 void EnEiyer_RotateAroundHome(EnEiyer* this) {

--- a/soh/src/overlays/actors/ovl_En_Elf/z_en_elf.c
+++ b/soh/src/overlays/actors/ovl_En_Elf/z_en_elf.c
@@ -8,7 +8,6 @@
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include <assert.h>
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_DRAW_CULLING_DISABLED | ACTOR_FLAG_UPDATE_DURING_OCARINA)
 
@@ -442,8 +441,6 @@ void EnElf_Destroy(Actor* thisx, PlayState* play) {
 
     LightContext_RemoveLight(play, &play->lightCtx, this->lightNodeGlow);
     LightContext_RemoveLight(play, &play->lightCtx, this->lightNodeNoGlow);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void func_80A02A20(EnElf* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Fd/z_en_fd.c
+++ b/soh/src/overlays/actors/ovl_En_Fd/z_en_fd.c
@@ -9,7 +9,6 @@
 #include "objects/object_fw/object_fw.h"
 #include "soh/frame_interpolation.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS                                                                                 \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | \
@@ -476,8 +475,6 @@ void EnFd_Destroy(Actor* thisx, PlayState* play) {
     EnFd* this = (EnFd*)thisx;
 
     Collider_DestroyJntSph(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnFd_Reappear(EnFd* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Firefly/z_en_firefly.c
+++ b/soh/src/overlays/actors/ovl_En_Firefly/z_en_firefly.c
@@ -8,7 +8,6 @@
 #include "objects/object_firefly/object_firefly.h"
 #include "overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_IGNORE_QUAKE | ACTOR_FLAG_CAN_ATTACH_TO_ARROW)
@@ -200,8 +199,6 @@ void EnFirefly_Destroy(Actor* thisx, PlayState* play) {
     EnFirefly* this = (EnFirefly*)thisx;
 
     Collider_DestroyJntSph(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnFirefly_SetupFlyIdle(EnFirefly* this) {

--- a/soh/src/overlays/actors/ovl_En_Fish/z_en_fish.c
+++ b/soh/src/overlays/actors/ovl_En_Fish/z_en_fish.c
@@ -7,7 +7,6 @@
 #include "z_en_fish.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "vt.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS 0
@@ -158,8 +157,6 @@ void EnFish_Destroy(Actor* thisx, PlayState* play2) {
     EnFish* this = (EnFish*)thisx;
 
     Collider_DestroyJntSph(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnFish_SetYOffset(EnFish* this) {

--- a/soh/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
+++ b/soh/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
@@ -7,7 +7,6 @@
 #include "z_en_floormas.h"
 #include "objects/object_wallmaster/object_wallmaster.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_HOOKSHOT_PULLS_PLAYER)
 
@@ -181,8 +180,6 @@ void EnFloormas_Destroy(Actor* thisx, PlayState* play) {
     EnFloormas* this = (EnFloormas*)thisx;
     ColliderCylinder* col = &this->collider;
     Collider_DestroyCylinder(play, col);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnFloormas_MakeInvulnerable(EnFloormas* this) {

--- a/soh/src/overlays/actors/ovl_En_Fr/z_en_fr.c
+++ b/soh/src/overlays/actors/ovl_En_Fr/z_en_fr.c
@@ -4,7 +4,6 @@
 #include "objects/object_fr/object_fr.h"
 #include <assert.h>
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/savestate_serialize.h"
 
 #define FLAGS                                                                                  \
@@ -328,9 +327,6 @@ void EnFr_Destroy(Actor* thisx, PlayState* play) {
     EnFr* this = (EnFr*)thisx;
 
     LightContext_RemoveLight(play, &play->lightCtx, this->lightNode);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
-    ResourceMgr_UnregisterSkeleton(&this->skelAnimeButterfly);
 }
 
 void EnFr_IsDivingIntoWater(EnFr* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Fu/z_en_fu.c
+++ b/soh/src/overlays/actors/ovl_En_Fu/z_en_fu.c
@@ -7,7 +7,6 @@
 #include "z_en_fu.h"
 #include "objects/object_fu/object_fu.h"
 #include "scenes/indoors/hakasitarelay/hakasitarelay_scene.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS                                                                                  \
@@ -103,8 +102,6 @@ void EnFu_Init(Actor* thisx, PlayState* play) {
 void EnFu_Destroy(Actor* thisx, PlayState* play) {
     EnFu* this = (EnFu*)thisx;
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelanime);
 }
 
 s32 func_80A1D94C(EnFu* this, PlayState* play, u16 textID, EnFuActionFunc actionFunc) {

--- a/soh/src/overlays/actors/ovl_En_Fw/z_en_fw.c
+++ b/soh/src/overlays/actors/ovl_En_Fw/z_en_fw.c
@@ -9,7 +9,6 @@
 #include "overlays/actors/ovl_En_Bom/z_en_bom.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "soh/frame_interpolation.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS                                                                                 \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | \
@@ -210,8 +209,6 @@ void EnFw_Init(Actor* thisx, PlayState* play) {
 void EnFw_Destroy(Actor* thisx, PlayState* play) {
     EnFw* this = (EnFw*)thisx;
     Collider_DestroyJntSph(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnFw_Bounce(EnFw* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
+++ b/soh/src/overlays/actors/ovl_En_Gb/z_en_gb.c
@@ -7,7 +7,6 @@
 #include "z_en_gb.h"
 #include "objects/object_ps/object_ps.h"
 #include "soh/frame_interpolation.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
@@ -226,8 +225,6 @@ void EnGb_Destroy(Actor* thisx, PlayState* play) {
     Collider_DestroyCylinder(play, &this->collider);
     LightContext_RemoveLight(play, &play->lightCtx, this->light);
     DynaPoly_DeleteBgActor(play, &play->colCtx.dyna, this->dyna.bgId);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void func_80A2F608(EnGb* this) {

--- a/soh/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
+++ b/soh/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
@@ -8,7 +8,6 @@
 #include "vt.h"
 #include "objects/object_ge1/object_ge1.h"
 #include "soh/Enhancements/randomizer/randomizer_entrance.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
@@ -186,8 +185,6 @@ void EnGe1_Destroy(Actor* thisx, PlayState* play) {
     EnGe1* this = (EnGe1*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 EnGe1_SetTalkAction(EnGe1* this, PlayState* play, u16 textId, f32 arg3, EnGe1ActionFunc actionFunc) {

--- a/soh/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
+++ b/soh/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
@@ -10,7 +10,6 @@
 #include "soh/Enhancements/randomizer/randomizer_entrance.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include <assert.h>
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -177,8 +176,6 @@ void EnGe2_Destroy(Actor* thisx, PlayState* play) {
     EnGe2* this = (EnGe2*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 // Detection/check functions

--- a/soh/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
+++ b/soh/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
@@ -6,7 +6,6 @@
 
 #include "z_en_ge3.h"
 #include "objects/object_geldb/object_geldb.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
@@ -92,8 +91,6 @@ void EnGe3_Destroy(Actor* thisx, PlayState* play) {
     EnGe3* this = (EnGe3*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnGe3_TurnToFacePlayer(EnGe3* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
+++ b/soh/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
@@ -8,7 +8,6 @@
 #include "objects/object_geldb/object_geldb.h"
 #include "soh/Enhancements/randomizer/randomizer_entrance.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -271,8 +270,6 @@ void EnGeldB_Destroy(Actor* thisx, PlayState* play) {
     Collider_DestroyTris(play, &this->blockCollider);
     Collider_DestroyCylinder(play, &this->bodyCollider);
     Collider_DestroyQuad(play, &this->swordCollider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 EnGeldB_ReactToPlayer(PlayState* play, EnGeldB* this, s16 arg2) {

--- a/soh/src/overlays/actors/ovl_En_Gm/z_en_gm.c
+++ b/soh/src/overlays/actors/ovl_En_Gm/z_en_gm.c
@@ -10,7 +10,6 @@
 #include "vt.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include <assert.h>
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -91,8 +90,6 @@ void EnGm_Destroy(Actor* thisx, PlayState* play) {
     EnGm* this = (EnGm*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 func_80A3D7C8(void) {

--- a/soh/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/soh/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -3,7 +3,6 @@
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "objects/object_oF1d_map/object_oF1d_map.h"
 #include "soh/frame_interpolation.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS                                                                                  \
@@ -1639,9 +1638,6 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
 }
 
 void EnGo2_Destroy(Actor* thisx, PlayState* play) {
-    EnGo2* this = (EnGo2*)thisx;
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnGo2_CurledUp(EnGo2* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Goma/z_en_goma.c
+++ b/soh/src/overlays/actors/ovl_En_Goma/z_en_goma.c
@@ -4,7 +4,6 @@
 #include "overlays/actors/ovl_Boss_Goma/z_boss_goma.h"
 #include "overlays/effects/ovl_Effect_Ss_Hahen/z_eff_ss_hahen.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/savestate_serialize.h"
 
 #define FLAGS                                                                                 \
@@ -186,8 +185,6 @@ void EnGoma_Destroy(Actor* thisx, PlayState* play) {
     if (this->actor.params < 10) {
         Collider_DestroyCylinder(play, &this->colCyl1);
         Collider_DestroyCylinder(play, &this->colCyl2);
-
-        ResourceMgr_UnregisterSkeleton(&this->skelanime);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Guest/z_en_guest.c
+++ b/soh/src/overlays/actors/ovl_En_Guest/z_en_guest.c
@@ -9,7 +9,6 @@
 #include "objects/object_boj/object_boj.h"
 #include "vt.h"
 #include <assert.h>
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -73,8 +72,6 @@ void EnGuest_Destroy(Actor* thisx, PlayState* play) {
     EnGuest* this = (EnGuest*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnGuest_Update(Actor* thisx, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
+++ b/soh/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
@@ -7,7 +7,6 @@
 #include "z_en_heishi1.h"
 #include "objects/object_sd/object_sd.h"
 #include "vt.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/Enhancements/savestate_serialize.h"
 
@@ -153,9 +152,6 @@ void EnHeishi1_Init(Actor* thisx, PlayState* play) {
 }
 
 void EnHeishi1_Destroy(Actor* thisx, PlayState* play) {
-    EnHeishi1* this = (EnHeishi1*)thisx;
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnHeishi1_SetupWalk(EnHeishi1* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/soh/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -11,7 +11,6 @@
 #include "overlays/actors/ovl_Bg_Gate_Shutter/z_bg_gate_shutter.h"
 #include "overlays/actors/ovl_En_Bom/z_en_bom.h"
 #include "overlays/actors/ovl_Bg_Spot15_Saku/z_bg_spot15_saku.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
@@ -169,8 +168,6 @@ void EnHeishi2_Destroy(Actor* thisx, PlayState* play) {
     if ((this->collider.dim.radius != 0) || (this->collider.dim.height != 0)) {
         Collider_DestroyCylinder(play, &this->collider);
     }
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnHeishi2_DoNothing1(EnHeishi2* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Heishi3/z_en_heishi3.c
+++ b/soh/src/overlays/actors/ovl_En_Heishi3/z_en_heishi3.c
@@ -7,7 +7,6 @@
 #include "z_en_heishi3.h"
 #include "objects/object_sd/object_sd.h"
 #include "vt.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS 0
 
@@ -90,8 +89,6 @@ void EnHeishi3_Destroy(Actor* thisx, PlayState* play) {
     EnHeishi3* this = (EnHeishi3*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnHeishi3_SetupGuardType(EnHeishi3* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.c
+++ b/soh/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.c
@@ -2,7 +2,6 @@
 #include "objects/object_sd/object_sd.h"
 #include "vt.h"
 #include "soh/OTRGlobals.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
 
@@ -109,8 +108,6 @@ void EnHeishi4_Destroy(Actor* thisx, PlayState* play) {
     EnHeishi4* this = (EnHeishi4*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void func_80A56328(EnHeishi4* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
+++ b/soh/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
@@ -7,7 +7,6 @@
 #include "z_en_hintnuts.h"
 #include "objects/object_hintnuts/object_hintnuts.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE)
 
@@ -107,8 +106,6 @@ void EnHintnuts_Destroy(Actor* thisx, PlayState* play) {
 
     if (this->actor.params != 0xA) {
         Collider_DestroyCylinder(play, &this->collider);
-
-        ResourceMgr_UnregisterSkeleton(&this->skelAnime);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Hs/z_en_hs.c
+++ b/soh/src/overlays/actors/ovl_En_Hs/z_en_hs.c
@@ -7,7 +7,6 @@
 #include "z_en_hs.h"
 #include "vt.h"
 #include "objects/object_hs/object_hs.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
@@ -99,8 +98,6 @@ void EnHs_Destroy(Actor* thisx, PlayState* play) {
     EnHs* this = (EnHs*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 func_80A6E53C(EnHs* this, PlayState* play, u16 textId, EnHsActionFunc actionFunc) {

--- a/soh/src/overlays/actors/ovl_En_Hs2/z_en_hs2.c
+++ b/soh/src/overlays/actors/ovl_En_Hs2/z_en_hs2.c
@@ -7,7 +7,6 @@
 #include "z_en_hs2.h"
 #include "vt.h"
 #include "objects/object_hs/object_hs.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
 
@@ -72,8 +71,6 @@ void EnHs2_Destroy(Actor* thisx, PlayState* play) {
     EnHs2* this = (EnHs2*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 func_80A6F0B4(EnHs2* this, PlayState* play, u16 textId, EnHs2ActionFunc actionFunc) {

--- a/soh/src/overlays/actors/ovl_En_Hy/z_en_hy.c
+++ b/soh/src/overlays/actors/ovl_En_Hy/z_en_hy.c
@@ -14,7 +14,6 @@
 #include "objects/object_cne/object_cne.h"
 #include "objects/object_cob/object_cob.h"
 #include "objects/object_os_anime/object_os_anime.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
@@ -917,8 +916,6 @@ void EnHy_Destroy(Actor* thisx, PlayState* play) {
     EnHy* this = (EnHy*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnHy_InitImpl(EnHy* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Ik/z_en_ik.c
+++ b/soh/src/overlays/actors/ovl_En_Ik/z_en_ik.c
@@ -9,7 +9,6 @@
 #include "objects/object_ik/object_ik.h"
 #include "vt.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS ACTOR_FLAG_UPDATE_CULLING_DISABLED
 
@@ -177,8 +176,6 @@ void EnIk_Destroy(Actor* thisx, PlayState* play) {
     Collider_DestroyTris(play, &this->shieldCollider);
     Collider_DestroyCylinder(play, &this->bodyCollider);
     Collider_DestroyQuad(play, &this->axeCollider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnIk_SetupAction(EnIk* this, EnIkActionFunc actionFunc) {

--- a/soh/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/soh/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -1,7 +1,6 @@
 #include "z_en_in.h"
 #include "overlays/actors/ovl_En_Horse/z_en_horse.h"
 #include "objects/object_in/object_in.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
@@ -505,8 +504,6 @@ void EnIn_Destroy(Actor* thisx, PlayState* play) {
 
     if (this->actionFunc != NULL && this->actionFunc != EnIn_WaitForObject) {
         Collider_DestroyCylinder(play, &this->collider);
-
-        ResourceMgr_UnregisterSkeleton(&this->skelAnime);
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Insect/z_en_insect.c
+++ b/soh/src/overlays/actors/ovl_En_Insect/z_en_insect.c
@@ -7,7 +7,6 @@
 #include "z_en_insect.h"
 #include "vt.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/savestate_serialize.h"
 
 #define FLAGS 0
@@ -243,8 +242,6 @@ void EnInsect_Destroy(Actor* thisx, PlayState* play) {
     if ((temp_v0 == 2 || temp_v0 == 3) && sDroppedCount > 0) {
         sDroppedCount--;
     }
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnInsect_SetupSlowDown(EnInsect* this) {

--- a/soh/src/overlays/actors/ovl_En_Jj/z_en_jj.c
+++ b/soh/src/overlays/actors/ovl_En_Jj/z_en_jj.c
@@ -7,7 +7,6 @@
 #include "z_en_jj.h"
 #include "objects/object_jj/object_jj.h"
 #include "overlays/actors/ovl_Eff_Dust/z_eff_dust.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_DRAW_CULLING_DISABLED)
 
@@ -144,8 +143,6 @@ void EnJj_Destroy(Actor* thisx, PlayState* play) {
         case JABUJABU_MAIN:
             DynaPoly_DeleteBgActor(play, &play->colCtx.dyna, this->dyna.bgId);
             Collider_DestroyCylinder(play, &this->collider);
-
-            ResourceMgr_UnregisterSkeleton(&this->skelAnime);
             break;
 
         case JABUJABU_COLLISION:

--- a/soh/src/overlays/actors/ovl_En_Js/z_en_js.c
+++ b/soh/src/overlays/actors/ovl_En_Js/z_en_js.c
@@ -7,7 +7,6 @@
 #include "z_en_js.h"
 #include "objects/object_js/object_js.h"
 #include "soh/OTRGlobals.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
@@ -79,8 +78,6 @@ void EnJs_Destroy(Actor* thisx, PlayState* play) {
     EnJs* this = (EnJs*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 u8 func_80A88F64(EnJs* this, PlayState* play, u16 textId) {

--- a/soh/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.c
+++ b/soh/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.c
@@ -9,7 +9,6 @@
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "overlays/effects/ovl_Effect_Ss_Hahen/z_eff_ss_hahen.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE)
 
@@ -121,8 +120,6 @@ void EnKarebaba_Destroy(Actor* thisx, PlayState* play) {
 
     Collider_DestroyCylinder(play, &this->bodyCollider);
     Collider_DestroyCylinder(play, &this->headCollider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnKarebaba_ResetCollider(EnKarebaba* this) {

--- a/soh/src/overlays/actors/ovl_En_Ko/z_en_ko.c
+++ b/soh/src/overlays/actors/ovl_En_Ko/z_en_ko.c
@@ -10,7 +10,6 @@
 #include "objects/object_km1/object_km1.h"
 #include "objects/object_kw1/object_kw1.h"
 #include "vt.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
@@ -1151,8 +1150,6 @@ void EnKo_Init(Actor* thisx, PlayState* play) {
 void EnKo_Destroy(Actor* thisx, PlayState* play) {
     EnKo* this = (EnKo*)thisx;
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void func_80A99048(EnKo* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Kz/z_en_kz.c
+++ b/soh/src/overlays/actors/ovl_En_Kz/z_en_kz.c
@@ -6,7 +6,6 @@
 
 #include "z_en_kz.h"
 #include "objects/object_kz/object_kz.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
@@ -406,8 +405,6 @@ void EnKz_Destroy(Actor* thisx, PlayState* play) {
     EnKz* this = (EnKz*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelanime);
 }
 
 void EnKz_PreMweepWait(EnKz* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Mb/z_en_mb.c
+++ b/soh/src/overlays/actors/ovl_En_Mb/z_en_mb.c
@@ -7,7 +7,6 @@
 #include "z_en_mb.h"
 #include "objects/object_mb/object_mb.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 /*
  * This actor can have three behaviors:
@@ -338,8 +337,6 @@ void EnMb_Destroy(Actor* thisx, PlayState* play) {
     Collider_DestroyTris(play, &this->frontShielding);
     Collider_DestroyCylinder(play, &this->hitbox);
     Collider_DestroyQuad(play, &this->attackCollider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnMb_FaceWaypoint(EnMb* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/soh/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -7,7 +7,6 @@
 #include "z_en_md.h"
 #include "objects/object_md/object_md.h"
 #include "overlays/actors/ovl_En_Elf/z_en_elf.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS                                                                                  \
@@ -676,8 +675,6 @@ void EnMd_Init(Actor* thisx, PlayState* play) {
 void EnMd_Destroy(Actor* thisx, PlayState* play) {
     EnMd* this = (EnMd*)thisx;
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnMd_Idle(EnMd* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Mk/z_en_mk.c
+++ b/soh/src/overlays/actors/ovl_En_Mk/z_en_mk.c
@@ -6,7 +6,6 @@
 
 #include "z_en_mk.h"
 #include "objects/object_mk/object_mk.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
@@ -80,8 +79,6 @@ void EnMk_Destroy(Actor* thisx, PlayState* play) {
     EnMk* this = (EnMk*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void func_80AACA40(EnMk* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Mm/z_en_mm.c
+++ b/soh/src/overlays/actors/ovl_En_Mm/z_en_mm.c
@@ -7,7 +7,6 @@
 #include "z_en_mm.h"
 #include "objects/object_mm/object_mm.h"
 #include "objects/object_link_child/object_link_child.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -199,8 +198,6 @@ void EnMm_Destroy(Actor* thisx, PlayState* play) {
     EnMm* this = (EnMm*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 func_80AADA70(void) {

--- a/soh/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
+++ b/soh/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
@@ -7,7 +7,6 @@
 #include "z_en_mm2.h"
 #include "vt.h"
 #include "objects/object_mm/object_mm.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -162,8 +161,6 @@ void EnMm2_Destroy(Actor* thisx, PlayState* play) {
     EnMm2* this = (EnMm2*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 func_80AAF224(EnMm2* this, PlayState* play, EnMm2ActionFunc actionFunc) {

--- a/soh/src/overlays/actors/ovl_En_Ms/z_en_ms.c
+++ b/soh/src/overlays/actors/ovl_En_Ms/z_en_ms.c
@@ -6,7 +6,6 @@
 
 #include "z_en_ms.h"
 #include "objects/object_ms/object_ms.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
@@ -101,8 +100,6 @@ void EnMs_Destroy(Actor* thisx, PlayState* play) {
     EnMs* this = (EnMs*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnMs_Wait(EnMs* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Nb/z_en_nb.c
+++ b/soh/src/overlays/actors/ovl_En_Nb/z_en_nb.c
@@ -8,7 +8,6 @@
 #include "vt.h"
 #include "objects/object_nb/object_nb.h"
 #include "overlays/actors/ovl_Door_Warp1/z_door_warp1.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS ACTOR_FLAG_UPDATE_CULLING_DISABLED
@@ -149,8 +148,6 @@ void EnNb_Destroy(Actor* thisx, PlayState* play) {
 
     D_80AB4318 = 0;
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void func_80AB0FBC(EnNb* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Niw/z_en_niw.c
+++ b/soh/src/overlays/actors/ovl_En_Niw/z_en_niw.c
@@ -9,7 +9,6 @@
 #include "overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.h"
 #include "vt.h"
 #include "soh/frame_interpolation.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/savestate_serialize.h"
 
 #define FLAGS (ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_THROW_ONLY)
@@ -255,8 +254,6 @@ void EnNiw_Destroy(Actor* thisx, PlayState* play) {
     EnNiw* this = (EnNiw*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void func_80AB5BF8(EnNiw* this, PlayState* play, s16 arg2) {

--- a/soh/src/overlays/actors/ovl_En_Niw_Girl/z_en_niw_girl.c
+++ b/soh/src/overlays/actors/ovl_En_Niw_Girl/z_en_niw_girl.c
@@ -7,7 +7,6 @@
 #include "z_en_niw_girl.h"
 #include "objects/object_gr/object_gr.h"
 #include "vt.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -93,9 +92,6 @@ void EnNiwGirl_Init(Actor* thisx, PlayState* play) {
 }
 
 void EnNiwGirl_Destroy(Actor* thisx, PlayState* play) {
-    EnNiwGirl* this = (EnNiwGirl*)thisx;
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnNiwGirl_Jump(EnNiwGirl* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
+++ b/soh/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
@@ -3,7 +3,6 @@
 #include "objects/object_os_anime/object_os_anime.h"
 #include "overlays/actors/ovl_En_Niw/z_en_niw.h"
 #include "vt.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
@@ -97,8 +96,6 @@ void EnNiwLady_Destroy(Actor* thisx, PlayState* play) {
     EnNiwLady* this = (EnNiwLady*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnNiwLady_ChoseAnimation(EnNiwLady* this, PlayState* play, s32 arg2) {

--- a/soh/src/overlays/actors/ovl_En_Okuta/z_en_okuta.c
+++ b/soh/src/overlays/actors/ovl_En_Okuta/z_en_okuta.c
@@ -2,7 +2,6 @@
 #include "objects/object_okuta/object_okuta.h"
 #include "objects/gameplay_field_keep/gameplay_field_keep.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE)
 
@@ -165,10 +164,6 @@ void EnOkuta_Destroy(Actor* thisx, PlayState* play) {
     EnOkuta* this = (EnOkuta*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    if (thisx->params == 0) {
-        ResourceMgr_UnregisterSkeleton(&this->skelAnime);
-    }
 }
 
 void EnOkuta_SpawnBubbles(EnOkuta* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Owl/z_en_owl.c
+++ b/soh/src/overlays/actors/ovl_En_Owl/z_en_owl.c
@@ -10,7 +10,6 @@
 #include "scenes/overworld/spot16/spot16_scene.h"
 #include "vt.h"
 #include <assert.h>
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
@@ -242,9 +241,6 @@ void EnOwl_Destroy(Actor* thisx, PlayState* play) {
     EnOwl* this = (EnOwl*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime2);
 }
 
 /**

--- a/soh/src/overlays/actors/ovl_En_Partner/z_en_partner.c
+++ b/soh/src/overlays/actors/ovl_En_Partner/z_en_partner.c
@@ -13,7 +13,6 @@
 #include <overlays/actors/ovl_Obj_Switch/z_obj_switch.h>
 #include <overlays/effects/ovl_Effect_Ss_HitMark/z_eff_ss_hitmark.h>
 #include "soh/OTRGlobals.h"
-#include "soh/ResourceManagerHelpers.h"
 #include <assets/objects/object_efc_tw/object_efc_tw.h>
 
 #define FLAGS                                                                                                   \
@@ -157,8 +156,6 @@ void EnPartner_Destroy(Actor* thisx, PlayState* play) {
 
     Collider_DestroyCylinder(play, &this->collider);
     Collider_DestroyCylinder(play, &this->weaponCollider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnPartner_UpdateLights(EnPartner* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
+++ b/soh/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
@@ -3,7 +3,6 @@
 #include "overlays/actors/ovl_En_Bom/z_en_bom.h"
 #include "overlays/effects/ovl_Effect_Ss_Hahen/z_eff_ss_hahen.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS                                                                                 \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | \
@@ -259,8 +258,6 @@ void EnPeehat_Destroy(Actor* thisx, PlayState* play) {
             parent->unk_2FA--;
         }
     }
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnPeehat_SpawnDust(PlayState* play, EnPeehat* this, Vec3f* pos, f32 arg3, s32 arg4, f32 arg5, f32 arg6) {

--- a/soh/src/overlays/actors/ovl_En_Po_Desert/z_en_po_desert.c
+++ b/soh/src/overlays/actors/ovl_En_Po_Desert/z_en_po_desert.c
@@ -6,7 +6,6 @@
 
 #include "z_en_po_desert.h"
 #include "objects/object_po_field/object_po_field.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_REACT_TO_LENS | ACTOR_FLAG_IGNORE_QUAKE)
 
@@ -86,8 +85,6 @@ void EnPoDesert_Destroy(Actor* thisx, PlayState* play) {
 
     LightContext_RemoveLight(play, &play->lightCtx, this->lightNode);
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnPoDesert_SetNextPathPoint(EnPoDesert* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.c
+++ b/soh/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.c
@@ -8,7 +8,6 @@
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "objects/object_po_field/object_po_field.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/savestate_serialize.h"
 
 #include <string.h>
@@ -199,8 +198,6 @@ void EnPoField_Destroy(Actor* thisx, PlayState* play) {
         Collider_DestroyCylinder(play, &this->flameCollider);
         Collider_DestroyCylinder(play, &this->collider);
     }
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnPoField_SetupWaitForSpawn(EnPoField* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
+++ b/soh/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
@@ -7,7 +7,6 @@
 #include "z_en_po_relay.h"
 #include "overlays/actors/ovl_En_Honotrap/z_en_honotrap.h"
 #include "objects/object_tk/object_tk.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
@@ -121,8 +120,6 @@ void EnPoRelay_Destroy(Actor* thisx, PlayState* play) {
     D_80AD8D24 = 0;
     LightContext_RemoveLight(play, &play->lightCtx, this->lightNode);
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnPoRelay_SetupIdle(EnPoRelay* this) {

--- a/soh/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.c
+++ b/soh/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.c
@@ -9,7 +9,6 @@
 #include "objects/object_po_sisters/object_po_sisters.h"
 #include "soh/frame_interpolation.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS                                                                                 \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | \
@@ -236,8 +235,6 @@ void EnPoSisters_Destroy(Actor* thisx, PlayState* play) {
         func_800F5B58();
     }
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void func_80AD9240(EnPoSisters* this, s32 arg1, Vec3f* arg2) {

--- a/soh/src/overlays/actors/ovl_En_Poh/z_en_poh.c
+++ b/soh/src/overlays/actors/ovl_En_Poh/z_en_poh.c
@@ -8,7 +8,6 @@
 #include "objects/object_poh/object_poh.h"
 #include "objects/object_po_composer/object_po_composer.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_IGNORE_QUAKE)
@@ -257,8 +256,6 @@ void EnPoh_Destroy(Actor* thisx, PlayState* play) {
     if (this->actor.params == EN_POH_RUPEE) {
         D_80AE1A50--;
     }
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void func_80ADE114(EnPoh* this) {

--- a/soh/src/overlays/actors/ovl_En_Rd/z_en_rd.c
+++ b/soh/src/overlays/actors/ovl_En_Rd/z_en_rd.c
@@ -1,7 +1,6 @@
 #include "z_en_rd.h"
 #include "objects/object_rd/object_rd.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS                                                                                 \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | \
@@ -179,8 +178,6 @@ void EnRd_Destroy(Actor* thisx, PlayState* play) {
         gSaveContext.sunsSongState = SUNSSONG_INACTIVE;
     }
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnRd_UpdateMourningTarget(PlayState* play, Actor* thisx, s32 arg2) {

--- a/soh/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
+++ b/soh/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
@@ -10,7 +10,6 @@
 #include "vt.h"
 #include "objects/object_reeba/object_reeba.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS                                                                                 \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | \
@@ -165,8 +164,6 @@ void EnReeba_Destroy(Actor* thisx, PlayState* play) {
             }
         }
     }
-
-    ResourceMgr_UnregisterSkeleton(&this->skelanime);
 }
 
 void EnReeba_SetupSurface(EnReeba* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Ru1/z_en_ru1.c
+++ b/soh/src/overlays/actors/ovl_En_Ru1/z_en_ru1.c
@@ -7,7 +7,6 @@
 #include "z_en_ru1.h"
 #include "objects/object_ru1/object_ru1.h"
 #include "vt.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_CAN_PRESS_SWITCHES)
@@ -207,8 +206,6 @@ void EnRu1_Destroy(Actor* thisx, PlayState* play) {
 
     D_80AF1938 = 0;
     EnRu1_DestroyColliders(this, play);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnRu1_UpdateEyes(EnRu1* this) {

--- a/soh/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
+++ b/soh/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
@@ -8,7 +8,6 @@
 #include "objects/object_ru2/object_ru2.h"
 #include "overlays/actors/ovl_Door_Warp1/z_door_warp1.h"
 #include "vt.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS ACTOR_FLAG_UPDATE_CULLING_DISABLED
@@ -156,8 +155,6 @@ void EnRu2_Destroy(Actor* thisx, PlayState* play) {
     EnRu2* this = (EnRu2*)thisx;
     D_80AF4118 = 0;
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnRu2_UpdateEyes(EnRu2* this) {

--- a/soh/src/overlays/actors/ovl_En_Sa/z_en_sa.c
+++ b/soh/src/overlays/actors/ovl_En_Sa/z_en_sa.c
@@ -4,7 +4,6 @@
 #include "scenes/overworld/spot04/spot04_scene.h"
 #include "scenes/overworld/spot05/spot05_scene.h"
 #include "soh/OTRGlobals.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS                                                                                  \
@@ -539,8 +538,6 @@ void EnSa_Destroy(Actor* thisx, PlayState* play) {
     EnSa* this = (EnSa*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void func_80AF6448(EnSa* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Shopnuts/z_en_shopnuts.c
+++ b/soh/src/overlays/actors/ovl_En_Shopnuts/z_en_shopnuts.c
@@ -1,7 +1,6 @@
 #include "z_en_shopnuts.h"
 #include "objects/object_shopnuts/object_shopnuts.h"
 #include "overlays/actors/ovl_En_Dns/z_en_dns.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE)
@@ -90,8 +89,6 @@ void EnShopnuts_Destroy(Actor* thisx, PlayState* play) {
     EnShopnuts* this = (EnShopnuts*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnShopnuts_SetupWait(EnShopnuts* this) {

--- a/soh/src/overlays/actors/ovl_En_Skb/z_en_skb.c
+++ b/soh/src/overlays/actors/ovl_En_Skb/z_en_skb.c
@@ -2,7 +2,6 @@
 #include "overlays/actors/ovl_En_Encount1/z_en_encount1.h"
 #include "objects/object_skb/object_skb.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -187,8 +186,6 @@ void EnSkb_Destroy(Actor* thisx, PlayState* play) {
         }
     }
     Collider_DestroyJntSph(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void func_80AFCD60(EnSkb* this) {

--- a/soh/src/overlays/actors/ovl_En_Skj/z_en_skj.c
+++ b/soh/src/overlays/actors/ovl_En_Skj/z_en_skj.c
@@ -3,7 +3,6 @@
 #include "objects/object_skj/object_skj.h"
 #include "soh/Enhancements/enhancementTypes.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS                                                                                 \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | \
@@ -471,8 +470,6 @@ void EnSkj_Destroy(Actor* thisx, PlayState* play) {
     EnSkj* this = (EnSkj*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 EnSkj_RangeCheck(Player* player, EnSkj* this) {

--- a/soh/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
+++ b/soh/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
@@ -1,7 +1,6 @@
 #include "z_en_ssh.h"
 #include "objects/object_ssh/object_ssh.h"
 #include "soh/OTRGlobals.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS                                                                                 \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | \
@@ -651,8 +650,6 @@ void EnSsh_Destroy(Actor* thisx, PlayState* play) {
         Collider_DestroyCylinder(play, &this->colCylinder[i]);
     }
     Collider_DestroyJntSph(play, &this->colSph);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnSsh_Wait(EnSsh* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_St/z_en_st.c
+++ b/soh/src/overlays/actors/ovl_En_St/z_en_st.c
@@ -7,7 +7,6 @@
 #include "z_en_st.h"
 #include "objects/object_st/object_st.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS                                                                                 \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | \
@@ -815,8 +814,6 @@ void EnSt_Destroy(Actor* thisx, PlayState* play) {
         Collider_DestroyCylinder(play, &this->colCylinder[i]);
     }
     Collider_DestroyJntSph(play, &this->colSph);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnSt_WaitOnCeiling(EnSt* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Sth/z_en_sth.c
+++ b/soh/src/overlays/actors/ovl_En_Sth/z_en_sth.c
@@ -10,7 +10,6 @@
 #include "objects/object_boj/object_boj.h"
 #include <assert.h>
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -186,8 +185,6 @@ void EnSth_Destroy(Actor* thisx, PlayState* play) {
     EnSth* this = (EnSth*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnSth_WaitForObjectLoaded(EnSth* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Sw/z_en_sw.c
+++ b/soh/src/overlays/actors/ovl_En_Sw/z_en_sw.c
@@ -1,7 +1,6 @@
 #include "z_en_sw.h"
 #include "objects/object_st/object_st.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -313,8 +312,6 @@ void EnSw_Destroy(Actor* thisx, PlayState* play) {
     EnSw* this = (EnSw*)thisx;
 
     Collider_DestroyJntSph(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 func_80B0C9F0(EnSw* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
+++ b/soh/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
@@ -4,7 +4,6 @@
 #include "objects/object_ossan/object_ossan.h"
 #include "soh/Enhancements/randomizer/randomizer_entrance.h"
 #include "soh/Enhancements/custom-message/CustomMessageTypes.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS                                                                                  \
@@ -178,9 +177,6 @@ void EnSyatekiMan_Init(Actor* thisx, PlayState* play) {
 }
 
 void EnSyatekiMan_Destroy(Actor* thisx, PlayState* play) {
-    EnSyatekiMan* this = (EnSyatekiMan*)thisx;
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnSyatekiMan_Start(EnSyatekiMan* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.c
+++ b/soh/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.c
@@ -8,7 +8,6 @@
 #include "objects/object_niw/object_niw.h"
 #include "vt.h"
 #include "soh/frame_interpolation.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS ACTOR_FLAG_UPDATE_CULLING_DISABLED
 
@@ -104,8 +103,6 @@ void EnSyatekiNiw_Destroy(Actor* thisx, PlayState* play) {
     EnSyatekiNiw* this = (EnSyatekiNiw*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnSyatekiNiw_UpdateRotations(EnSyatekiNiw* this, PlayState* play, s16 arg2) {

--- a/soh/src/overlays/actors/ovl_En_Ta/z_en_ta.c
+++ b/soh/src/overlays/actors/ovl_En_Ta/z_en_ta.c
@@ -8,7 +8,6 @@
 #include "vt.h"
 #include "objects/object_ta/object_ta.h"
 #include "soh/OTRGlobals.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
@@ -245,8 +244,6 @@ void EnTa_Destroy(Actor* thisx, PlayState* play) {
     if (this->stateFlags & 0x200) {
         func_800F5B58();
     }
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 EnTa_RequestTalk(EnTa* this, PlayState* play, u16 textId) {

--- a/soh/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.c
+++ b/soh/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.c
@@ -8,7 +8,6 @@
 #include "vt.h"
 #include "objects/object_ts/object_ts.h"
 #include "soh/OTRGlobals.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/savestate_serialize.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
@@ -86,9 +85,6 @@ void EnTakaraMan_Init(Actor* thisx, PlayState* play) {
 }
 
 void EnTakaraMan_Destroy(Actor* thisx, PlayState* play) {
-    EnTakaraMan* this = (EnTakaraMan*)thisx;
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void func_80B176E0(EnTakaraMan* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Test/z_en_test.c
+++ b/soh/src/overlays/actors/ovl_En_Test/z_en_test.c
@@ -7,7 +7,6 @@
 #include "z_en_test.h"
 #include "objects/object_sk2/object_sk2.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -323,9 +322,6 @@ void EnTest_Destroy(Actor* thisx, PlayState* play) {
     Collider_DestroyCylinder(play, &this->shieldCollider);
     Collider_DestroyCylinder(play, &this->bodyCollider);
     Collider_DestroyQuad(play, &this->swordCollider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
-    ResourceMgr_UnregisterSkeleton(&this->upperSkelanime);
 }
 
 /**

--- a/soh/src/overlays/actors/ovl_En_Tite/z_en_tite.c
+++ b/soh/src/overlays/actors/ovl_En_Tite/z_en_tite.c
@@ -10,7 +10,6 @@
 #include "vt.h"
 #include "objects/object_tite/object_tite.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -219,8 +218,6 @@ void EnTite_Destroy(Actor* thisx, PlayState* play) {
         osSyncPrintf("\n\n");
     }
     Collider_DestroyJntSph(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnTite_SetupIdle(EnTite* this) {

--- a/soh/src/overlays/actors/ovl_En_Tk/z_en_tk.c
+++ b/soh/src/overlays/actors/ovl_En_Tk/z_en_tk.c
@@ -8,7 +8,6 @@
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "objects/object_tk/object_tk.h"
 #include "soh/frame_interpolation.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
@@ -516,8 +515,6 @@ void EnTk_Destroy(Actor* thisx, PlayState* play) {
     EnTk* this = (EnTk*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnTk_Rest(EnTk* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
+++ b/soh/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
@@ -6,7 +6,6 @@
 
 #include "z_en_toryo.h"
 #include "objects/object_toryo/object_toryo.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
@@ -138,8 +137,6 @@ void EnToryo_Destroy(Actor* thisx, PlayState* play) {
     EnToryo* this = (EnToryo*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 EnToryo_TalkRespond(EnToryo* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Tr/z_en_tr.c
+++ b/soh/src/overlays/actors/ovl_En_Tr/z_en_tr.c
@@ -7,7 +7,6 @@
 #include "z_en_tr.h"
 #include "objects/object_tr/object_tr.h"
 #include <assert.h>
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS ACTOR_FLAG_UPDATE_CULLING_DISABLED
 
@@ -122,9 +121,6 @@ void EnTr_Init(Actor* thisx, PlayState* play) {
 }
 
 void EnTr_Destroy(Actor* thisx, PlayState* play) {
-    EnTr* this = (EnTr*)thisx;
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnTr_CrySpellcast(EnTr* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Vali/z_en_vali.c
+++ b/soh/src/overlays/actors/ovl_En_Vali/z_en_vali.c
@@ -8,7 +8,6 @@
 #include "objects/object_vali/object_vali.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include <stdlib.h>
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_IGNORE_QUAKE)
@@ -175,8 +174,6 @@ void EnVali_Destroy(Actor* thisx, PlayState* play) {
     Collider_DestroyQuad(play, &this->leftArmCollider);
     Collider_DestroyQuad(play, &this->rightArmCollider);
     Collider_DestroyCylinder(play, &this->bodyCollider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnVali_SetupLurk(EnVali* this) {

--- a/soh/src/overlays/actors/ovl_En_Vm/z_en_vm.c
+++ b/soh/src/overlays/actors/ovl_En_Vm/z_en_vm.c
@@ -9,7 +9,6 @@
 #include "overlays/actors/ovl_En_Bom/z_en_bom.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -164,8 +163,6 @@ void EnVm_Destroy(Actor* thisx, PlayState* play) {
     EnVm* this = (EnVm*)thisx;
 
     Collider_DestroyCylinder(play, &this->colliderCylinder);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnVm_SetupWait(EnVm* this) {

--- a/soh/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
+++ b/soh/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
@@ -8,7 +8,6 @@
 #include "objects/object_wallmaster/object_wallmaster.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -154,8 +153,6 @@ void EnWallmas_Destroy(Actor* thisx, PlayState* play) {
     EnWallmas* this = (EnWallmas*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnWallmas_TimerInit(EnWallmas* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Weiyer/z_en_weiyer.c
+++ b/soh/src/overlays/actors/ovl_En_Weiyer/z_en_weiyer.c
@@ -7,7 +7,6 @@
 #include "z_en_weiyer.h"
 #include "objects/object_ei/object_ei.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE)
 
@@ -119,8 +118,6 @@ void EnWeiyer_Destroy(Actor* thisx, PlayState* play) {
     EnWeiyer* this = (EnWeiyer*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnWeiyer_SetupFreeSwim(EnWeiyer* this) {

--- a/soh/src/overlays/actors/ovl_En_Wf/z_en_wf.c
+++ b/soh/src/overlays/actors/ovl_En_Wf/z_en_wf.c
@@ -9,7 +9,6 @@
 #include "overlays/actors/ovl_En_Encount1/z_en_encount1.h"
 #include "objects/object_wf/object_wf.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -281,8 +280,6 @@ void EnWf_Destroy(Actor* thisx, PlayState* play) {
             osSyncPrintf("\n\n");
         }
     }
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 EnWf_ChangeAction(PlayState* play, EnWf* this, s16 mustChoose) {

--- a/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -13,7 +13,6 @@
 #include "scenes/indoors/tokinoma/tokinoma_scene.h"
 #include "scenes/dungeons/ice_doukutu/ice_doukutu_scene.h"
 #include "vt.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/Enhancements/savestate_serialize.h"
 
@@ -77,8 +76,6 @@ void EnXc_Destroy(Actor* thisx, PlayState* play) {
     EnXc* this = (EnXc*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnXc_CalculateHeadTurn(EnXc* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_En_Zf/z_en_zf.c
+++ b/soh/src/overlays/actors/ovl_En_Zf/z_en_zf.c
@@ -7,7 +7,6 @@
 #include "z_en_zf.h"
 #include "objects/object_zf/object_zf.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/savestate_serialize.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
@@ -373,8 +372,6 @@ void EnZf_Destroy(Actor* thisx, PlayState* play) {
     Effect_Delete(play, this->blureIndex);
     Collider_DestroyCylinder(play, &this->bodyCollider);
     Collider_DestroyQuad(play, &this->swordCollider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 /**

--- a/soh/src/overlays/actors/ovl_En_Zl3/z_en_zl3.c
+++ b/soh/src/overlays/actors/ovl_En_Zl3/z_en_zl3.c
@@ -11,7 +11,6 @@
 #include "overlays/actors/ovl_Door_Warp1/z_door_warp1.h"
 #include "objects/object_zl2/object_zl2.h"
 #include "objects/object_zl2_anime2/object_zl2_anime2.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/Enhancements/savestate_serialize.h"
 
@@ -94,8 +93,6 @@ void EnZl3_Destroy(Actor* thisx, PlayState* play) {
     EnZl3* this = (EnZl3*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void func_80B53468(void) {

--- a/soh/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
+++ b/soh/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
@@ -7,7 +7,6 @@
 #include "z_en_zl4.h"
 #include "objects/object_zl4/object_zl4.h"
 #include "scenes/indoors/nakaniwa/nakaniwa_scene.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
@@ -404,8 +403,6 @@ void EnZl4_Destroy(Actor* thisx, PlayState* play) {
     EnZl4* this = (EnZl4*)thisx;
 
     Collider_DestroyCylinder(play, &this->collider);
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 s32 EnZl4_SetNextAnim(EnZl4* this, s32 nextAnim) {

--- a/soh/src/overlays/actors/ovl_En_Zo/z_en_zo.c
+++ b/soh/src/overlays/actors/ovl_En_Zo/z_en_zo.c
@@ -8,7 +8,6 @@
 #include "objects/object_zo/object_zo.h"
 
 #include "soh/frame_interpolation.h"
-#include "soh/ResourceManagerHelpers.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
 
@@ -614,9 +613,6 @@ void EnZo_Init(Actor* thisx, PlayState* play) {
 }
 
 void EnZo_Destroy(Actor* thisx, PlayState* play) {
-    EnZo* this = (EnZo*)thisx;
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
 }
 
 void EnZo_Standing(EnZo* this, PlayState* play) {

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -30,7 +30,6 @@
 #include "soh/Enhancements/randomizer/randomizer_grotto.h"
 #include "soh/frame_interpolation.h"
 #include "soh/OTRGlobals.h"
-#include "soh/ResourceManagerHelpers.h"
 #include "soh/Enhancements/savestate_serialize.h"
 
 #include <string.h>
@@ -12577,9 +12576,6 @@ void Player_Destroy(Actor* thisx, PlayState* play) {
     Magic_Reset(play);
 
     gSaveContext.linkAge = play->linkAgeOnLoad;
-
-    ResourceMgr_UnregisterSkeleton(&this->skelAnime);
-    ResourceMgr_UnregisterSkeleton(&this->upperSkelAnime);
 }
 
 // first person manipulate player actor


### PR DESCRIPTION
moves tons of `ResourceMgr_UnregisterSkeleton`'s out of source

unregister file is C so i could avoid messing with all the actor header files

also i intentionally left out `z_en_partner` and `z_en_box` bc `z_en_partner` doesnt seem to have its own actor id and `z_en_box` just kept crashing the game and i couldnt figure out why, probably due to `OnActorDestroy` triggering earlier than the old unregister was but idk. im open to suggestions on both of these but for now i left the old unregisters how they were for these 2

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8617922214.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8617870694.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8617860905.zip)
<!--- section:artifacts:end -->