### PR TITLE
Restoration, hover fishing condition + XZ speed

### DIFF
--- a/soh/soh/Enhancements/Fishing.cpp
+++ b/soh/soh/Enhancements/Fishing.cpp
@@ -3,6 +3,7 @@
 
 extern "C" {
 #include <variables.h>
+#include <functions.h>
 extern PlayState* gPlayState;
 extern SaveContext gSaveContext;
 f32 Fishing_GetMinimumRequiredScore();
@@ -17,6 +18,21 @@ void BuildFishingMessage(uint16_t* textId, bool* loadFromMessageTable) {
 void RegisterFishingMessages() {
     COND_ID_HOOK(OnOpenText, 0x40AE, CVarGetInteger(CVAR_ENHANCEMENT("CustomizeFishing"), 0), BuildFishingMessage);
     COND_ID_HOOK(OnOpenText, 0x4080, CVarGetInteger(CVAR_ENHANCEMENT("CustomizeFishing"), 0), BuildFishingMessage);
+}
+
+void RegisterHoverFishing() {
+    COND_VB_SHOULD(VB_NOT_CAST_FISHING, (CVarGetInteger(CVAR_ENHANCEMENT("HoverFishing"), false)), {
+        Vec3f* rodCheckPos = va_arg(args, Vec3f*);
+        *should = false;
+        // Run only original NTSC 1.0 check before cast
+        if (BgCheck_SphVsFirstPoly(&gPlayState->colCtx, rodCheckPos, 20.0f)) {
+            *should = true;
+        }
+    });
+
+    COND_VB_SHOULD(VB_FISHING_ZERO_XZ, (CVarGetInteger(CVAR_ENHANCEMENT("HoverFishing"), false)), {
+        *should = false; // NTSC 1.0
+    });
 }
 
 // Vanilla bug: Not possible to fish with blank B because blank B item value 0xFF is saved
@@ -43,5 +59,6 @@ void RegisterAllowFishingBlankB() {
 }
 
 static RegisterShipInitFunc initFunc(RegisterFishingMessages, { CVAR_ENHANCEMENT("CustomizeFishing") });
+static RegisterShipInitFunc initHoverFishing(RegisterHoverFishing, { CVAR_ENHANCEMENT("HoverFishing") });
 static RegisterShipInitFunc initAllowFishingBlankB(RegisterAllowFishingBlankB,
                                                    { CVAR_ENHANCEMENT("FishingBlankB"), "IS_RANDO" });

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -2575,6 +2575,23 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // !(this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) || (this->actor.world.pos.z > 1300.0f) ||
+    // BgCheck_SphVsFirstPoly(&play->colCtx, &rodCheckPos, 20.0f)
+    // ```
+    // #### `args`
+    // - `*f32`
+    VB_NOT_CAST_FISHING,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - None
+    VB_FISHING_ZERO_XZ,
+
+    // #### `result`
+    // ```c
     // false
     // ```
     // #### `args`

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6598,17 +6598,20 @@ s32 func_8083C6B8(PlayState* play, Player* this) {
 
             rodCheckPos.y += 50.0f;
 
-            if (CVarGetInteger(CVAR_ENHANCEMENT("HoverFishing"), 0)
-                    ? 0
-                    : !(this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) || (this->actor.world.pos.z > 1300.0f) ||
-                          BgCheck_SphVsFirstPoly(&play->colCtx, &rodCheckPos, 20.0f)) {
+            if (GameInteractor_Should(VB_NOT_CAST_FISHING,
+                                      (!(this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) ||
+                                       (this->actor.world.pos.z > 1300.0f) ||
+                                       BgCheck_SphVsFirstPoly(&play->colCtx, &rodCheckPos, 20.0f)),
+                                      &rodCheckPos)) {
                 Sfx_PlaySfxCentered(NA_SE_SY_ERROR);
                 return 0;
             }
 
             Player_SetupAction(play, this, Player_Action_80850C68, 0);
             this->unk_860 = 1;
-            Player_ZeroSpeedXZ(this);
+            if (GameInteractor_Should(VB_FISHING_ZERO_XZ, true)) {
+                Player_ZeroSpeedXZ(this);
+            }
             Player_AnimPlayOnce(play, this, &gPlayerAnim_link_fishing_throw);
             return 1;
         } else {


### PR DESCRIPTION
See decomp, NTSC 1.0 did have a check in place where the anti-hover fix is which in SoH restoration has been replaced with "false" to never fail start fishing.
Also, `Player_ZeroSpeedXZ` shouldn't run for restoration.
(The ordering of `unk_860`/fishing rod state is not functionally important)

https://github.com/zeldaret/oot/blob/05e9046417d11d8a9660074b1c014023b337eb27/src/overlays/actors/ovl_player_actor/z_player.c#L6632-L6650