### PR TITLE
Fix bugs in hints

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/hints.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/hints.cpp
@@ -480,8 +480,8 @@ static void CreateTrialHints(uint8_t copies) {
                 ctx->GetTrials()->GetTrialList();             // there's probably a way to remove this assignment
             if (ctx->GetOption(RSK_TRIAL_COUNT).Get() >= 4) { // 4 or 5 required trials, get skipped trials
                 trials = FilterFromPool(trials, [](TrialInfo* trial) { return trial->IsSkipped(); });
-            } else { // 1 to 3 trials, get requried trials
-                auto requiredTrials = FilterFromPool(trials, [](TrialInfo* trial) { return trial->IsRequired(); });
+            } else { // 1 to 3 trials, get required trials
+                trials = FilterFromPool(trials, [](TrialInfo* trial) { return trial->IsRequired(); });
             }
             for (auto& trial : trials) { // create a hint for each hinted trial
                 AddGossipStoneHintCopies(copies, HINT_TYPE_TRIAL, "Trial", {}, {}, {}, { trial->GetTrialKey() });

--- a/soh/soh/Enhancements/randomizer/hint.cpp
+++ b/soh/soh/Enhancements/randomizer/hint.cpp
@@ -181,9 +181,10 @@ void Hint::NamesChosen() {
     }
 
     if (hintType == HINT_TYPE_ITEM || hintType == HINT_TYPE_ITEM_AREA) {
+        namesTemp.clear();
+        saveNames = false;
+
         for (size_t c = 0; c < locations.size(); c++) {
-            namesTemp = {};
-            saveNames = false;
             uint8_t selection = GetRandomHintTextEntry(GetItemHintText(static_cast<u8>(c)));
             if (selection > 0) {
                 saveNames = true;
@@ -197,7 +198,7 @@ void Hint::NamesChosen() {
 
     if (hintType == HINT_TYPE_FOOLISH || hintType == HINT_TYPE_ITEM_AREA || hintType == HINT_TYPE_WOTH ||
         hintType == HINT_TYPE_ALTAR_CHILD || hintType == HINT_TYPE_ALTAR_ADULT) {
-        namesTemp = {};
+        namesTemp.clear();
         saveNames = false;
 
         for (uint8_t c = 0; c < areas.size(); c++) {

--- a/soh/soh/resource/type/Scene.cpp
+++ b/soh/soh/resource/type/Scene.cpp
@@ -2,7 +2,7 @@
 
 namespace SOH {
 void* Scene::GetPointer() {
-    // Scene is a special type that requries C++ processing. As such, we return nothing.
+    // Scene is a special type that requires C++ processing. As such, we return nothing.
     return nullptr;
 }
 


### PR DESCRIPTION
1. fix filtering trials hints when only 1-3 required
2. clearing names per iteration won't work with dual hints

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9030957749.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9030735082.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9030698677.zip)
<!--- section:artifacts:end -->