### PR TITLE
Enemy rando, fix healthy big Guays not dying

### DIFF
--- a/soh/soh/Enhancements/ExtraModes/RandomizedEnemySizes.cpp
+++ b/soh/soh/Enhancements/ExtraModes/RandomizedEnemySizes.cpp
@@ -6,6 +6,8 @@
 extern "C" {
 #include "functions.h"
 #include "src/overlays/actors/ovl_En_Fz/z_en_fz.h"
+#include "src/overlays/actors/ovl_En_Crow/z_en_crow.h"
+extern void EnCrow_TurnAway(EnCrow*, PlayState*);
 }
 
 static constexpr int32_t CVAR_RANDO_ENEMY_SIZE_DEFAULT = 0;
@@ -61,6 +63,35 @@ static void RandomizedEnemySizes(void* refActor) {
 
 static void RegisterRandomizedEnemySizes() {
     COND_HOOK(OnActorInit, CVAR_RANDO_ENEMY_SIZE_VALUE, RandomizedEnemySizes);
+
+    // Guays try to die on any damage, but EnCrow_Update doesn't let them reach ground if health != 0
+    // Makeshift "damaged but not dead" action setup
+    COND_VB_SHOULD(VB_GUAY_SETUP_DAMAGED, CVAR_RANDO_ENEMY_SIZE_VALUE && CVAR_ENEMY_SCALE_HEALTH_VALUE, {
+        EnCrow* enCrow = va_arg(args, EnCrow*);
+
+        if (enCrow->actor.colChkInfo.damage < enCrow->actor.colChkInfo.health) {
+            *should = false;
+            Actor_ApplyDamage(&enCrow->actor);
+            enCrow->actor.colorFilterTimer = 40;
+            Actor_SetColorFilter(&enCrow->actor, 0x4000, 255, 0, 40);
+            Audio_PlayActorSound2(&enCrow->actor, NA_SE_EN_KAICHO_DEAD);
+            enCrow->timer = 50;
+            enCrow->actor.speedXZ = 3.5f;
+            enCrow->aimRotX = -0x1000;
+            enCrow->aimRotY = enCrow->actor.yawTowardsPlayer + 0x8000;
+            enCrow->skelAnime.playSpeed = 2.0f;
+            enCrow->actionFunc = EnCrow_TurnAway;
+        }
+    });
+
+    // Clamp distance from ground due to hard to hit with Kokiri
+    COND_VB_SHOULD(VB_GUAY_ALIVE_MOVE_HEIGHT_OFFSET, CVAR_RANDO_ENEMY_SIZE_VALUE && CVAR_ENEMY_SCALE_HEALTH_VALUE, {
+        f32* scale = va_arg(args, f32*);
+
+        if (*should && *scale > 2.0f) {
+            *scale = 2.0f;
+        }
+    });
 }
 
 static void RegisterFreezardHealthScale() {

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -1381,6 +1381,22 @@ typedef enum {
     // true
     // ```
     // #### `args`
+    // - `*EnCrow`
+    VB_GUAY_SETUP_DAMAGED,
+
+    // #### `result`
+    // ```c
+    // this->actor.colChkInfo.health != 0
+    // ```
+    // #### `args`
+    // - `*f32` (scale)
+    VB_GUAY_ALIVE_MOVE_HEIGHT_OFFSET,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
     // - None
     VB_HAVE_OCARINA_NOTE_A4,
 

--- a/soh/src/overlays/actors/ovl_En_Crow/z_en_crow.c
+++ b/soh/src/overlays/actors/ovl_En_Crow/z_en_crow.c
@@ -424,7 +424,7 @@ void EnCrow_UpdateDamage(EnCrow* this, PlayState* play) {
         if ((this->actor.colChkInfo.damageEffect != 0) || (this->actor.colChkInfo.damage != 0)) {
             if (this->actor.colChkInfo.damageEffect == 1) { // Deku Nuts
                 EnCrow_SetupTurnAway(this);
-            } else {
+            } else if (GameInteractor_Should(VB_GUAY_SETUP_DAMAGED, true, this)) {
                 Actor_ApplyDamage(&this->actor);
                 this->actor.flags &= ~ACTOR_FLAG_ATTENTION_ENABLED;
                 Enemy_StartFinishingBlow(play, &this->actor);
@@ -447,7 +447,7 @@ void EnCrow_Update(Actor* thisx, PlayState* play) {
     this->actor.world.rot.x = -this->actor.shape.rot.x;
 
     if (this->actionFunc != EnCrow_Respawn) {
-        if (this->actor.colChkInfo.health != 0) {
+        if (GameInteractor_Should(VB_GUAY_ALIVE_MOVE_HEIGHT_OFFSET, this->actor.colChkInfo.health != 0, &scale)) {
             height = 20.0f * scale;
             Actor_MoveXYZ(&this->actor);
         } else {


### PR DESCRIPTION
Fixes an issue in #7000

Guays have 1 health and are semi-hardcoded for this:
- `EnCrow_Update` forces the collider to be at least 20 units above ground if health is not 0
- `EnCrow_UpdateDamage` will setup damaged action function on any damage, regardless of Guay health
- `EnCrow_Damaged` will only call setup die once the Guay reaches ground

So if the Guay has 2 health, like an extra big one in enemy rando with health scaling, and only takes 1 damage, it will enter damaged state but will never reach ground to continue to die state.

This fix makes Guay instead setup `EnCrow_TurnAway` if damage taken is less than current health. It plays the death sound, which isn't optimal, but I think it's ok for now as this is a rare enemy. (It doesn't call the native setup function because it plays Deku Nut flashed sound.)

I also clamped the collider Y height offset slightly (normal scale for Guay is 0.01, biggest I've seen was 0.023) as the biggest are very hard to hit with Kokiri even with jumpslash. The exact value can of course be adjusted, I just picked someting.


https://github.com/user-attachments/assets/de867629-63e4-47d3-bd08-47069ab675b8



<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9182392358.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9182282468.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9182281203.zip)
<!--- section:artifacts:end -->