### PR TITLE
Dampe race both rewards fix

### DIFF
--- a/soh/soh/Enhancements/Minigames/DampeBothPrizes.cpp
+++ b/soh/soh/Enhancements/Minigames/DampeBothPrizes.cpp
@@ -4,7 +4,7 @@
 extern "C" {
 #include "functions.h"
 #include "macros.h"
-#include "src/overlays/actors/ovl_en_po_relay/z_en_po_relay.h"
+#include "src/overlays/actors/ovl_En_Po_Relay/z_en_o_relay.h"
 extern SaveContext gSaveContext;
 extern PlayState* gPlayState;
 }

--- a/soh/soh/Enhancements/Minigames/DampeBothPrizes.cpp
+++ b/soh/soh/Enhancements/Minigames/DampeBothPrizes.cpp
@@ -4,6 +4,7 @@
 extern "C" {
 #include "functions.h"
 #include "macros.h"
+#include "src/overlays/actors/ovl_en_po_relay/z_en_po_relay.h"
 extern SaveContext gSaveContext;
 extern PlayState* gPlayState;
 }
@@ -11,14 +12,33 @@ extern PlayState* gPlayState;
 #define CVAR_DAMPE_BOTH_PRIZES_NAME CVAR_ENHANCEMENT("DampeBothPrizes")
 #define CVAR_DAMPE_BOTH_PRIZES_VALUE CVarGetInteger(CVAR_DAMPE_BOTH_PRIZES_NAME, 0)
 
