### PR TITLE
Enhancement, drop throw-only actors toggle

### DIFF
--- a/soh/soh/Enhancements/DropThrowOnlyActors.cpp
+++ b/soh/soh/Enhancements/DropThrowOnlyActors.cpp
@@ -1,0 +1,31 @@
+#include <soh/Enhancements/game-interactor/GameInteractor.h>
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
+
+void RegisterAllowThrowOnlyDrop() {
+    COND_VB_SHOULD(VB_ON_ACTOR_THROW_ONLY_CHECK, true, {
+        Actor* actor = va_arg(args, Actor*);
+
+        switch (actor->id) {
+            case ACTOR_EN_ISHI:
+            case ACTOR_EN_KUSA:
+            case ACTOR_EN_NIW:
+            case ACTOR_OBJ_TSUBO:
+                break;
+            default:
+                return;
+        }
+
+        // Set correct flag for held actor + condition for the cvar
+        if (CVarGetInteger(CVAR_ENHANCEMENT("DropThrowOnlyObjects"), false)) {
+            actor->flags &= ~ACTOR_FLAG_THROW_ONLY;
+            *should = true;
+        } else {
+            actor->flags |= ACTOR_FLAG_THROW_ONLY;
+            *should = false;
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterAllowThrowOnlyDrop, { CVAR_ENHANCEMENT("DropThrowOnlyObjects") });

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -2849,6 +2849,14 @@ typedef enum {
     // true
     // ```
     // #### `args`
+    // - `*Actor`
+    VB_ON_ACTOR_THROW_ONLY_CHECK,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
     // - `*EnHs`
     VB_TRADE_COJIRO,
 

--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -334,6 +334,12 @@ void SohMenu::AddMenuEnhancements() {
             "Butterflies will transform into a fairy as soon as you approach them with a Deku Stick, "
             "skipping the need to stand still and let the butterfly land on your stick."));
 
+    AddWidget(path, "Allow Dropping Throw-Only Objects", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("DropThrowOnlyObjects"))
+        .Options(CheckboxOptions().Tooltip("Allows normally throw-only objects (such as Cuccos, pots, grass, and small "
+                                           "rocks) to be dropped by pressing A while standing still. Can be toggled "
+                                           "while holding an object."));
+
     AddWidget(path, "Convenience", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Quit Fishing at Door", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("QuitFishingAtDoor"))

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -7461,13 +7461,23 @@ void func_8083EA94(Player* this, PlayState* play) {
     Player_AnimPlayOnce(play, this, GET_PLAYER_ANIM(PLAYER_ANIMGROUP_throw, this->modelAnimType));
 }
 
-s32 func_8083EAF0(Player* this, Actor* actor) {
-    if ((actor != NULL) && !(actor->flags & ACTOR_FLAG_THROW_ONLY) &&
+/**
+ * Checks if an actor can be thrown or dropped.
+ * It is assumed that the `actor` argument is the actor currently being carried.
+ *
+ * @return true if it can be thrown, false if it can be dropped.
+ */
+s32 Player_CanThrowCarriedActor(Player* this, Actor* actor) {
+    // If the actor arg is null, true will be returned.
+    // It doesn't make sense for a non-existent actor to be thrown or dropped, so
+    // the safety check should happen before this function is even called.
+    if ((actor != NULL) &&
+        GameInteractor_Should(VB_ON_ACTOR_THROW_ONLY_CHECK, !(actor->flags & ACTOR_FLAG_THROW_ONLY), actor) &&
         ((this->linearVelocity < 1.1f) || (actor->id == ACTOR_EN_BOM_CHU))) {
-        return 0;
+        return false;
     }
 
-    return 1;
+    return true;
 }
 
 s32 Player_ActionHandler_9(Player* this, PlayState* play) {
@@ -7480,17 +7490,17 @@ s32 Player_ActionHandler_9(Player* this, PlayState* play) {
                                CHECK_BTN_ANY(sControlInput->press.button, buttonsToCheck)),
                               sControlInput)) {
         if (!func_80835644(play, this, this->heldActor)) {
-            if (!func_8083EAF0(this, this->heldActor)) {
+            if (!Player_CanThrowCarriedActor(this, this->heldActor)) {
                 Player_SetupAction(play, this, Player_Action_808464B0, 1);
                 Player_AnimPlayOnce(play, this, GET_PLAYER_ANIM(PLAYER_ANIMGROUP_put, this->modelAnimType));
             } else {
                 func_8083EA94(this, play);
             }
         }
-        return 1;
+        return true;
     }
 
-    return 0;
+    return false;
 }
 
 s32 func_8083EC18(Player* this, PlayState* play, u32 wallFlags) {
@@ -11037,7 +11047,7 @@ void Player_UpdateInterface(PlayState* play, Player* this) {
                 } else if ((this->stateFlags1 & PLAYER_STATE1_CARRYING_ACTOR) && (this->getItemId == GI_NONE) &&
                            (heldActor != NULL)) {
                     if ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) || (heldActor->id == ACTOR_EN_NIW)) {
-                        if (func_8083EAF0(this, heldActor) == 0) {
+                        if (!Player_CanThrowCarriedActor(this, heldActor)) {
                             doAction = DO_ACTION_DROP;
                         } else {
                             doAction = DO_ACTION_THROW;


### PR DESCRIPTION
Supersedes #5882

Allow dropping normally throw-only actors by setting the actor's flag according to cvar when the actor is held (in `Player_CanThrowCarriedActor` check).

I tried putting it in action handler 9 (drop/throw) in the already existing hook as well as in setup lifting/upper action carry actor, but these resulted in noticeable lag between lift and correct A text.

Function name and comments from decomp.

https://github.com/user-attachments/assets/0a421b5f-91b2-44e9-a9f4-6a1176b51cba


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8932565352.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8932455462.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/8932284712.zip)
<!--- section:artifacts:end -->