### PR TITLE
Ingo Race: skip rematch

### DIFF
--- a/soh/soh/Enhancements/Minigames/IngoRaceOnce.cpp
+++ b/soh/soh/Enhancements/Minigames/IngoRaceOnce.cpp
@@ -11,12 +11,14 @@ extern PlayState* gPlayState;
 #define CVAR_INGO_RACE_ONCE_NAME CVAR_ENHANCEMENT("IngoRaceOnce")
 #define CVAR_INGO_RACE_ONCE_VALUE CVarGetInteger(CVAR_INGO_RACE_ONCE_NAME, INGO_RACE_TWICE)
 
+static constexpr u16 INGO_RACE_EVENT_FLAGS = 0x8046;
+
 static void RegisterIngoRaceOnce() {
     COND_VB_SHOULD(VB_RACE_INGO, CVAR_INGO_RACE_ONCE_VALUE == INGO_RACE_NONE, {
         s32 entranceIndex = va_arg(args, s32);
-        if (entranceIndex == 2 && (gSaveContext.eventInf[0] & 0x10) == 0) {
+        if (entranceIndex == 2 && (gSaveContext.eventInf[0] & 0x12) == 2) {
             gPlayState->nextEntranceIndex = ENTR_LON_LON_RANCH_7;
-            gSaveContext.eventInf[0] = (gSaveContext.eventInf[0] & ~0xF) | 0x8006;
+            gSaveContext.eventInf[0] = (gSaveContext.eventInf[0] & ~0xF) | INGO_RACE_EVENT_FLAGS;
             gPlayState->transitionType = TRANS_TYPE_FADE_WHITE;
             gPlayState->transitionTrigger = TRANS_TRIGGER_START;
             gSaveContext.timerState = TIMER_STATE_OFF;

--- a/soh/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/soh/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -728,16 +728,21 @@ void func_80A7A848(EnIn* this, PlayState* play) {
         if ((play->msgCtx.choiceIndex == 0 && gSaveContext.rupees < 50) || play->msgCtx.choiceIndex == 1) {
             gSaveContext.eventInf[0] &= ~0xF;
             this->actionFunc = func_80A7A4C8;
-        } else {
-            func_80A79BAC(this, play, 2, TRANS_TYPE_CIRCLE(TCA_STARBURST, TCC_BLACK, TCS_FAST));
+        }
+        else {
+            if (GameInteractor_Should(VB_RACE_INGO, true, 2)) {
+                func_80A79BAC(this, play, 2, TRANS_TYPE_CIRCLE(TCA_STARBURST, TCC_BLACK, TCS_FAST));
+            }
             gSaveContext.eventInf[0] = (gSaveContext.eventInf[0] & ~0xF) | 2;
             gSaveContext.eventInf[0] = (gSaveContext.eventInf[0] & ~0x8000) | 0x8000;
             play->msgCtx.stateTimer = 0;
             play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
         }
         this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
-        gSaveContext.eventInf[0] &= ~0x20;
-        gSaveContext.eventInf[0] &= ~0x40;
+        if (GameInteractor_Should(VB_RACE_INGO, true, 2)) {
+            gSaveContext.eventInf[0] &= ~0x20;
+            gSaveContext.eventInf[0] &= ~0x40;
+        }
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/soh/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -728,8 +728,7 @@ void func_80A7A848(EnIn* this, PlayState* play) {
         if ((play->msgCtx.choiceIndex == 0 && gSaveContext.rupees < 50) || play->msgCtx.choiceIndex == 1) {
             gSaveContext.eventInf[0] &= ~0xF;
             this->actionFunc = func_80A7A4C8;
-        }
-        else {
+        } else {
             if (GameInteractor_Should(VB_RACE_INGO, true, 2)) {
                 func_80A79BAC(this, play, 2, TRANS_TYPE_CIRCLE(TCA_STARBURST, TCC_BLACK, TCS_FAST));
             }


### PR DESCRIPTION
I missed a use case with the Ingo Race skip. If the player loses, the player can ask Ingo for a rematch outside the corral. That rematch would not be skipped if the option was set to None. Now it is.

https://github.com/user-attachments/assets/457058dd-a918-472e-ad18-b7593f79483f

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8620558643.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8620534178.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8620503976.zip)
<!--- section:artifacts:end -->