### PR TITLE
Enemy rando, remove switch flag setting from Wolfos

### DIFF
--- a/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
+++ b/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
@@ -587,6 +587,10 @@ static u8 GetRandomizedEnemy(PlayState* play, s16* actorId, s16* posX, s16* posY
             case ACTOR_EN_CROW:
                 *posY = *posY + 75;
                 break;
+            // Remove switch flag setting from Wolfos
+            case ACTOR_EN_WF:
+                *params |= 0xFF00;
+                break;
             default:
                 break;
         }


### PR DESCRIPTION
Fixes an issue in #7000

Wolfos use high byte of params to mark type (normal or white), and low byte of params as which switch flag to set on death unless it is set to 0xFF.
Currently, enemy rando Wolfos spawn with params 0x0000 or 0x0001, causing flag 0x0 to be set on death and preventing respawns.
This adds 0xFF00 to Wolfos params, so that no flag is set on death and their respawn behavior is like normal enemies.
The Wolfos in child SFM (sets flag 0x1F) is already excluded from randomizing so it is not affected.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9051149534.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9051052681.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9050990668.zip)
<!--- section:artifacts:end -->