### PR TITLE
Minor Typo: Fix Roc's Feather Trap name typo

### DIFF
--- a/soh/soh/Enhancements/randomizer/Traps.cpp
+++ b/soh/soh/Enhancements/randomizer/Traps.cpp
@@ -670,7 +670,7 @@ static void InitTrickNames() {
     trickNameTable[RG_ROCS_FEATHER] = {
         Text{ "Chicken Wing", "Chicken Wing", "Chicken Wing" }, // "Chicken Wing"
         Text{ "Roc's Leg", "Roc's Leg", "Roc's Leg" },          // "Roc's Leg"
-        Text{ "Roc's Fapper", "Roc's Fapper", "Roc's Fapper" }, // "Roc's Fapper"
+        Text{ "Roc's Flapper", "Roc's Flapper", "Roc's Flapper" }, // "Roc's Flapper"
     };
     trickNameTable[RG_DEATH_MOUNTAIN_CRATER_BEAN_SOUL] = {
         // TODO_TRANSLATE

--- a/soh/soh/Enhancements/randomizer/Traps.cpp
+++ b/soh/soh/Enhancements/randomizer/Traps.cpp
@@ -668,8 +668,8 @@ static void InitTrickNames() {
         Text{ "Force Gem" },
     };
     trickNameTable[RG_ROCS_FEATHER] = {
-        Text{ "Chicken Wing", "Chicken Wing", "Chicken Wing" }, // "Chicken Wing"
-        Text{ "Roc's Leg", "Roc's Leg", "Roc's Leg" },          // "Roc's Leg"
+        Text{ "Chicken Wing", "Chicken Wing", "Chicken Wing" },    // "Chicken Wing"
+        Text{ "Roc's Leg", "Roc's Leg", "Roc's Leg" },             // "Roc's Leg"
         Text{ "Roc's Flapper", "Roc's Flapper", "Roc's Flapper" }, // "Roc's Flapper"
     };
     trickNameTable[RG_DEATH_MOUNTAIN_CRATER_BEAN_SOUL] = {


### PR DESCRIPTION
Pretty simple. Fixes what I assume must be a typo in the Roc's Feather Ice Trap names.