### PR TITLE
Enemy rando, set EnTp EnSkb EnPeehat collider positions on actor init

### DIFF
--- a/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
+++ b/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
@@ -620,8 +620,7 @@ void EnemyRando_SetColliderPosSkb(void* ptr) {
     EnSkb* enSkb = (EnSkb*)ptr;
     u8 i;
 
-    // EnSkb doesn't set collider for element 0
-    for (i = 1; i < 20; i++) {
+    for (i = 0; i < 2; i++) {
         enSkb->collider.elements[i].dim.worldSphere.center.x = (s16)enSkb->actor.world.pos.x;
         enSkb->collider.elements[i].dim.worldSphere.center.y = (s16)enSkb->actor.world.pos.y;
         enSkb->collider.elements[i].dim.worldSphere.center.z = (s16)enSkb->actor.world.pos.z;

--- a/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
+++ b/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
@@ -21,6 +21,8 @@ extern "C" {
 #include "src/overlays/actors/ovl_En_Peehat/z_en_peehat.h"
 #include "src/overlays/actors/ovl_En_Rr/z_en_rr.h"
 #include "src/overlays/actors/ovl_En_Vali/z_en_vali.h"
+#include "src/overlays/actors/ovl_En_Skb/z_en_skb.h"
+#include "src/overlays/actors/ovl_En_Tp/z_en_tp.h"
 
 extern PlayState* gPlayState;
 }
@@ -602,6 +604,46 @@ void FixClubMoblinScale(void* ptr) {
     }
 }
 
+// EnTp, EnSkb and EnPeehat update collider position only in their draw functions,
+// causes 0,0,0 issues, so set their collider positions once on actor init
+void EnemyRando_SetColliderPosTp(void* ptr) {
+    EnTp* enTp = (EnTp*)ptr;
+
+    enTp->collider.elements[0].dim.worldSphere.center.x = (s16)enTp->actor.world.pos.x;
+    enTp->collider.elements[0].dim.worldSphere.center.y = (s16)enTp->actor.world.pos.y;
+    enTp->collider.elements[0].dim.worldSphere.center.z = (s16)enTp->actor.world.pos.z;
+    enTp->collider.elements[0].dim.worldSphere.radius =
+        (s16)(enTp->collider.elements[0].dim.modelSphere.radius * enTp->collider.elements[0].dim.scale);
+}
+
+void EnemyRando_SetColliderPosSkb(void* ptr) {
+    EnSkb* enSkb = (EnSkb*)ptr;
+    u8 i;
+
+    // EnSkb doesn't set collider for element 0
+    for (i = 1; i < 20; i++) {
+        enSkb->collider.elements[i].dim.worldSphere.center.x = (s16)enSkb->actor.world.pos.x;
+        enSkb->collider.elements[i].dim.worldSphere.center.y = (s16)enSkb->actor.world.pos.y;
+        enSkb->collider.elements[i].dim.worldSphere.center.z = (s16)enSkb->actor.world.pos.z;
+        enSkb->collider.elements[i].dim.worldSphere.radius =
+            (s16)(enSkb->collider.elements[i].dim.modelSphere.radius * enSkb->collider.elements[i].dim.scale);
+    }
+}
+
+void EnemyRando_SetColliderPosPeehat(void* ptr) {
+    EnPeehat* enPeehat = (EnPeehat*)ptr;
+    u8 i;
+
+    for (i = 0; i < 4; i++) {
+        enPeehat->colliderQuad.dim.quad[i].x = enPeehat->actor.world.pos.x + (f32)i;
+        enPeehat->colliderQuad.dim.quad[i].y = enPeehat->actor.world.pos.y + (f32)i;
+        enPeehat->colliderQuad.dim.quad[i].z = enPeehat->actor.world.pos.z + (f32)i;
+    }
+    Collider_SetQuadVertices(&enPeehat->colliderQuad, &enPeehat->colliderQuad.dim.quad[0],
+                             &enPeehat->colliderQuad.dim.quad[1], &enPeehat->colliderQuad.dim.quad[2],
+                             &enPeehat->colliderQuad.dim.quad[3]);
+}
+
 static void OnGerudoFighterDefeat(void* refActor) {
     EnGeldB* enGeldB = reinterpret_cast<EnGeldB*>(refActor);
 
@@ -651,6 +693,9 @@ void CustomPeehatLarvaDestroy(Actor* thisx, PlayState* play) {
 
 void RegisterEnemyRandomizer() {
     COND_ID_HOOK(OnActorInit, ACTOR_EN_MB, ENEMY_RANDOMIZER_ENABLED, FixClubMoblinScale);
+    COND_ID_HOOK(OnActorInit, ACTOR_EN_TP, ENEMY_RANDOMIZER_ENABLED, EnemyRando_SetColliderPosTp);
+    COND_ID_HOOK(OnActorInit, ACTOR_EN_SKB, ENEMY_RANDOMIZER_ENABLED, EnemyRando_SetColliderPosSkb);
+    COND_ID_HOOK(OnActorInit, ACTOR_EN_PEEHAT, ENEMY_RANDOMIZER_ENABLED, EnemyRando_SetColliderPosPeehat);
 
     // prevent dark link from triggering a voidout
     COND_VB_SHOULD(VB_TRIGGER_VOIDOUT, ENEMY_RANDOMIZER_ENABLED, {

--- a/soh/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
+++ b/soh/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
@@ -207,8 +207,8 @@ void EnPeehat_Init(Actor* thisx, PlayState* play) {
     this->actor.floorHeight = this->actor.world.pos.y;
     Collider_InitCylinder(play, &this->colCylinder);
     Collider_SetCylinder(play, &this->colCylinder, &this->actor, &sCylinderInit);
-    Collider_InitQuad(play, &this->colQuad);
-    Collider_SetQuad(play, &this->colQuad, &this->actor, &sQuadInit);
+    Collider_InitQuad(play, &this->colliderQuad);
+    Collider_SetQuad(play, &this->colliderQuad, &this->actor, &sQuadInit);
     Collider_InitJntSph(play, &this->colJntSph);
     Collider_SetJntSph(play, &this->colJntSph, &this->actor, &sJntSphInit, this->colJntSphItemList);
 
@@ -236,8 +236,8 @@ void EnPeehat_Init(Actor* thisx, PlayState* play) {
             this->colCylinder.dim.height = 15;
             this->colCylinder.dim.yShift = -5;
             this->colCylinder.info.bumper.dmgFlags = 0x1F824;
-            this->colQuad.base.atFlags = AT_ON | AT_TYPE_ENEMY;
-            this->colQuad.base.acFlags = AC_ON | AC_TYPE_PLAYER;
+            this->colliderQuad.base.atFlags = AT_ON | AT_TYPE_ENEMY;
+            this->colliderQuad.base.acFlags = AC_ON | AC_TYPE_PLAYER;
             this->actor.naviEnemyId = 0x49; // Larva
             EnPeehat_Larva_SetStateSeekPlayer(this);
             break;
@@ -562,15 +562,15 @@ void EnPeehat_Larva_StateSeekPlayer(EnPeehat* this, PlayState* play) {
     this->bladeRot += this->bladeRotVel;
     Math_SmoothStepToF(&this->scaleShift, 0.075f, 1.0f, 0.005f, 0.0f);
     Audio_PlayActorSound2(&this->actor, NA_SE_EN_PIHAT_SM_FLY - SFX_FLAG);
-    if (this->colQuad.base.atFlags & AT_BOUNCED) {
+    if (this->colliderQuad.base.atFlags & AT_BOUNCED) {
         this->actor.colChkInfo.health = 0;
-        this->colQuad.base.acFlags = this->colQuad.base.acFlags & ~AC_BOUNCED;
+        this->colliderQuad.base.acFlags = this->colliderQuad.base.acFlags & ~AC_BOUNCED;
         EnPeehat_SetStateAttackRecoil(this);
-    } else if ((this->colQuad.base.atFlags & AT_HIT) || (this->colCylinder.base.acFlags & AC_HIT) ||
+    } else if ((this->colliderQuad.base.atFlags & AT_HIT) || (this->colCylinder.base.acFlags & AC_HIT) ||
                (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
         Player* player = GET_PLAYER(play);
-        this->colQuad.base.atFlags &= ~AT_HIT;
-        if (!(this->colCylinder.base.acFlags & AC_HIT) && &player->actor == this->colQuad.base.at) {
+        this->colliderQuad.base.atFlags &= ~AT_HIT;
+        if (!(this->colCylinder.base.acFlags & AC_HIT) && &player->actor == this->colliderQuad.base.at) {
             if (Rand_ZeroOne() > 0.5f) {
                 this->actor.world.rot.y += 0x2000;
             } else {
@@ -588,7 +588,7 @@ void EnPeehat_Larva_StateSeekPlayer(EnPeehat* this, PlayState* play) {
                 EffectSsDeadDb_Spawn(play, &pos, &zeroVec, &zeroVec, 40, 7, 255, 255, 255, 255, 255, 0, 0, 1, 9, 1);
             }
         }
-        if (&player->actor != this->colQuad.base.at || this->colCylinder.base.acFlags & AC_HIT) {
+        if (&player->actor != this->colliderQuad.base.at || this->colCylinder.base.acFlags & AC_HIT) {
             if (!(this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
                 EffectSsDeadSound_SpawnStationary(play, &this->actor.projectedPos, NA_SE_EN_PIHAT_SM_DEAD, 1, 1, 40);
             }
@@ -885,8 +885,8 @@ void EnPeehat_StateExplode(EnPeehat* this, PlayState* play) {
 }
 
 void EnPeehat_Adult_CollisionCheck(EnPeehat* this, PlayState* play) {
-    if ((this->colCylinder.base.acFlags & AC_BOUNCED) || (this->colQuad.base.acFlags & AC_BOUNCED)) {
-        this->colQuad.base.acFlags &= ~AC_BOUNCED;
+    if ((this->colCylinder.base.acFlags & AC_BOUNCED) || (this->colliderQuad.base.acFlags & AC_BOUNCED)) {
+        this->colliderQuad.base.acFlags &= ~AC_BOUNCED;
         this->colCylinder.base.acFlags &= ~AC_BOUNCED;
         this->colJntSph.base.acFlags &= ~AC_HIT;
     } else if (this->colJntSph.base.acFlags & AC_HIT) {
@@ -973,9 +973,9 @@ void EnPeehat_Update(Actor* thisx, PlayState* play) {
                 }
             }
         }
-        if (thisx->params != PEAHAT_TYPE_FLYING && this->colQuad.base.atFlags & AT_HIT) {
-            this->colQuad.base.atFlags &= ~AT_HIT;
-            if (&player->actor == this->colQuad.base.at) {
+        if (thisx->params != PEAHAT_TYPE_FLYING && this->colliderQuad.base.atFlags & AT_HIT) {
+            this->colliderQuad.base.atFlags &= ~AT_HIT;
+            if (&player->actor == this->colliderQuad.base.at) {
                 EnPeehat_SetStateAttackRecoil(this);
             }
         }
@@ -983,8 +983,8 @@ void EnPeehat_Update(Actor* thisx, PlayState* play) {
     if (this->state == PEAHAT_STATE_15 || this->state == PEAHAT_STATE_SEEK_PLAYER || this->state == PEAHAT_STATE_FLY ||
         this->state == PEAHAT_STATE_RETURN_HOME || this->state == PEAHAT_STATE_EXPLODE) {
         if (thisx->params != PEAHAT_TYPE_FLYING) {
-            CollisionCheck_SetAT(play, &play->colChkCtx, &this->colQuad.base);
-            CollisionCheck_SetAC(play, &play->colChkCtx, &this->colQuad.base);
+            CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderQuad.base);
+            CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderQuad.base);
         }
         // if PEAHAT_TYPE_GROUNDED
         if (thisx->params < 0 && (thisx->flags & ACTOR_FLAG_INSIDE_CULLING_VOLUME)) {
@@ -1076,11 +1076,11 @@ void EnPeehat_Draw(Actor* thisx, PlayState* play) {
     Gfx_SetupDL_25Opa(play->state.gfxCtx);
     SkelAnime_DrawSkeletonOpa(play, &this->skelAnime, EnPeehat_OverrideLimbDraw, EnPeehat_PostLimbDraw, this);
     if (this->actor.speedXZ != 0.0f || this->actor.velocity.y != 0.0f) {
-        Matrix_MultVec3f(&D_80AD285C[0], &this->colQuad.dim.quad[1]);
-        Matrix_MultVec3f(&D_80AD285C[1], &this->colQuad.dim.quad[0]);
-        Matrix_MultVec3f(&D_80AD285C[2], &this->colQuad.dim.quad[3]);
-        Matrix_MultVec3f(&D_80AD285C[3], &this->colQuad.dim.quad[2]);
-        Collider_SetQuadVertices(&this->colQuad, &this->colQuad.dim.quad[0], &this->colQuad.dim.quad[1],
-                                 &this->colQuad.dim.quad[2], &this->colQuad.dim.quad[3]);
+        Matrix_MultVec3f(&D_80AD285C[0], &this->colliderQuad.dim.quad[1]);
+        Matrix_MultVec3f(&D_80AD285C[1], &this->colliderQuad.dim.quad[0]);
+        Matrix_MultVec3f(&D_80AD285C[2], &this->colliderQuad.dim.quad[3]);
+        Matrix_MultVec3f(&D_80AD285C[3], &this->colliderQuad.dim.quad[2]);
+        Collider_SetQuadVertices(&this->colliderQuad, &this->colliderQuad.dim.quad[0], &this->colliderQuad.dim.quad[1],
+                                 &this->colliderQuad.dim.quad[2], &this->colliderQuad.dim.quad[3]);
     }
 }

--- a/soh/src/overlays/actors/ovl_En_Peehat/z_en_peehat.h
+++ b/soh/src/overlays/actors/ovl_En_Peehat/z_en_peehat.h
@@ -41,7 +41,7 @@ typedef struct EnPeehat {
     /* 0x0300 */ ColliderCylinder colCylinder;
     /* 0x034C */ ColliderJntSph colJntSph;
     /* 0x036C */ ColliderJntSphElement colJntSphItemList[1];
-    /* 0x03AC */ ColliderQuad colQuad;
+    /* 0x03AC */ ColliderQuad colliderQuad;
 } EnPeehat; // size = 0x042C
 
 #endif


### PR DESCRIPTION
Fixes an issue in #7000

Tailpasaran, Stalchild, Peehat only set their collider positions in their draw function but activate the colliders in update, so they have active colliders at 0,0,0 until player gets in range for them to draw for the first time.
This sets collider positions once on actor init at their actor->world.pos to move them away from 0,0,0.

Tested by warping to DMC and by logging the collider positions to ensure they are at the actor->world.pos.
Might not be needed to have unique Vec3f for the quads, but it feels nice.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9033177563.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9033093218.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9033057918.zip)
<!--- section:artifacts:end -->