### PR TITLE
Savestates, add `sEffectContext`

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -186,7 +186,7 @@ void EnItem00_CustomItemsParticles(Actor* Parent, PlayState* play, GetItemEntry 
 void EnItem00_SetupAction(EnItem00* this, EnItem00ActionFunc actionFunc);
 void func_8001E5C8(EnItem00* this, PlayState* play);
 void Item_DropCollectibleRandom(PlayState* play, Actor* fromActor, Vec3f* spawnPos, s16 params);
-void EffectBlure_ChangeType(EffectBlure* this, int type);
+void EffectBlureShip_ChangeType(EffectBlure* this, int type);
 void EffectBlure_AddVertex(EffectBlure* this, Vec3f* p1, Vec3f* p2);
 void EffectBlure_AddSpace(EffectBlure* this);
 void EffectBlure_Init1(void* thisx, void* initParamsx);

--- a/soh/soh/Enhancements/savestates.cpp
+++ b/soh/soh/Enhancements/savestates.cpp
@@ -16,6 +16,7 @@
 #include "savestate_serialize.h"
 
 extern "C" PlayState* gPlayState;
+extern "C" EffectContext sEffectContext;
 
 extern "C" void BgDdanKd_SaveState(SaveStateCtx* ctx);
 extern "C" void BgDodoago_SaveState(SaveStateCtx* ctx);
@@ -86,6 +87,7 @@ typedef struct SaveStateInfo {
     unsigned char audioHeapCopy[AUDIO_HEAP_SIZE];
 
     SaveContext saveContextCopy;
+    EffectContext effectContextCopy;
     GameInfo gameInfoCopy;
     AudioContext audioContextCopy;
     uint32_t rngSeed;
@@ -442,6 +444,7 @@ void SaveState::Save(void) {
 
     memcpy(&info->saveContextCopy, &gSaveContext, sizeof(gSaveContext));
     memcpy(&info->gameInfoCopy, gGameInfo, sizeof(*gGameInfo));
+    memcpy(&info->effectContextCopy, &sEffectContext, sizeof(sEffectContext));
 
     // Various static data
     SaveOverlayStaticData();
@@ -459,6 +462,7 @@ void SaveState::Load(void) {
 
     memcpy(&gSaveContext, &info->saveContextCopy, sizeof(gSaveContext));
     memcpy(gGameInfo, &info->gameInfoCopy, sizeof(*gGameInfo));
+    memcpy(&sEffectContext, &info->effectContextCopy, sizeof(sEffectContext));
 
     memcpy(gActiveSounds, info->gActiveSoundsCopy, sizeof(gActiveSounds));
     memcpy(gSoundBankMuted, &info->gSoundBankMutedCopy, sizeof(info->gSoundBankMutedCopy));

--- a/soh/src/code/z_eff_blure.c
+++ b/soh/src/code/z_eff_blure.c
@@ -73,7 +73,7 @@ void EffectBlure_AddVertex(EffectBlure* this, Vec3f* p1, Vec3f* p2) {
 }
 
 // SoH: dumb doo doo command to change the type of a weapon's blur on the fly. Link's Swords with unique trail colors.
-void EffectBlure_ChangeType(EffectBlure* this, int type) {
+void EffectBlureShip_ChangeType(EffectBlure* this, int type) {
     this->trailType = type;
 }
 
@@ -206,6 +206,7 @@ s32 EffectBlure_Update(void* thisx) {
     static u8 changed = 0;
     u8 reset = 0;
 
+    // SoH
     switch (this->trailType) {
         case TRAIL_TYPE_BOOMERANG:
             if (CVarGetInteger(CVAR_COSMETIC("Trails.Boomerang.Changed"), 0)) {
@@ -322,6 +323,7 @@ s32 EffectBlure_Update(void* thisx) {
         }
     }
 
+    // Vanilla code from here on
     if (this == NULL) {
         return 0;
     }

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -1830,7 +1830,7 @@ void Player_PostLimbDrawGameplay(PlayState* play, s32 limbIndex, Gfx** dList, Ve
             } else {
                 D_80126080.x = sMeleeWeaponLengths[Player_GetMeleeWeaponHeld(this)];
                 EffectBlureShip_ChangeType(Effect_GetByIndex(this->meleeWeaponEffectIndex),
-                                       sSwordTypes[Player_GetMeleeWeaponHeld(this)]);
+                                           sSwordTypes[Player_GetMeleeWeaponHeld(this)]);
             }
 
             func_80090A28(this, spE4);

--- a/soh/src/code/z_player_lib.c
+++ b/soh/src/code/z_player_lib.c
@@ -1807,7 +1807,7 @@ void Player_PostLimbDrawGameplay(PlayState* play, s32 limbIndex, Gfx** dList, Ve
                 D_80126080.x = this->unk_85C * 5000.0f;
                 func_80090A28(this, sp124);
                 if (this->meleeWeaponState != 0) {
-                    EffectBlure_ChangeType(Effect_GetByIndex(this->meleeWeaponEffectIndex), TRAIL_TYPE_STICK);
+                    EffectBlureShip_ChangeType(Effect_GetByIndex(this->meleeWeaponEffectIndex), TRAIL_TYPE_STICK);
                     func_800906D4(play, this, sp124);
                 } else {
                     Math_Vec3f_Copy(&this->meleeWeaponInfo[0].tip, &sp124[0]);
@@ -1829,7 +1829,7 @@ void Player_PostLimbDrawGameplay(PlayState* play, s32 limbIndex, Gfx** dList, Ve
                 D_80126080.x = 1500.0f;
             } else {
                 D_80126080.x = sMeleeWeaponLengths[Player_GetMeleeWeaponHeld(this)];
-                EffectBlure_ChangeType(Effect_GetByIndex(this->meleeWeaponEffectIndex),
+                EffectBlureShip_ChangeType(Effect_GetByIndex(this->meleeWeaponEffectIndex),
                                        sSwordTypes[Player_GetMeleeWeaponHeld(this)]);
             }
 


### PR DESCRIPTION
`sEffectContext` not being saved in savestates led to crash if saving before Dark Link and loading after defeating him due to Dark Link's trail blure effect being deleted and not restored on load.
Tested adding this with Dark Link and this prevents crash.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9027172621.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9027093893.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9027070573.zip)
<!--- section:artifacts:end -->