### PR TITLE
Fix startup crash from over-long "Speak Hylian" stat name

### DIFF
--- a/soh/soh/Enhancements/gameplaystats.cpp
+++ b/soh/soh/Enhancements/gameplaystats.cpp
@@ -897,7 +897,7 @@ void SetupDisplayNames() {
     strcpy(itemTimestampDisplayName[TIMESTAMP_FOUND_SPEAK_DEKU],                       "Speak Deku:            ");
     strcpy(itemTimestampDisplayName[TIMESTAMP_FOUND_SPEAK_GERUDO],                     "Speak Gerudo:          ");
     strcpy(itemTimestampDisplayName[TIMESTAMP_FOUND_SPEAK_GORON],                      "Speak Goron:           ");
-    strcpy(itemTimestampDisplayName[TIMESTAMP_FOUND_SPEAK_HYLIAN],                     "Speak Hylian:           ");
+    strcpy(itemTimestampDisplayName[TIMESTAMP_FOUND_SPEAK_HYLIAN],                     "Speak Hylian:          ");
     strcpy(itemTimestampDisplayName[TIMESTAMP_FOUND_SPEAK_KOKIRI],                     "Speak Kokiri:          ");
     strcpy(itemTimestampDisplayName[TIMESTAMP_FOUND_SPEAK_ZORA],                       "Speak Zora:            ");
     strcpy(itemTimestampDisplayName[TIMESTAMP_FOUND_DMC_BEAN_SOUL],                    "DMC Bean Soul:         ");


### PR DESCRIPTION
## Bug

Booting aborts before the main menu on any `_FORTIFY_SOURCE` build:

```
SetupDisplayNames() -> __strcpy_chk -> abort (signal 6)
GameplayStatsWindow::InitElement()
```

## Cause

`itemTimestampDisplayName` rows are `char[24]`, sized for the 23-character column the rest of the table uses. #6978 corrected the typo `"SpeakHylian:"` -> `"Speak Hylian:"` but kept the original trailing padding, so the string became 24 chars + NUL = **25 bytes** and overflows its buffer. `strcpy` then aborts via `__strcpy_chk` during GUI init. Unfortified builds overrun by one byte silently and still boot, which is why CI didn't catch it.

## Fix

Drop one trailing space so the entry is back to the 23-character column (matching `"Speak Kokiri:"`, `"Speak Goron:"`, etc.). No other row exceeds 23 characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8641160051.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8641046052.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8641035666.zip)
<!--- section:artifacts:end -->