-static void RegisterDampeSecondPrize() {
-    COND_VB_SHOULD(VB_DAMPE_AWARD_SECOND_PRIZE, CVAR_DAMPE_BOTH_PRIZES_VALUE || IS_RANDO, {
-        if (!*should) {
-            Flags_SetTempClear(gPlayState, 4);
+static void RegisterDampeBothPrizes() {
+    COND_VB_SHOULD(VB_DAMPE_AWARD_PRIZES, CVAR_DAMPE_BOTH_PRIZES_VALUE || IS_RANDO, {
+        EnPoRelay* enPoRelay = va_arg(args, EnPoRelay*);
+        Vec3f posAtGround;
+        posAtGround.x = enPoRelay->actor.world.pos.x;
+        posAtGround.y = enPoRelay->actor.floorHeight;
+        posAtGround.z = enPoRelay->actor.world.pos.z;
+
+        if (gSaveContext.timerSeconds < HIGH_SCORE(HS_DAMPE_RACE)) {
             HIGH_SCORE(HS_DAMPE_RACE) = gSaveContext.timerSeconds;
-            *should = true;
         }
+        // spawn Hookshot chest
+        if (!Flags_GetTreasure(gPlayState, 0)) {
+            Flags_SetTempClear(gPlayState, 4);
+        }
+        // spawn Piece of Heart
+        if (!Flags_GetCollectible(gPlayState, enPoRelay->actor.params) && gSaveContext.timerSeconds <= 60) {
+            Item_DropCollectible2(gPlayState, &posAtGround,
+                                  (enPoRelay->actor.params << 8) + (0x4000 | ITEM00_HEART_PIECE));
+        } else {
+            Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_ITEM00, posAtGround.x, posAtGround.y, posAtGround.z,
+                        0, 0, 0, 2);
+        }
+
+        Actor_Kill(&enPoRelay->actor);
+        *should = false;
     });
 }
 
-static RegisterShipInitFunc initFunc(RegisterDampeSecondPrize, { CVAR_DAMPE_BOTH_PRIZES_NAME, "IS_RANDO" });
+static RegisterShipInitFunc initFunc(RegisterDampeBothPrizes, { CVAR_DAMPE_BOTH_PRIZES_NAME, "IS_RANDO" });

--- a/soh/soh/Enhancements/Minigames/DampeBothPrizes.cpp
+++ b/soh/soh/Enhancements/Minigames/DampeBothPrizes.cpp
@@ -4,7 +4,7 @@
 extern "C" {
 #include "functions.h"
 #include "macros.h"
-#include "src/overlays/actors/ovl_En_Po_Relay/z_en_o_relay.h"
+#include "src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.h"
 extern SaveContext gSaveContext;
 extern PlayState* gPlayState;
 }

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -462,11 +462,11 @@ typedef enum {
 
     // #### `result`
     // ```c
-    // this->hookshotSlotFull != 0
+    // Math_StepToF(&this->actor.scale.x, 0.0f, 0.001f) != 0
     // ```
     // #### `args`
-    // - None
-    VB_DAMPE_AWARD_SECOND_PRIZE,
+    // - `*EnPoRelay`
+    VB_DAMPE_AWARD_PRIZES,
 
     // #### `result`
     // ```c

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1536,12 +1536,6 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
         case VB_DEKU_THEATER_FINISH_GIVING_PRIZE:
             *should = true;
             break;
-        case VB_DAMPE_AWARD_SECOND_PRIZE:
-            if (!*should) {
-                Flags_SetTreasure(gPlayState, 0x1E);
-                *should = true;
-            }
-            break;
         case VB_FROGS_GO_TO_IDLE: {
             EnFr* enFr = va_arg(args, EnFr*);
 

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1698,7 +1698,8 @@ void SohMenu::AddMenuEnhancements() {
             info.options->disabled = IS_RANDO && GameInteractor::IsSaveLoaded(true);
             info.options->disabledTooltip = "This setting is forcefully enabled when you are playing a Randomizer.";
         })
-        .Options(CheckboxOptions().Tooltip("Dampe awards both prizes on the first race, not just the Hookshot."));
+        .Options(CheckboxOptions().Tooltip("Dampe awards both prizes on the first race if you finish within "
+                                           "one minute, not just the Hookshot."));
     AddWidget(path, "Horseback Archery", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("HorsebackArcheryBothPrizes"))
         .Options(CheckboxOptions().Tooltip("Link can win both Horseback Archery prizes in one attempt"));

--- a/soh/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
+++ b/soh/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
@@ -335,18 +335,21 @@ void EnPoRelay_DisappearAndReward(EnPoRelay* this, PlayState* play) {
             Audio_PlayActorSound2(&this->actor, NA_SE_EN_EXTINCT);
         }
     }
-    if (Math_StepToF(&this->actor.scale.x, 0.0f, 0.001f) != 0) {
-        if (GameInteractor_Should(VB_DAMPE_AWARD_SECOND_PRIZE, this->hookshotSlotFull != 0)) {
-            sp60.x = this->actor.world.pos.x;
-            sp60.y = this->actor.floorHeight;
-            sp60.z = this->actor.world.pos.z;
+    if (GameInteractor_Should(VB_DAMPE_AWARD_PRIZES, Math_StepToF(&this->actor.scale.x, 0.0f, 0.001f), this)) {
+        if (this->hookshotSlotFull) {
+            Vec3f posAtGround;
+
+            posAtGround.x = this->actor.world.pos.x;
+            posAtGround.y = this->actor.floorHeight;
+            posAtGround.z = this->actor.world.pos.z;
             if (gSaveContext.timerSeconds < HIGH_SCORE(HS_DAMPE_RACE)) {
                 HIGH_SCORE(HS_DAMPE_RACE) = gSaveContext.timerSeconds;
             }
-            if (Flags_GetCollectible(play, this->actor.params) == 0 && gSaveContext.timerSeconds <= 60) {
-                Item_DropCollectible2(play, &sp60, (this->actor.params << 8) + (0x4000 | ITEM00_HEART_PIECE));
+            if (!Flags_GetCollectible(play, this->actor.params) && gSaveContext.timerSeconds <= 60) {
+                Item_DropCollectible2(play, &posAtGround, (this->actor.params << 8) + (0x4000 | ITEM00_HEART_PIECE));
             } else {
-                Actor_Spawn(&play->actorCtx, play, ACTOR_EN_ITEM00, sp60.x, sp60.y, sp60.z, 0, 0, 0, 2);
+                Actor_Spawn(&play->actorCtx, play, ACTOR_EN_ITEM00, posAtGround.x, posAtGround.y, posAtGround.z, 0, 0,
+                            0, 2);
             }
         } else {
             Flags_SetTempClear(play, 4);

--- a/soh/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
+++ b/soh/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
@@ -304,7 +304,6 @@ void EnPoRelay_DisappearAndReward(EnPoRelay* this, PlayState* play) {
     Vec3f vec;
     f32 multiplier;
     s32 pad;
-    Vec3f sp60;
     s32 pad1;
 
     this->actionTimer++;


### PR DESCRIPTION
The Dampe give heart piece part was always run, skipping the give Hookshot part.
This moves the hook up a step and gives both rewards inside the hook, replacing the vanilla give reward part.
`posAtGround` is from decomp.

Chest and heart piece flags on/off in vanilla (did same thing in randomizer):

https://github.com/user-attachments/assets/35537c2f-d55c-4bfc-b95c-9223df9c14da

(Annerley - Stars to the Sky)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8659037742.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8658888888.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8658879106.zip)
<!--- section:artifacts:end -->