### PR TITLE
Cleanup and fix Dampe's race both prizes regression

### DIFF
--- a/soh/soh/Enhancements/Minigames/DampeBothPrizes.cpp
+++ b/soh/soh/Enhancements/Minigames/DampeBothPrizes.cpp
@@ -11,14 +11,17 @@ extern PlayState* gPlayState;
 #define CVAR_DAMPE_BOTH_PRIZES_NAME CVAR_ENHANCEMENT("DampeBothPrizes")
 #define CVAR_DAMPE_BOTH_PRIZES_VALUE CVarGetInteger(CVAR_DAMPE_BOTH_PRIZES_NAME, 0)
 
-static void RegisterDampeSecondPrize() {
+static void RegisterDampeBothPrizes() {
     COND_VB_SHOULD(VB_DAMPE_AWARD_SECOND_PRIZE, CVAR_DAMPE_BOTH_PRIZES_VALUE || IS_RANDO, {
         if (!*should) {
             Flags_SetTempClear(gPlayState, 4);
             HIGH_SCORE(HS_DAMPE_RACE) = gSaveContext.timerSeconds;
+            if (IS_RANDO) {
+                Flags_SetTreasure(gPlayState, 0x1E);
+            }
             *should = true;
         }
     });
 }
 
-static RegisterShipInitFunc initFunc(RegisterDampeSecondPrize, { CVAR_DAMPE_BOTH_PRIZES_NAME, "IS_RANDO" });
+static RegisterShipInitFunc initFunc(RegisterDampeBothPrizes, { CVAR_DAMPE_BOTH_PRIZES_NAME, "IS_RANDO" });

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -462,7 +462,7 @@ typedef enum {
 
     // #### `result`
     // ```c
-    // this->hookshotSlotFull != 0
+    // this->hookshotSlotFull
     // ```
     // #### `args`
     // - None

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -1536,12 +1536,6 @@ void RandomizerOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_l
         case VB_DEKU_THEATER_FINISH_GIVING_PRIZE:
             *should = true;
             break;
-        case VB_DAMPE_AWARD_SECOND_PRIZE:
-            if (!*should) {
-                Flags_SetTreasure(gPlayState, 0x1E);
-                *should = true;
-            }
-            break;
         case VB_FROGS_GO_TO_IDLE: {
             EnFr* enFr = va_arg(args, EnFr*);
 

--- a/soh/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
+++ b/soh/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
@@ -346,7 +346,8 @@ void EnPoRelay_DisappearAndReward(EnPoRelay* this, PlayState* play) {
             if (Flags_GetCollectible(play, this->actor.params) == 0 && gSaveContext.timerSeconds <= 60) {
                 Item_DropCollectible2(play, &posAtGround, (this->actor.params << 8) + (0x4000 | ITEM00_HEART_PIECE));
             } else {
-                Actor_Spawn(&play->actorCtx, play, ACTOR_EN_ITEM00, posAtGround.x, posAtGround.y, posAtGround.z, 0, 0, 0, 2);
+                Actor_Spawn(&play->actorCtx, play, ACTOR_EN_ITEM00, posAtGround.x, posAtGround.y, posAtGround.z, 0, 0,
+                            0, 2);
             }
         } else {
             Flags_SetTempClear(play, 4);

--- a/soh/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
+++ b/soh/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
@@ -284,7 +284,7 @@ void EnPoRelay_Talk2(EnPoRelay* this, PlayState* play) {
     Math_ScaledStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 0x100);
     if (Message_GetState(&play->msgCtx) == TEXT_STATE_EVENT) {
         if (Message_ShouldAdvance(play)) {
-            if (this->hookshotSlotFull != 0) {
+            if (this->hookshotSlotFull) {
                 Actor_SetTextWithPrefix(play, &this->actor, 0x2E);
             } else {
                 Actor_SetTextWithPrefix(play, &this->actor, 0x2D);
@@ -304,7 +304,7 @@ void EnPoRelay_DisappearAndReward(EnPoRelay* this, PlayState* play) {
     Vec3f vec;
     f32 multiplier;
     s32 pad;
-    Vec3f sp60;
+    Vec3f posAtGround;
     s32 pad1;
 
     this->actionTimer++;
@@ -335,18 +335,18 @@ void EnPoRelay_DisappearAndReward(EnPoRelay* this, PlayState* play) {
             Audio_PlayActorSound2(&this->actor, NA_SE_EN_EXTINCT);
         }
     }
-    if (Math_StepToF(&this->actor.scale.x, 0.0f, 0.001f) != 0) {
-        if (GameInteractor_Should(VB_DAMPE_AWARD_SECOND_PRIZE, this->hookshotSlotFull != 0)) {
-            sp60.x = this->actor.world.pos.x;
-            sp60.y = this->actor.floorHeight;
-            sp60.z = this->actor.world.pos.z;
+    if (Math_StepToF(&this->actor.scale.x, 0.0f, 0.001f)) {
+        if (GameInteractor_Should(VB_DAMPE_AWARD_SECOND_PRIZE, this->hookshotSlotFull)) {
+            posAtGround.x = this->actor.world.pos.x;
+            posAtGround.y = this->actor.floorHeight;
+            posAtGround.z = this->actor.world.pos.z;
             if (gSaveContext.timerSeconds < HIGH_SCORE(HS_DAMPE_RACE)) {
                 HIGH_SCORE(HS_DAMPE_RACE) = gSaveContext.timerSeconds;
             }
             if (Flags_GetCollectible(play, this->actor.params) == 0 && gSaveContext.timerSeconds <= 60) {
-                Item_DropCollectible2(play, &sp60, (this->actor.params << 8) + (0x4000 | ITEM00_HEART_PIECE));
+                Item_DropCollectible2(play, &posAtGround, (this->actor.params << 8) + (0x4000 | ITEM00_HEART_PIECE));
             } else {
-                Actor_Spawn(&play->actorCtx, play, ACTOR_EN_ITEM00, sp60.x, sp60.y, sp60.z, 0, 0, 0, 2);
+                Actor_Spawn(&play->actorCtx, play, ACTOR_EN_ITEM00, posAtGround.x, posAtGround.y, posAtGround.z, 0, 0, 0, 2);
             }
         } else {
             Flags_SetTempClear(play, 4);


### PR DESCRIPTION
As reported on Discord:

> On the latest nightly build I did the Dampe race several times but it only gives me PoH check, not the Hookshot chest check

I did a stupid when making that option by separating it into two hooks that were supposed to cover both rando and the option itself. The problem was that both hooks required the Hookshot slot check to be false, but then set to true, meaning that whichever hook ran first would override the other one. I've fixed this by uniting the two hooks into one. I also did a bit of syntax cleanup and renaming.

Hopefully someday I'll learn not to make that mistake again.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8699923478.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8699748770.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8699711664.zip)
<!--- section:artifacts:end -->