### PR TITLE
Small Key Null Checks

### DIFF
--- a/soh/soh/Enhancements/randomizer/dungeon.cpp
+++ b/soh/soh/Enhancements/randomizer/dungeon.cpp
@@ -99,6 +99,10 @@ RandomizerSettingKey DungeonInfo::GetMQSetting() const {
 }
 
 int8_t FindUsedSmallKeys(const SaveContext* saveContext, const SceneID scene, const std::vector<uint8_t>* DoorFlags) {
+    if (DoorFlags == nullptr) {
+        return 0;
+    }
+
     // Get the swch value for the scene
     uint32_t swch;
     if (gPlayState != nullptr && gPlayState->sceneNum == scene) {

--- a/soh/soh/Enhancements/randomizer/logic.cpp
+++ b/soh/soh/Enhancements/randomizer/logic.cpp
@@ -2699,7 +2699,11 @@ int8_t Logic::GetSmallKeyCount(SceneID sceneId) {
         return FindTotalSmallKeys(mSaveContext, SCENE_THIEVES_HIDEOUT, &DoorFlags);
     }
 
-    return Rando::Context::GetInstance()->GetDungeons()->GetDungeonFromScene(sceneId)->GetTotalSmallKeys(mSaveContext);
+    if (auto* dungeon = Rando::Context::GetInstance()->GetDungeons()->GetDungeonFromScene(sceneId)) {
+        return dungeon->GetTotalSmallKeys(mSaveContext);
+    }
+
+    return FindTotalSmallKeys(mSaveContext, sceneId, nullptr);
 }
 
 void Logic::SetSmallKeyCount(uint32_t dungeonIndex, uint8_t count) {


### PR DESCRIPTION
The Treasure Box Shop is not in the dungeon table, so `GetDungeonFromScene` was returning a nullptr.

https://github.com/HarbourMasters/Shipwright/blob/a75c8113dd81b8fa6cc40432cc030b529124d8fc/soh/soh/Enhancements/randomizer/location_access/overworld/market.cpp#L205-L222

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8914976722.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8914855297.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8914792223.zip)
<!--- section:artifacts:end -->