### PR TITLE
Let the Song of Time play out before the age shift

### DIFF
--- a/soh/soh/Enhancements/QoL/OcarinaTimeTravel.cpp
+++ b/soh/soh/Enhancements/QoL/OcarinaTimeTravel.cpp
@@ -12,10 +12,14 @@ extern "C" PlayState* gPlayState;
 #define CVAR_OCARINA_TIME_TRAVEL_NAME CVAR_ENHANCEMENT("TimeTravel")
 #define CVAR_OCARINA_TIME_TRAVEL_VALUE CVarGetInteger(CVAR_OCARINA_TIME_TRAVEL_NAME, CVAR_OCARINA_TIME_TRAVEL_DEFAULT)
 
-/// Switches Link's age and respawns him at the last entrance he entered.
-void OcarinaTimeTravel() {
+// Set when the Song of Time is recognised, cleared once the era has changed.
+static bool timeTravelPending = false;
+
+/// True when the Song of Time just played moves Link between eras, rather than driving a Time Block, a
+/// staff spot, the frogs or a Gossip Stone.
+static bool TimeTravelApplies() {
     if (!GameInteractor::IsSaveLoaded(true)) {
-        return;
+        return false;
     }
 
     Actor* player = &GET_PLAYER(gPlayState)->actor;
@@ -31,10 +35,9 @@ void OcarinaTimeTravel() {
                             !nearbyFrogs && !nearbyGossipStone;
     bool hasOcarinaOfTime = (INV_CONTENT(ITEM_OCARINA_TIME) == ITEM_OCARINA_TIME);
     bool hasMasterSword = CHECK_OWNED_EQUIP(EQUIP_TYPE_SWORD, EQUIP_INV_SWORD_MASTER);
-    int timeTravelSetting = CVarGetInteger(CVAR_ENHANCEMENT("TimeTravel"), 0);
     bool meetsTimeTravelRequirements = false;
 
-    switch (timeTravelSetting) {
+    switch (CVAR_OCARINA_TIME_TRAVEL_VALUE) {
         case TIME_TRAVEL_ANY:
             meetsTimeTravelRequirements = true;
             break;
@@ -50,13 +53,43 @@ void OcarinaTimeTravel() {
             break;
     }
 
-    if (justPlayedSoT && notNearAnySource && meetsTimeTravelRequirements) {
-        SwitchAge();
+    return justPlayedSoT && notNearAnySource && meetsTimeTravelRequirements;
+}
+
+/// Arms the era change; the shift itself waits for the song (see OcarinaTimeTravelUpdate).
+static void OcarinaTimeTravel() {
+    if (TimeTravelApplies()) {
+        timeTravelPending = true;
     }
 }
 
+/// Switches Link's age once the Song of Time has played itself out, respawning him where he stood.
+static void OcarinaTimeTravelUpdate() {
+    // This hook also runs on the title screen and the file select, where there is no play state to read.
+    if (!timeTravelPending || !GameInteractor::IsSaveLoaded(true)) {
+        return;
+    }
+
+    // Let the song finish, since the scene load fades out whatever is still playing, and leave anything
+    // already warping Link alone.
+    if ((func_800FA0B4(SEQ_PLAYER_FANFARE) == NA_BGM_OCA_TIME) ||
+        (gPlayState->transitionTrigger != TRANS_TRIGGER_OFF)) {
+        return;
+    }
+
+    timeTravelPending = false;
+    SwitchAge();
+
+    // The fade the Sun's Song changes the time of day behind (z_parameter.c, sunsSongState).
+    gPlayState->transitionType = TRANS_TYPE_FADE_WHITE_FAST;
+    gSaveContext.nextTransitionType = TRANS_TYPE_FADE_WHITE;
+    gPlayState->haltAllActors = 1;
+}
+
 static void RegisterOcarinaTimeTravel() {
+    timeTravelPending = false;
     COND_HOOK(OnOcarinaSongAction, CVAR_OCARINA_TIME_TRAVEL_VALUE, OcarinaTimeTravel);
+    COND_HOOK(OnGameFrameUpdate, CVAR_OCARINA_TIME_TRAVEL_VALUE, OcarinaTimeTravelUpdate);
 }
 
 static RegisterShipInitFunc initFunc(RegisterOcarinaTimeTravel, { CVAR_OCARINA_TIME_TRAVEL_NAME });


### PR DESCRIPTION
## What

With **Time Travel with Song of Time** enabled, playing the Song of Time away from a Time Block switched Link's age the instant the song was recognised: the performance was cut off mid-phrase and the world swapped with no transition (`SwitchAge()` leaves `TRANS_TYPE_INSTANT` behind). Now the song finishes first and the era changes behind a white fade.

Nothing else moves: the same requirements gate it, the same nearby sources take precedence (Time Blocks, empty warp blocks, staff spots, the Door of Time, the frogs, Gossip Stones), and Link still respawns where he stood. No new CVar.

## How

`OnOcarinaSongAction` fires while the fanfare is still playing, so it now only arms the change. An `OnGameFrameUpdate` poll waits for the fanfare player to stop running `NA_BGM_OCA_TIME` before calling `SwitchAge()` - there is no sequence-finished hook to listen on, and a frame countdown would just be a magic number. One bool test per frame while nothing is pending, and the hook is only registered while the enhancement is on.

The transition borrows what the Sun's Song uses for a time-of-day change (`z_parameter.c`, the `sunsSongState` block): `TRANS_TYPE_FADE_WHITE_FAST` out, `TRANS_TYPE_FADE_WHITE` in, `haltAllActors`. Audio is left alone; the scene load ends the song the same way it does for the Sun's Song.

Eligibility moved into a `TimeTravelApplies()` helper so arming and shift cannot drift apart.

## Testing

- [x] Song of Time away from any source: plays in full, white fade, other era, Link where he stood
- [x] Near a Time Block, empty warp block, staff spot, Door of Time, frogs, Gossip Stone: those still take the song, no age change
- [x] Each requirement setting (Any Ocarina / + Master Sword / Ocarina of Time / + Master Sword) still gates the shift
- [x] Indoors and outdoors, and in a scene with a Time Block present but out of range

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9345559238.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9345510107.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9345422864.zip)
<!--- section:artifacts:end -->
