### PR TITLE
Fix Gold Skulltula tokens overwriting the Bow inventory slot

### DIFF
--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -170,6 +170,18 @@ static s16 sExtraItemBases[] = {
     ITEM_BOW,   ITEM_BOW,   ITEM_SEEDS, ITEM_BOMBCHU, ITEM_BOMBCHU, ITEM_STICK, ITEM_STICK, ITEM_NUT,  ITEM_NUT,
 };
 
+// These tables only cover the item IDs that live in the inventory, so anything else (quest items, songs,
+// medallions) must report SLOT_NONE rather than read past their end.
+static s16 Item_GetSlot(u8 item) {
+    if ((item >= ITEM_STICKS_5) && (item < ITEM_STICKS_5 + ARRAY_COUNT(sExtraItemBases))) {
+        return SLOT(sExtraItemBases[item - ITEM_STICKS_5]);
+    }
+    if (item < ARRAY_COUNT(gItemSlots)) {
+        return SLOT(item);
+    }
+    return SLOT_NONE;
+}
+
 static s16 sEnvHazard = PLAYER_ENV_HAZARD_NONE;
 static s16 sEnvHazardActive = false;
 
@@ -1870,13 +1882,11 @@ u8 Item_Give(PlayState* play, u8 item) {
     // Gameplay stats: Update the time the item was obtained
     GameplayStats_SetTimestamp(play, item);
 
-    slot = SLOT(item);
-    if (item >= ITEM_STICKS_5) {
-        slot = SLOT(sExtraItemBases[item - ITEM_STICKS_5]);
-    }
+    slot = Item_GetSlot(item);
 
     osSyncPrintf(VT_FGCOL(YELLOW));
-    osSyncPrintf("item_get_setting=%d  pt=%d  z=%x\n", item, slot, gSaveContext.inventory.items[slot]);
+    osSyncPrintf("item_get_setting=%d  pt=%d  z=%x\n", item, slot,
+                 (slot != SLOT_NONE) ? gSaveContext.inventory.items[slot] : ITEM_NONE);
     osSyncPrintf(VT_RST);
 
     if ((item >= ITEM_MEDALLION_FOREST) && (item <= ITEM_MEDALLION_LIGHT)) {
@@ -2450,23 +2460,25 @@ u8 Item_Give(PlayState* play, u8 item) {
         }
         return Return_Item(item, MOD_NONE, ITEM_NONE);
     }
+    if (slot == SLOT_NONE) {
+        // Nothing to store: writing would land on an unrelated slot instead.
+        return Return_Item(item, MOD_NONE, ITEM_NONE);
+    }
+
     returnItem = gSaveContext.inventory.items[slot];
     osSyncPrintf("Item_Register(%d)=%d  %d\n", slot, item, returnItem);
-    INV_CONTENT(item) = item;
+    gSaveContext.inventory.items[slot] = item;
     return Return_Item(item, MOD_NONE, returnItem);
 }
 
 u8 Item_CheckObtainability(u8 item) {
     s16 i;
-    s16 slot = SLOT(item);
+    s16 slot = Item_GetSlot(item);
     s32 temp;
 
-    if (item >= ITEM_STICKS_5) {
-        slot = SLOT(sExtraItemBases[item - ITEM_STICKS_5]);
-    }
-
     osSyncPrintf(VT_FGCOL(GREEN));
-    osSyncPrintf("item_get_non_setting=%d  pt=%d  z=%x\n", item, slot, gSaveContext.inventory.items[slot]);
+    osSyncPrintf("item_get_non_setting=%d  pt=%d  z=%x\n", item, slot,
+                 (slot != SLOT_NONE) ? gSaveContext.inventory.items[slot] : ITEM_NONE);
     osSyncPrintf(VT_RST);
 
     if (IS_RANDO) {
@@ -2588,7 +2600,7 @@ u8 Item_CheckObtainability(u8 item) {
         return ITEM_NONE;
     }
 
-    return gSaveContext.inventory.items[slot];
+    return (slot != SLOT_NONE) ? gSaveContext.inventory.items[slot] : ITEM_NONE;
 }
 
 void Inventory_DeleteItem(u16 item, u16 invSlot) {


### PR DESCRIPTION
On a build with link-time optimization enabled, collecting a Gold Skulltula token permanently corrupts the save: the token is written into the **Bow inventory slot**, and the Gold Skulltula counter never increments. The underlying out-of-bounds access is present in every build; see "Repro conditions" below for why LTO is what makes it bite.

### Steps to reproduce

1. Build for Linux with clang 22, Release, adding `-flto=thin`. That flag is the only change from a stock Release build — the optimization level stays at the project's own `-O2`.
2. Start a new **Master Quest** save. No randomizer, no debug menu, no save editor.
3. Get the Kokiri Sword and Deku Shield and enter the Deku Tree.
4. Break the crate holding the first Gold Skulltula and collect the token.
5. Open the pause menu. The Gold Skulltula counter still reads **0**, and the **Bow slot** now holds a Gold Skulltula token.

`inventory.items[3]` goes from `ITEM_NONE` to `0x71` and `inventory.gsTokens` stays `0`. Once saved, the bad value round-trips through the save file, and the token can be assigned to a C button.

To catch the exact write under gdb:

```
watch gSaveContext.inventory.items[3] if gSaveContext.inventory.items[3] > 0x37 && gSaveContext.inventory.items[3] != 0xFF
```

It stops in `Item_Give`, called from `EnSi_Update` with `item = 113`.

### Cause

`gItemSlots` has 56 entries, covering only the item IDs that live in the inventory. `Item_Give` and `Item_CheckObtainability` index it with *any* item ID, up to `0x9D`:

```c
slot = SLOT(item);   // gItemSlots[item], unconditional, before any dispatch
```

For `ITEM_SKULL_TOKEN` (`0x71` = 113) that reads 57 bytes past the end, landing on `gUpgradeShifts[1]`, which holds `3` — `SLOT_BOW`. So the fallthrough at the end of `Item_Give`:

```c
INV_CONTENT(item) = item;   // items[gItemSlots[113]] = 113
```

stores the token into `items[3]`. It is deterministic, which is why the corruption always lands on the Bow and always with value `0x71`.

`sExtraItemBases` has the same problem: an 18-entry table indexed as `sExtraItemBases[item - ITEM_STICKS_5]`, which runs off the end for `ITEM_CUSTOM` and `ITEM_ROCS_FEATHER`.

### Why the token branch is never reached

`Item_Give` does have an `ITEM_SKULL_TOKEN` branch that returns before that store. Reading out of bounds is undefined behaviour, and link-time optimization is free to act on it. With the out-of-bounds read present, clang drops code:

- the entire `else if (item == ITEM_SKULL_TOKEN)` branch, including `gsTokens++`
- the `if (item == ITEM_MEDALLION_WATER) Horse_FixLakeHyliaPosition(play);` call

Both are present in the pre-link bitcode and absent from the linked binary; the disassembly of `Item_Give` contains no `0x71` comparison at all. Removing the out-of-bounds read restores both, with LTO still enabled.

**Repro conditions, to save anyone the trouble:** I hit this on a Linux build with `-flto=thin` (clang 22). Link-time optimization is what turns the undefined behaviour into deleted code, so this will *not* reproduce on a default Linux or macOS build, since neither enables IPO. Windows Release does — `soh/CMakeLists.txt` sets `INTERPROCEDURAL_OPTIMIZATION_RELEASE` — so the exposure is real for shipped builds, though I have not verified that MSVC makes the same deduction.

The out-of-bounds read itself is unconditional and present in every build; only whether a given compiler acts on it varies, and that can change with any toolchain update.

### The fix

Route both call sites through a bounds-checked `Item_GetSlot()` that reports `SLOT_NONE` for items with no inventory slot, and skip the inventory store when there is no slot.

Behaviour is unchanged for every item that has a real slot: they resolve to exactly the same index as before. The only cases that change are the ones that were previously reading or writing a slot picked out of unrelated data.

### Testing

- Linux, clang 22, stock Release (`-O2`) plus `-flto=thin`. Fresh Master Quest save: collecting Gold Skulltula tokens increments the counter and leaves the Bow slot untouched.
- Verified in the linked binary that the `ITEM_SKULL_TOKEN` branch and the Water Medallion horse fixup are both present again.
- Existing saves already carrying the bad value need to be repaired once; this only stops new corruption.

Related: #7004


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8917540629.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8917416530.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8917404561.zip)
<!--- section:artifacts:end -->