### PR TITLE
Pick up newly added source files without a manual re-configure

### DIFF
--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -117,7 +117,7 @@ set(Header_Files "resource.h")
 source_group("headers" FILES ${Header_Files})
 
 # include {{{
-file(GLOB Header_Files__include "include/*.h" "include/*.inc")
+file(GLOB Header_Files__include CONFIGURE_DEPENDS "include/*.h" "include/*.inc")
 list(APPEND Header_Files__include ${CMAKE_CURRENT_SOURCE_DIR}/include/libc/stdarg.h)
 list(REMOVE_ITEM Header_Files__include ${CMAKE_CURRENT_SOURCE_DIR}/include/bgm.h)
 list(REMOVE_ITEM Header_Files__include ${CMAKE_CURRENT_SOURCE_DIR}/include/math_n64.h)
@@ -129,7 +129,7 @@ source_group("include" FILES ${Header_Files__include})
 # }}}
 
 # soh (root)
-file(GLOB_RECURSE soh__ RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "soh/*.c" "soh/*.cpp" "soh/*.h" "soh/*.hpp")
+file(GLOB_RECURSE soh__ CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "soh/*.c" "soh/*.cpp" "soh/*.h" "soh/*.hpp")
 
 # Add specific files that don't match the pattern
 list(APPEND soh__ ${CMAKE_CURRENT_SOURCE_DIR}/soh/Enhancements/speechsynthesizer/DarwinSpeechSynthesizer.mm)
@@ -167,14 +167,14 @@ endif()
 list(FILTER ship__ EXCLUDE REGEX "soh/Extractor/*")
 
 if(NOT CMAKE_SYSTEM_NAME MATCHES "NintendoSwitch|CafeOS")
-    file(GLOB_RECURSE soh__Extractor RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+    file(GLOB_RECURSE soh__Extractor CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
         "soh/Extractor/*.c"
         "soh/Extractor/*.cpp"
         "soh/Extractor/*.h"
         "soh/Extractor/*.hpp"
     )
 else()
-    file(GLOB_RECURSE soh__Extractor RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+    file(GLOB_RECURSE soh__Extractor CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
         "soh/Extractor/*.h"
         "soh/Extractor/*.hpp"
     )
@@ -182,7 +182,7 @@ endif()
 # }}}
 
 # src (decomp) {{{
-file(GLOB_RECURSE src__ RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "src/*.c" "src/*.h")
+file(GLOB_RECURSE src__ CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "src/*.c" "src/*.h")
 set_source_files_properties(${src__} PROPERTIES COMPILE_OPTIONS "${WARNING_OVERRIDE}")
 
 list(APPEND src__ ${CMAKE_CURRENT_SOURCE_DIR}/Resource.rc)


### PR DESCRIPTION
## What

Adds `CONFIGURE_DEPENDS` to the source and header globs in `soh/CMakeLists.txt`.

Adding a file under `soh/` or `src/` currently leaves it out of the build until CMake is re-run by hand. Nothing says so: the build succeeds, the new translation unit is simply absent, and you find out from a link error about the symbol you just wrote, or worse, from behaviour that silently never runs.

## Why / how

`CONFIGURE_DEPENDS` makes the generator re-check each glob at build time and re-configure when its result changes, which is exactly the case these globs are collecting. Five globs are covered: the `include/` headers, the `soh/` tree, both branches of the Extractor glob, and the `src/` decomp tree.

The cost is one directory stat per glob per build, against a class of confusing failure that hits anyone adding a file - and adding files is routine here, since enhancements are usually a new `.cpp` under `soh/Enhancements/`.

Worth noting that CMake's documentation cautions that `CONFIGURE_DEPENDS` is not guaranteed to be reliable on all generators; it is reliable on Ninja and Make, which is what this project builds with everywhere except MSVC, where the Visual Studio generator also supports it.

## Testing

- [x] Ninja on Linux: adding a new `.cpp` under `soh/Enhancements/` is picked up by a plain `ninja soh`, with no manual `cmake -S . -B build`
- [x] Same on Windows/MSVC and macOS


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9129062637.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9128928634.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9128851789.zip)
<!--- section:artifacts:end -->