### PR TITLE
Keep an unlisted combobox value from killing the menu

### DIFF
--- a/soh/soh/SohGui/UIWidgets.hpp
+++ b/soh/soh/SohGui/UIWidgets.hpp
@@ -107,6 +107,18 @@ template <typename T>
 bool Combobox(std::string label, T* value, const std::map<T, const char*>& comboMap,
               const ComboboxOptions& options = {}) {
     bool dirty = false;
+
+    if (comboMap.empty()) {
+        return dirty;
+    }
+    // A value with no entry (a stale config, a map that has since changed) must not throw out of at() below.
+    if (!comboMap.contains(*value)) {
+        SPDLOG_WARN("Combobox \"{}\" holds unlisted value {}, showing the default instead", label,
+                    static_cast<int32_t>(*value));
+        T fallback = static_cast<T>(options.defaultIndex);
+        *value = comboMap.contains(fallback) ? fallback : comboMap.begin()->first;
+    }
+
     float startX = ImGui::GetCursorPosX();
     std::string invisibleLabelStr = "##" + std::string(label);
     const char* invisibleLabel = invisibleLabelStr.c_str();


### PR DESCRIPTION
## What

`UIWidgets::Combobox` looked up the current value with `comboMap.at(*value)`. A value with no entry in the map throws `std::out_of_range`, nothing catches it, and the process aborts - the whole menu takes the game down with it.

```
terminate called after throwing an instance of 'std::out_of_range'
  what():  map::at
```

It is easy to end up with such a value: a config written by a build whose enum had an extra entry, an option whose combo map lost a value between versions, or a backend enumerated at runtime that is not available on this machine. The one that surfaced here was `Audio API`, whose value comes from `GetCurrentAudioBackend()` and can name a backend that is not in `GetAvailableAudioBackends()`.

What turns that from dormant into fatal is the menu search: it draws **every** widget whose name or tooltip matches, including combo boxes on pages you have never opened. So a single keystroke in the search box can render a widget carrying a stale value, and the game dies with no obvious connection to what was typed.

## Why / how

Before the lookup, an unlisted value falls back to the widget's `defaultIndex` when that is a key in the map, otherwise to the map's first entry, and logs which widget and which value:

```
[warning] Combobox "Audio API" holds unlisted value 2, showing the default instead
```

An empty map returns early rather than dereferencing `begin()`.

The fallback is display-only: the stored CVar is not rewritten, so nothing in the user's config changes behind their back, and the setting keeps whatever it had until they pick something. The log line is there so the underlying stale value can still be tracked down.

## Testing

- [x] With a config naming an audio backend this build does not provide, the menu search no longer aborts; the combo box shows the default and the warning above appears in the log
- [x] Combo boxes with valid values are unaffected


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9129241515.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9129038188.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9129037144.zip)
<!--- section:artifacts:end -->