### PR TITLE
Enemy rando, fix Dark Link crush etc voidouts

### DIFF
--- a/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
+++ b/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
@@ -656,16 +656,6 @@ void RegisterEnemyRandomizer() {
     COND_VB_SHOULD(VB_TRIGGER_VOIDOUT, ENEMY_RANDOMIZER_ENABLED, {
         Actor* actor = va_arg(args, Actor*);
 
-        if (actor->category != ACTORCAT_PLAYER) {
-            *should = false;
-            Actor_Kill(actor);
-        }
-    });
-
-    // prevent Dark Link from triggering a voidout from quicksand, crushing, floortype 9, whirlpools
-    COND_VB_SHOULD(VB_QUICKSAND_CRUSH_WHIRLPOOL_VOIDOUT, ENEMY_RANDOMIZER_ENABLED, {
-        Actor* actor = va_arg(args, Actor*);
-
         if (*should == true && actor->category != ACTORCAT_PLAYER) {
             // Improvement opportunity: Play sfx
             *should = false;

--- a/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
+++ b/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
@@ -662,6 +662,17 @@ void RegisterEnemyRandomizer() {
         }
     });
 
+    // prevent Dark Link from triggering a voidout from quicksand, crushing, floortype 9, whirlpools
+    COND_VB_SHOULD(VB_QUICKSAND_CRUSH_WHIRLPOOL_VOIDOUT, ENEMY_RANDOMIZER_ENABLED, {
+        Actor* actor = va_arg(args, Actor*);
+
+        if (*should == true && actor->category != ACTORCAT_PLAYER) {
+            // Improvement opportunity: Play sfx
+            *should = false;
+            Actor_Kill(actor);
+        }
+    });
+
     // prevent dark link dealing fall damage to the player
     COND_VB_SHOULD(VB_RECIEVE_FALL_DAMAGE, ENEMY_RANDOMIZER_ENABLED, {
         Actor* actor = va_arg(args, Actor*);

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -3084,15 +3084,6 @@ typedef enum {
 
     // #### `result`
     // ```c
-    // (sp68 || (this->actor.bgCheckFlags & BGCHECKFLAG_CRUSHED) || (sFloorType == 9) ||
-    // (this->stateFlags2 & PLAYER_STATE2_FORCED_VOID_OUT))
-    // ```
-    // #### `args`
-    // - `*Actor`
-    VB_QUICKSAND_CRUSH_WHIRLPOOL_VOIDOUT,
-
-    // #### `result`
-    // ```c
     // true
     // ```
     // #### `args`

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -2579,7 +2579,7 @@ typedef enum {
     // BgCheck_SphVsFirstPoly(&play->colCtx, &rodCheckPos, 20.0f)
     // ```
     // #### `args`
-    // - `*f32`
+    // - `*Vec3f`
     VB_NOT_CAST_FISHING,
 
     // #### `result`
@@ -3081,6 +3081,15 @@ typedef enum {
     // #### `args`
     // - `*Actor`
     VB_TRIGGER_VOIDOUT,
+
+    // #### `result`
+    // ```c
+    // (sp68 || (this->actor.bgCheckFlags & BGCHECKFLAG_CRUSHED) || (sFloorType == 9) ||
+    // (this->stateFlags2 & PLAYER_STATE2_FORCED_VOID_OUT))
+    // ```
+    // #### `args`
+    // - `*Actor`
+    VB_QUICKSAND_CRUSH_WHIRLPOOL_VOIDOUT,
 
     // #### `result`
     // ```c

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -3076,7 +3076,7 @@ typedef enum {
 
     // #### `result`
     // ```c
-    // true
+    // varies
     // ```
     // #### `args`
     // - `*Actor`

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -4731,8 +4731,10 @@ s32 func_808382DC(Player* this, PlayState* play) {
     } else {
         sp68 = ((Player_GetHeight(this) - 8.0f) < (this->unk_6C4 * this->actor.scale.y));
 
-        if (sp68 || (this->actor.bgCheckFlags & BGCHECKFLAG_CRUSHED) || (sFloorType == 9) ||
-            (this->stateFlags2 & PLAYER_STATE2_FORCED_VOID_OUT)) {
+        if (GameInteractor_Should(VB_QUICKSAND_CRUSH_WHIRLPOOL_VOIDOUT,
+                                  (sp68 || (this->actor.bgCheckFlags & BGCHECKFLAG_CRUSHED) || (sFloorType == 9) ||
+                                   (this->stateFlags2 & PLAYER_STATE2_FORCED_VOID_OUT)),
+                                  &this->actor)) {
             Player_PlayVoiceSfx(this, NA_SE_VO_LI_DAMAGE_S);
 
             if (sp68) {
@@ -4758,9 +4760,7 @@ s32 func_808382DC(Player* this, PlayState* play) {
                     gSaveContext.respawn[RESPAWN_MODE_DOWN].yaw = respawnInfo->yaw;
                 }
 
-                if (GameInteractor_Should(VB_TRIGGER_VOIDOUT, true, this)) {
-                    Play_TriggerVoidOut(play);
-                }
+                Play_TriggerVoidOut(play);
             }
 
             Player_PlayVoiceSfx(this, NA_SE_VO_LI_TAKEN_AWAY);

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -4731,7 +4731,7 @@ s32 func_808382DC(Player* this, PlayState* play) {
     } else {
         sp68 = ((Player_GetHeight(this) - 8.0f) < (this->unk_6C4 * this->actor.scale.y));
 
-        if (GameInteractor_Should(VB_QUICKSAND_CRUSH_WHIRLPOOL_VOIDOUT,
+        if (GameInteractor_Should(VB_TRIGGER_VOIDOUT,
                                   (sp68 || (this->actor.bgCheckFlags & BGCHECKFLAG_CRUSHED) || (sFloorType == 9) ||
                                    (this->stateFlags2 & PLAYER_STATE2_FORCED_VOID_OUT)),
                                   &this->actor)) {


### PR DESCRIPTION
The hook was only for `Play_TriggerVoidout`, which led to `play->haltAllActors = true` still running and freezing the player, forcing warping out or other action.

Hook is now at the voidout conditions handled by this part, quicksand (`sp68`), crushing, floortype 9, and Water Temple whirlpools. Tested crushing Dark Link and player.

Would be cool to play the voidout Link sound effect, but when I tried adding it it just played the very beginning.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9023857006.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9023782397.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9023734453.zip)
<!--- section:artifacts:end -->