### PR TITLE
Fix graveyard sign checks at night

### DIFF
--- a/soh/soh/Enhancements/randomizer/ShuffleSigns.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleSigns.cpp
@@ -94,20 +94,34 @@ static CheckIdentity IdentifySign(s32 sceneNum, s32 posX, s32 posZ, s32 id) {
     uint32_t signSceneNum = sceneNum;
     Rando::Location* location = nullptr;
 
-    // align child/adult signs
+    // align child/adult and day/night signs
     if (sceneNum == SCENE_KAKARIKO_VILLAGE && LINK_IS_ADULT && posX == 1165 && posZ == 1545) {
         posZ = 1550;
     } else if (sceneNum == SCENE_GRAVEYARD && LINK_IS_ADULT) {
-        if (id == ACTOR_EN_WONDER_TALK2 && posX == -807 && posZ == 266) {
+        if (id == ACTOR_EN_WONDER_TALK2 && ((posX == -807 && posZ == 266) || (posX == -806 && posZ == 266))) {
             posX = -805;
         } else if (id == ACTOR_EN_WONDER_TALK) {
-            if (posX == 634 && posZ == 260) {
+            if ((posX == 634 && posZ == 260) || (posX == 638 && posZ == 260)) {
                 posX = 654;
                 posZ = 258;
-            } else if (posX == 634 && posZ == -100) {
+            } else if ((posX == 634 && posZ == -100) || (posX == 638 && posZ == -100)) {
                 posX = 654;
                 posZ = -102;
-            } else if (posX == 753 && posZ == 85) {
+            } else if ((posX == 753 && posZ == 85) || (posX == 758 && posZ == 85)) {
+                posX = 752;
+            }
+        }
+    } else if (sceneNum == SCENE_GRAVEYARD && LINK_IS_CHILD) {
+        if (id == ACTOR_EN_WONDER_TALK2 && posX == -805 && posZ == 264) {
+            posZ = 266;
+        } else if (id == ACTOR_EN_WONDER_TALK) {
+            if (posX == 630 && posZ == 260) {
+                posX = 654;
+                posZ = 258;
+            } else if (posX == 630 && posZ == -100) {
+                posX = 654;
+                posZ = -102;
+            } else if (posX == 758 && posZ == 85) {
                 posX = 752;
             }
         }


### PR DESCRIPTION
Correct the actor lookup positions for graves at night to match child day

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9117865977.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9117582618.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9117525618.zip)
<!--- section:artifacts:end -->