### PR TITLE
Fix potential key softlock with hover boosts in MQ spirit

### DIFF
--- a/soh/soh/Enhancements/randomizer/location_access/dungeons/spirit_temple.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/dungeons/spirit_temple.cpp
@@ -1,7 +1,6 @@
 #include "soh/Enhancements/randomizer/location_access.h"
 #include "soh/Enhancements/randomizer/entrance.h"
 #include "soh/Enhancements/randomizer/dungeon.h"
-#include "soh/Enhancements/randomizer/randomizerTypes.h"
 
 using namespace Rando;
 

--- a/soh/soh/Enhancements/randomizer/location_access/dungeons/spirit_temple.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/dungeons/spirit_temple.cpp
@@ -690,7 +690,7 @@ void RegionTable_Init_SpiritTemple() {
         //This tracks possible child access, if adult has not entered STATUE_ROOM. Certain Child Access is checked for separately as 7 Keys
         //Needs 2 keys if hover recoils are on because you can recoil past the jet and waste a key without having Statue Room Access.
         //If the clip through the grate in 3 suns room is added to logic, being able to perform that will reduce the requirement as well.
-        ENTRANCE(RR_SPIRIT_TEMPLE_MQ_UNDER_LIKE_LIKE, logic->SmallKeys(SCENE_SPIRIT_TEMPLE, (ctx->GetTrickOption(RT_HOVER_BOOST_SIMPLE) && !logic->Get(LOGIC_SPIRIT_MQ_3SUNS_ENEMIES)) ? 2 : 1)),
+        ENTRANCE(RR_SPIRIT_TEMPLE_MQ_UNDER_LIKE_LIKE, logic->SmallKeys(SCENE_SPIRIT_TEMPLE, (ctx->GetTrickOption(RT_HOVER_BOOST_SIMPLE) && !(logic->Get(LOGIC_SPIRIT_MQ_3SUNS_ENEMIES) || logic->Get(LOGIC_REVERSE_SPIRIT_ADULT))) ? 2 : 1)),
     });
 
     areaTable[RR_SPIRIT_TEMPLE_MQ_UNDER_LIKE_LIKE] = Region("Spirit Temple MQ Under Like Like", SCENE_SPIRIT_TEMPLE, {}, {
@@ -713,7 +713,7 @@ void RegionTable_Init_SpiritTemple() {
         //Exits
         ENTRANCE(RR_SPIRIT_TEMPLE_MQ_UNDER_LIKE_LIKE,  logic->CanHitSwitch()),
         //This exit only governs child forwards access, adult and reverse access starts on the other side so never checks this
-        ENTRANCE(RR_SPIRIT_TEMPLE_MQ_STATUE_ROOM_CHILD, logic->SmallKeys(SCENE_SPIRIT_TEMPLE, 2)),
+        ENTRANCE(RR_SPIRIT_TEMPLE_MQ_STATUE_ROOM_CHILD, logic->SmallKeys(SCENE_SPIRIT_TEMPLE, (ctx->GetTrickOption(RT_HOVER_BOOST_SIMPLE) && !(logic->Get(LOGIC_SPIRIT_MQ_3SUNS_ENEMIES) || logic->Get(LOGIC_REVERSE_SPIRIT_ADULT))) ? 3 : 2)),
     });
 
     areaTable[RR_SPIRIT_TEMPLE_MQ_STATUE_ROOM_CHILD] = Region("Spirit Temple MQ Statue Room Child", SCENE_SPIRIT_TEMPLE, {}, {

--- a/soh/soh/Enhancements/randomizer/location_access/dungeons/spirit_temple.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/dungeons/spirit_temple.cpp
@@ -690,7 +690,8 @@ void RegionTable_Init_SpiritTemple() {
         //This tracks possible child access, if adult has not entered STATUE_ROOM. Certain Child Access is checked for separately as 7 Keys
         //Needs 2 keys if hover recoils are on because you can recoil past the jet and waste a key without having Statue Room Access.
         //If the clip through the grate in 3 suns room is added to logic, being able to perform that will reduce the requirement as well.
-        ENTRANCE(RR_SPIRIT_TEMPLE_MQ_UNDER_LIKE_LIKE, logic->SmallKeys(SCENE_SPIRIT_TEMPLE, (ctx->GetTrickOption(RT_HOVER_BOOST_SIMPLE) && !(logic->Get(LOGIC_SPIRIT_MQ_3SUNS_ENEMIES) || logic->Get(LOGIC_REVERSE_SPIRIT_ADULT))) ? 2 : 1)),
+        ENTRANCE(RR_SPIRIT_TEMPLE_MQ_UNDER_LIKE_LIKE, logic->SmallKeys(SCENE_SPIRIT_TEMPLE,
+                                                                           (ctx->GetTrickOption(RT_HOVER_BOOST_SIMPLE) && !((logic->Get(LOGIC_SPIRIT_MQ_3SUNS_ENEMIES) && (logic->CanUse(RG_CLIMB) || logic->CanUse(RG_LONGSHOT))) || logic->Get(LOGIC_REVERSE_SPIRIT_ADULT))) ? 2 : 1)),
     });
 
     areaTable[RR_SPIRIT_TEMPLE_MQ_UNDER_LIKE_LIKE] = Region("Spirit Temple MQ Under Like Like", SCENE_SPIRIT_TEMPLE, {}, {
@@ -713,7 +714,8 @@ void RegionTable_Init_SpiritTemple() {
         //Exits
         ENTRANCE(RR_SPIRIT_TEMPLE_MQ_UNDER_LIKE_LIKE,  logic->CanHitSwitch()),
         //This exit only governs child forwards access, adult and reverse access starts on the other side so never checks this
-        ENTRANCE(RR_SPIRIT_TEMPLE_MQ_STATUE_ROOM_CHILD, logic->SmallKeys(SCENE_SPIRIT_TEMPLE, (ctx->GetTrickOption(RT_HOVER_BOOST_SIMPLE) && !(logic->Get(LOGIC_SPIRIT_MQ_3SUNS_ENEMIES) || logic->Get(LOGIC_REVERSE_SPIRIT_ADULT))) ? 3 : 2)),
+        ENTRANCE(RR_SPIRIT_TEMPLE_MQ_STATUE_ROOM_CHILD, logic->SmallKeys(SCENE_SPIRIT_TEMPLE, 
+                                                                           (ctx->GetTrickOption(RT_HOVER_BOOST_SIMPLE) && !((logic->Get(LOGIC_SPIRIT_MQ_3SUNS_ENEMIES) && (logic->CanUse(RG_CLIMB) || logic->CanUse(RG_LONGSHOT))) || logic->Get(LOGIC_REVERSE_SPIRIT_ADULT))) ? 3 : 2)),
     });
 
     areaTable[RR_SPIRIT_TEMPLE_MQ_STATUE_ROOM_CHILD] = Region("Spirit Temple MQ Statue Room Child", SCENE_SPIRIT_TEMPLE, {}, {

--- a/soh/soh/Enhancements/randomizer/location_access/dungeons/spirit_temple.cpp
+++ b/soh/soh/Enhancements/randomizer/location_access/dungeons/spirit_temple.cpp
@@ -1,6 +1,7 @@
 #include "soh/Enhancements/randomizer/location_access.h"
 #include "soh/Enhancements/randomizer/entrance.h"
 #include "soh/Enhancements/randomizer/dungeon.h"
+#include "soh/Enhancements/randomizer/randomizerTypes.h"
 
 using namespace Rando;
 
@@ -688,7 +689,9 @@ void RegionTable_Init_SpiritTemple() {
         //Exits
         ENTRANCE(RR_SPIRIT_TEMPLE_MQ_CHILD_SIDE_HUB,  logic->CanUse(RG_CRAWL) && logic->Get(LOGIC_SPIRIT_MQ_CRAWL_BOULDER)),
         //This tracks possible child access, if adult has not entered STATUE_ROOM. Certain Child Access is checked for separately as 7 Keys
-        ENTRANCE(RR_SPIRIT_TEMPLE_MQ_UNDER_LIKE_LIKE, logic->SmallKeys(SCENE_SPIRIT_TEMPLE, 1)),
+        //Needs 2 keys if hover recoils are on because you can recoil past the jet and waste a key without having Statue Room Access.
+        //If the clip through the grate in 3 suns room is added to logic, being able to perform that will reduce the requirement as well.
+        ENTRANCE(RR_SPIRIT_TEMPLE_MQ_UNDER_LIKE_LIKE, logic->SmallKeys(SCENE_SPIRIT_TEMPLE, (ctx->GetTrickOption(RT_HOVER_BOOST_SIMPLE) && !logic->Get(LOGIC_SPIRIT_MQ_3SUNS_ENEMIES)) ? 2 : 1)),
     });
 
     areaTable[RR_SPIRIT_TEMPLE_MQ_UNDER_LIKE_LIKE] = Region("Spirit Temple MQ Under Like Like", SCENE_SPIRIT_TEMPLE, {}, {


### PR DESCRIPTION
Using hover recoils, Adult can reach the symphony room lock without having access to Statue Room and thus the shared area of MQ spirit. This means that child logically needs an extra key to pass their early locks and get shared checks as adult can waste it, but it was not reflected in the current logic.

This change fixes the issue, requiring an extra key for the first 2 child locks while both hover boost tricks are on unless either the grate in 3 suns room (which gives a hover sliding adult statue room access) is both open and climbable, or Adult already has reverse access to the dungeon, either of which giving the shared key logic assumed Statue Room access.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8853120176.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8852978477.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8852855458.zip)
<!--- section:artifacts:end -->