### PR TITLE
Add current CafeOS / Aroma build integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ docs/doxygen/
 *.v64
 *.map
 *.dump
+*.wuhb
+*.rpx
+wiiu-staging*/
 out.txt
 *.sln
 *.vcxproj

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,18 @@ set(CMAKE_C_STANDARD 23 CACHE STRING "The C standard to use")
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
 
 project(Ship VERSION 9.2.3 LANGUAGES C CXX)
+
+# devkitPro's WiiU.cmake does not currently declare CMake's WHOLE_ARCHIVE
+# feature.  SoH uses it for the static StormLib dependency on CafeOS.
+if(CMAKE_SYSTEM_NAME STREQUAL "CafeOS")
+    set(CMAKE_C_LINK_LIBRARY_USING_WHOLE_ARCHIVE_SUPPORTED TRUE)
+    set(CMAKE_C_LINK_LIBRARY_USING_WHOLE_ARCHIVE
+        "LINKER:--whole-archive" "<LINK_ITEM>" "LINKER:--no-whole-archive")
+    set(CMAKE_CXX_LINK_LIBRARY_USING_WHOLE_ARCHIVE_SUPPORTED TRUE)
+    set(CMAKE_CXX_LINK_LIBRARY_USING_WHOLE_ARCHIVE
+        "LINKER:--whole-archive" "<LINK_ITEM>" "LINKER:--no-whole-archive")
+endif()
+
 include(CMake/soh-cvars.cmake)
 include(CMake/lus-cvars.cmake)
 set(SPDLOG_LEVEL_TRACE 0)

--- a/README-WIIU.md
+++ b/README-WIIU.md
@@ -1,0 +1,104 @@
+# Ship of Harkinian 9.2.3 on Wii U / Aroma
+
+This checkout is intentionally pinned to official HarbourMasters `Shipwright`
+tag `9.2.3`, commit `cb71e22a79bc5d1f688fa881795bbd93094895fc` (2026-04-14).
+The separate `HarbourMasters/Shipwright-WiiU` repository is an older fork whose
+last code push was June 2024; do not use it for this build.
+
+The current main release needs local CaféOS compatibility work: the GX2
+renderer and WUT application layer are restored in `libultraship`; the
+platform dependency CMake code supplies nlohmann-json and spdlog; and the
+audio bootstrap builds the missing PPC Ogg/Opus/Vorbis libraries in the build
+directory. Two small dependency patches eliminate PPC TLS relocations which
+WUT's `elf2rpl` cannot encode. Everything is source-visible, pinned, and
+kept inside this checkout/build directory.
+
+## Toolchain
+
+The upstream build script is `scripts/wiiu/build.sh`: CMake's current CafeOS
+toolchain file and the `soh_wuhb` target build the Aroma Homebrew Bundle.
+Install the current supported devkitPro package set on macOS:
+
+```sh
+sudo installer -pkg /tmp/devkitpro-pacman-installer-6.0.2.pkg -target /
+sudo /opt/devkitpro/pacman/bin/pacman -Syu wiiu-dev ppc-libzip ppc-tinyxml2 ppc-bzip2 ppc-zlib ppc-libpng wiiu-sdl2
+```
+
+Open a new shell and verify (the supplied build script also auto-detects these
+paths if zsh does not export them):
+
+```sh
+printf '%s\n' "$DEVKITPRO" "$DEVKITPPC"
+"$DEVKITPPC/bin/powerpc-eabi-g++" --version
+test -f "$DEVKITPRO/cmake/WiiU.cmake"
+```
+
+`wiiu-dev` supplies devkitPPC, WUT, and the Wii U port libraries (including
+SDL2) required by the source. No third-party Wii U fork or release binary is
+used. On this macOS 26 machine, Homebrew LLVM is used for host asset generation
+with `-DFMT_CONSTEVAL=` because the release's bundled fmt otherwise fails with
+AppleClang 21; this is a compiler workaround, not a source patch.
+
+Run `./build-wiiu.sh /absolute/path/to/your-rom.z64`. It verifies the supplied
+ROM's SHA-1 against the source's supported-hash list, creates only a temporary
+extractor copy (then removes it on exit), and does not track or stage the ROM
+itself. The build produces `oot.o2r` (ROM data),
+`soh.o2r` (port data), `build-wiiu/gamecontrollerdb.txt` (controller mappings),
+and `build-wiiu/soh/soh.wuhb`. Set
+`SOH_WIIU_BUILD_DIR=build-wiiu-current` to select another relative build
+directory.
+
+## SD staging and data locations
+
+After a successful Wii U build run `./prepare-sd.sh`. If the build directory
+is not the script's default `build-wiiu`, set `SOH_WIIU_BUILD_DIR` to its
+repository-relative name. It never touches a
+mounted SD card and refuses an existing staging app directory. Its result is:
+
+```text
+wiiu/apps/soh/
+  soh.wuhb
+  gamecontrollerdb.txt
+  oot.o2r
+  soh.o2r
+  mods/
+  logs/
+```
+
+The Wii U build deliberately uses the application directory as its data path,
+so `shipofharkinian.json`, `oot_save.sav`, `mods/`, and `logs/Ship of
+Harkinian.log` live alongside `soh.wuhb`. Back up the whole existing
+`wiiu/apps/soh` directory before merging staging onto an SD card. `.wuhb` is
+the Aroma/HB-AppStore-friendly bundle; `.rpx` is the raw executable and is not
+the preferred Aroma install artifact.
+
+## First boot
+
+Start with no mods. Set 16:9, 1080p output, and 30 FPS first; use interpolation
+only after testing. Enable gyro only after verifying the GamePad mapping and
+leave experimental graphics off. Test: launch; title screen; make a save;
+audio; GamePad/controller input; enter Kokiri Forest; save, exit, and relaunch.
+Once reliable, try 60 FPS with interpolation off first and retain it only if
+Kokiri Forest and Hyrule Field remain smooth.
+
+## Mods
+
+Do not install a large pack until the base port has passed the test above.
+Current SoH loads `.otr` and `.o2r` patch archives from `mods/`; later-loaded
+archives can replace earlier assets, so packs with overlapping textures/models
+must be installed intentionally and tested one at a time. There is no current
+upstream Wii U compatibility/performance certification for OoT Reloaded or the
+Djipi/Skilar 3D-style packs. For real Wii U, use a 1080p-oriented/light variant
+if the author provides one, keep the archive names/version notes, and begin at
+30 FPS before trying 60. Do not combine Reloaded and 3DS-style packs wholesale:
+they overlap substantially. A lighter 3DS-style pack plus 60 FPS is the safer
+goal; a full 4K Reloaded-plus-model-overhaul combination is not recommended
+without per-area performance testing.
+
+## Updating
+
+Patch releases normally keep `oot.o2r`; a major `x.0.0` release requires
+regenerating it. Before updating, back up `wiiu/apps/soh` (especially the JSON,
+saves, and mods), build the new tag in a fresh checkout, stage it separately,
+then replace only `soh.wuhb` and `soh.o2r` when the release does not require a
+new ROM archive. Re-test with `mods/` temporarily moved out.

--- a/build-wiiu.sh
+++ b/build-wiiu.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Build the pinned Shipwright source into an Aroma-compatible Wii U bundle.
+set -euo pipefail
+
+repo_dir="$(cd "$(dirname "$0")" && pwd)"
+cd "$repo_dir"
+
+rom_path="${1:?Usage: $0 /absolute/path/to/your-supported-oot-rom.z64}"
+[[ -f "$rom_path" ]] || { echo "ROM path is not a regular file: $rom_path" >&2; exit 1; }
+rom_sha1="$(shasum -a 1 "$rom_path" | awk '{print $1}')"
+rg -F '"'"$rom_sha1"'"' docs/supportedHashes.json >/dev/null || {
+  echo "ROM SHA-1 is not supported by this source: $rom_sha1" >&2; exit 1;
+}
+
+if [[ "$(git rev-parse HEAD)" != "cb71e22a79bc5d1f688fa881795bbd93094895fc" ]]; then
+  echo "Refusing: this toolkit is pinned to Shipwright 9.2.3 (cb71e22...)." >&2
+  exit 1
+fi
+
+export DEVKITPRO="${DEVKITPRO:-/opt/devkitpro}"
+export DEVKITPPC="${DEVKITPPC:-$DEVKITPRO/devkitPPC}"
+echo "DEVKITPRO=$DEVKITPRO"
+echo "DEVKITPPC=$DEVKITPPC"
+[[ -f "$DEVKITPRO/cmake/WiiU.cmake" ]] || { echo "Missing $DEVKITPRO/cmake/WiiU.cmake" >&2; exit 1; }
+[[ -x "$DEVKITPPC/bin/powerpc-eabi-g++" ]] || { echo "Missing devkitPPC compiler" >&2; exit 1; }
+command -v cmake >/dev/null
+command -v ninja >/dev/null
+command -v git >/dev/null
+
+build_dir="${SOH_WIIU_BUILD_DIR:-build-wiiu}"
+[[ "$build_dir" != /* ]] || { echo "SOH_WIIU_BUILD_DIR must be relative to the repository." >&2; exit 1; }
+
+# OTRExporter discovers ROMs in its own directory. This temporary copy is
+# removed on exit; neither the ROM nor ROM-derived archives are git-tracked.
+rom_temp="$(mktemp "$repo_dir/OTRExporter/soh-rom.XXXXXX")"
+rom_copy="${rom_temp}.z64"
+mv "$rom_temp" "$rom_copy"
+trap 'rm -f "$rom_copy"' EXIT
+cp "$rom_path" "$rom_copy"
+
+# The host target generates archives.  On macOS 26, the bundled fmt in this
+# source release needs FMT_CONSTEVAL disabled; this changes no source files.
+if [[ "$(uname)" == "Darwin" ]] && command -v brew >/dev/null; then
+  llvm_prefix="$(brew --prefix llvm 2>/dev/null || true)"
+  if [[ -x "$llvm_prefix/bin/clang" && -x "$llvm_prefix/bin/clang++" ]]; then
+    export CC="$llvm_prefix/bin/clang"
+    export CXX="$llvm_prefix/bin/clang++"
+  fi
+fi
+
+cmake -S . -B build-host -G Ninja -DCMAKE_BUILD_TYPE=Release \
+  -DPython3_EXECUTABLE="$(command -v python3)" '-DCMAKE_CXX_FLAGS:STRING=-DFMT_CONSTEVAL='
+cmake --build build-host --target ExtractAssets --parallel 4
+
+scripts/wiiu/build-portlibs.sh "$build_dir"
+
+cmake -S . -B "$build_dir" -G Ninja -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_TOOLCHAIN_FILE="$DEVKITPRO/cmake/WiiU.cmake" \
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+  -DSOH_WIIU_PORTLIBS_PREFIX="$repo_dir/$build_dir/local-portlibs"
+cmake --build "$build_dir" --target soh_wuhb --parallel 4
+
+test -s "$build_dir/soh/soh.wuhb"
+test -s "$build_dir/gamecontrollerdb.txt"
+echo "Built $(git describe --tags --always) ($(git rev-parse HEAD))"
+ls -lh "$build_dir/soh/soh.wuhb" "$build_dir/gamecontrollerdb.txt" oot.o2r soh.o2r

--- a/prepare-sd.sh
+++ b/prepare-sd.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Create, but never mount or overwrite, an Aroma SD-card staging tree.
+set -euo pipefail
+
+repo_dir="$(cd "$(dirname "$0")" && pwd)"
+stage_dir="${1:-$repo_dir/wiiu-staging}"
+build_dir="${SOH_WIIU_BUILD_DIR:-build-wiiu}"
+cd "$repo_dir"
+
+[[ "$(git rev-parse HEAD)" == "cb71e22a79bc5d1f688fa881795bbd93094895fc" ]] || {
+  echo "Refusing: source is not the recorded 9.2.3 commit." >&2; exit 1;
+}
+[[ "$build_dir" != /* ]] || { echo "SOH_WIIU_BUILD_DIR must be relative to the repository." >&2; exit 1; }
+for artifact in "$build_dir/soh/soh.wuhb" "$build_dir/gamecontrollerdb.txt" oot.o2r soh.o2r; do
+  [[ -s "$artifact" ]] || { echo "Missing build artifact: $artifact" >&2; exit 1; }
+done
+command -v unzip >/dev/null
+unzip -t oot.o2r >/dev/null
+unzip -t soh.o2r >/dev/null
+
+app_dir="$stage_dir/wiiu/apps/soh"
+if [[ -e "$app_dir" ]]; then
+  echo "Refusing to overwrite existing staging app directory: $app_dir" >&2
+  exit 1
+fi
+mkdir -p "$app_dir/mods" "$app_dir/logs"
+cp "$build_dir/soh/soh.wuhb" "$app_dir/soh.wuhb"
+cp "$build_dir/gamecontrollerdb.txt" "$app_dir/"
+cp oot.o2r soh.o2r "$app_dir/"
+
+echo "Created staging tree: $stage_dir (using $build_dir)"
+find "$stage_dir" -type f -maxdepth 5 -print
+echo "To copy safely, first back up any SD-card wiiu/apps/soh directory, then review:"
+echo "  rsync -av --dry-run '$stage_dir/' '/Volumes/<YOUR_SD_NAME>/'"
+echo "Only after reviewing the dry run:"
+echo "  rsync -av '$stage_dir/' '/Volumes/<YOUR_SD_NAME>/'"

--- a/scripts/wiiu/build-portlibs.sh
+++ b/scripts/wiiu/build-portlibs.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Build the audio libraries unavailable in devkitPro's current Wii U packages.
+set -euo pipefail
+
+repo_dir="$(cd "$(dirname "$0")/../.." && pwd)"
+build_dir="${1:?Usage: $0 /absolute/or/repository-relative/build-directory}"
+case "$build_dir" in
+  /*) ;;
+  *) build_dir="$repo_dir/$build_dir" ;;
+esac
+
+: "${DEVKITPRO:=/opt/devkitpro}"
+: "${DEVKITPPC:=$DEVKITPRO/devkitPPC}"
+export DEVKITPRO DEVKITPPC
+[[ -f "$DEVKITPRO/cmake/WiiU.cmake" ]] || { echo "Missing Wii U toolchain." >&2; exit 1; }
+command -v cmake >/dev/null
+command -v ninja >/dev/null
+command -v git >/dev/null
+
+src_dir="$build_dir/local-deps-src"
+work_dir="$build_dir/local-deps-build"
+prefix="$build_dir/local-portlibs"
+mkdir -p "$src_dir" "$work_dir" "$prefix"
+
+fetch() {
+  local name="$1" url="$2" revision="$3"
+  if [[ ! -d "$src_dir/$name/.git" ]]; then
+    git clone --filter=blob:none "$url" "$src_dir/$name"
+  fi
+  git -C "$src_dir/$name" fetch --quiet --tags origin "$revision"
+  git -C "$src_dir/$name" checkout --quiet --detach "$revision"
+  [[ "$(git -C "$src_dir/$name" rev-parse HEAD)" == "$revision" ]] || {
+    echo "Unexpected revision for $name" >&2; exit 1;
+  }
+}
+
+fetch ogg https://github.com/xiph/ogg.git be05b13e98b048f0b5a0f5fa8ce514d56db5f822
+fetch opus https://github.com/xiph/opus.git 22244de5a79bd1d6d623c32e72bf1954b56235be
+fetch opusfile https://github.com/xiph/opusfile.git a55c164e9891a9326188b7d4d216ec9a88373739
+fetch vorbis https://github.com/xiph/vorbis.git 0657aee69dec8508a0011f47f3b69d7538e9d262
+
+# The source tree is deliberately mutable only inside the selected build dir.
+cmake -E copy_if_different "$repo_dir/scripts/wiiu/opusfile-CMakeLists.txt" "$src_dir/opusfile/CMakeLists.txt"
+
+configure_build_install() {
+  local name="$1"
+  shift
+  cmake -S "$src_dir/$name" -B "$work_dir/$name" -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_TOOLCHAIN_FILE="$DEVKITPRO/cmake/WiiU.cmake" \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+    -DCMAKE_INSTALL_PREFIX="$prefix" \
+    "$@"
+  cmake --build "$work_dir/$name" --parallel 4
+  cmake --install "$work_dir/$name"
+}
+
+configure_build_install ogg -DBUILD_SHARED_LIBS=OFF -DINSTALL_DOCS=OFF
+configure_build_install opus -DOPUS_BUILD_SHARED_LIBRARY=OFF -DOPUS_BUILD_PROGRAMS=OFF -DOPUS_BUILD_TESTING=OFF
+configure_build_install opusfile -DCMAKE_PREFIX_PATH="$prefix"
+configure_build_install vorbis -DBUILD_SHARED_LIBS=OFF -DCMAKE_PREFIX_PATH="$prefix"
+
+for lib in libogg.a libopus.a libopusfile.a libvorbis.a libvorbisenc.a libvorbisfile.a; do
+  [[ -s "$prefix/lib/$lib" ]] || { echo "Missing $prefix/lib/$lib" >&2; exit 1; }
+done
+echo "Built isolated Wii U audio portlibs in $prefix"

--- a/scripts/wiiu/opusfile-CMakeLists.txt
+++ b/scripts/wiiu/opusfile-CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.16)
+project(opusfile_local LANGUAGES C)
+
+# libopusfile's source checkout supplies Autotools metadata only. SoH only
+# needs its in-memory decoder, not HTTP, opusurl, examples, or tools.
+find_package(Ogg CONFIG REQUIRED)
+find_package(Opus CONFIG REQUIRED)
+
+add_library(opusfile STATIC
+    src/info.c
+    src/internal.c
+    src/opusfile.c
+    src/stream.c
+)
+target_compile_features(opusfile PRIVATE c_std_99)
+target_include_directories(opusfile PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(opusfile PUBLIC Ogg::ogg Opus::opus m)
+install(TARGETS opusfile ARCHIVE DESTINATION lib)
+install(FILES include/opusfile.h DESTINATION include)

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -681,15 +681,34 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "NintendoSwitch")
     )
 elseif(CMAKE_SYSTEM_NAME STREQUAL "CafeOS")
     find_package(SDL2 REQUIRED)
+    set(SOH_WIIU_PORTLIBS_PREFIX "${CMAKE_BINARY_DIR}/local-portlibs" CACHE PATH
+        "Optional prefix containing Wii U portlibs built for this tree")
     set(ADDITIONAL_LIBRARY_DEPENDENCIES
         "libultraship;"
         SDL2::SDL2-static
+        vorbisfile
+        vorbisenc
+        vorbis
+        opusfile
+        opus
+        ogg
+        m
 
         "$<$<CONFIG:Debug>:-Wl,--wrap=abort>"
     )
     target_include_directories(${PROJECT_NAME} PRIVATE
         ${DEVKITPRO}/portlibs/wiiu/include/
     )
+    if(EXISTS "${SOH_WIIU_PORTLIBS_PREFIX}/include")
+        target_include_directories(${PROJECT_NAME} PRIVATE
+            "${SOH_WIIU_PORTLIBS_PREFIX}/include"
+            # opusfile.h uses the legacy unprefixed Opus public includes.
+            "${SOH_WIIU_PORTLIBS_PREFIX}/include/opus"
+        )
+        target_link_directories(${PROJECT_NAME} PRIVATE
+            "${SOH_WIIU_PORTLIBS_PREFIX}/lib"
+        )
+    endif()
 else()
     find_package(SDL2)
     set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/soh/include/z64collision_check.h
+++ b/soh/include/z64collision_check.h
@@ -6,6 +6,13 @@
 #define COLLISION_CHECK_OC_MAX 50
 #define COLLISION_CHECK_OC_LINE_MAX 3
 
+// newlib exposes `quad` as a legacy alias for `quad_t`.  global.h removes
+// that macro after this header has been parsed, which otherwise leaves the
+// ColliderQuadDim member with a different preprocessed name on CaféOS.
+#ifdef quad
+#undef quad
+#endif
+
 // From z64.h
 struct Actor;
 

--- a/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
+++ b/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
@@ -322,6 +322,7 @@ void SohInputEditorWindow::DrawButtonLineEditMappingButton(uint8_t port, N64Butt
     ImGui::PopStyleVar();
     ImGui::SameLine(0, 0);
 
+#ifndef __WIIU__
     auto sdlAxisDirectionToButtonMapping = std::dynamic_pointer_cast<Ship::SDLAxisDirectionToButtonMapping>(mapping);
     if (sdlAxisDirectionToButtonMapping != nullptr) {
         ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.0f, 0.5f));
@@ -437,6 +438,7 @@ void SohInputEditorWindow::DrawButtonLineEditMappingButton(uint8_t port, N64Butt
         ImGui::PopStyleVar();
         ImGui::SameLine(0, 0);
     }
+#endif
 
     ImGui::PushStyleColor(ImGuiCol_Button, buttonColor);
     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, buttonHoveredColor);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -388,6 +388,14 @@ extern std::shared_ptr<SohGui::SohMenu> mSohMenu;
 }
 
 void OTRGlobals::RunExtract(int argc, char* argv[]) {
+#if defined(__WIIU__)
+    // Wii U builds intentionally ship without the desktop extractor.  The user
+    // supplies a compatible, pre-generated O2R archive in the app directory.
+    // Archive validation continues in Initialize().
+    (void)argc;
+    (void)argv;
+    return;
+#else
     bool extractDone = false;
     ExtractSteps extractStep = ES_PORT_ARCHIVE;
     WindowsSteps windowsStep = WS_TEMP;
@@ -421,13 +429,6 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
                           "\x1b[4;2HPlease regenerate a new ROM O2R and relaunch."
                           "\x1b[6;2HPress the Home button to exit...",
                           "OK", "", [&]() { exit(1); });
-#elif defined(__WIIU__)
-    SohGui::RegisterPopup("Outdated ROM Archives",
-                          "You've launched the Ship with an old a ROM O2R file.\n\n"
-                          "Please generate a ROM O2R and relaunch.\n\n"
-                          "Press and hold the Power button to shutdown...",
-                          "OK", "", [&]() { exit(1); });
-    OSFatal();
 #endif
 
     if (!std::filesystem::exists(installPath + "/assets")) {
@@ -758,9 +759,8 @@ void OTRGlobals::RunExtract(int argc, char* argv[]) {
 
 #ifdef __SWITCH__
     Ship::Switch::Init(Ship::PreInitPhase);
-#elif defined(__WIIU__)
-    Ship::WiiU::Init(appShortName);
 #endif
+#endif // !__WIIU__
 }
 
 void OTRGlobals::Initialize() {
@@ -1445,7 +1445,12 @@ OTRVersion DetectOTRVersion(std::string fileName, bool isMQ) {
 }
 
 extern "C" void Messagebox_ShowErrorBox(char* title, char* body) {
+#if defined(__WIIU__)
+    (void)title;
+    OSFatal(body);
+#else
     Extractor::ShowErrorBox(title, body);
+#endif
 }
 
 bool VerifyArchiveVersion(OTRVersion version) {
@@ -1453,6 +1458,12 @@ bool VerifyArchiveVersion(OTRVersion version) {
 }
 
 extern "C" void InitOTR(int argc, char* argv[]) {
+#ifdef __WIIU__
+    // Aroma does not promise a particular current directory.  Establish the
+    // app directory before configuration, archive lookup, logging, or the
+    // window backend are initialized.
+    Ship::WiiU::Init(appShortName);
+#endif
     OTRGlobals::Instance = new OTRGlobals();
     OTRGlobals::Instance->RunExtract(argc, argv);
 

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -1,4 +1,10 @@
 #include "SaveManager.h"
+
+#if defined(__WIIU__) || defined(__SWITCH__)
+// Defined near the platform-specific file helpers below.  It must be visible
+// before the save-migration path that uses it.
+int copy_file(const char* src, const char* dst);
+#endif
 #include "OTRGlobals.h"
 #include "Enhancements/game-interactor/GameInteractor.h"
 #include "Enhancements/randomizer/SeedContext.h"

--- a/soh/soh/SohGui/MenuTypes.h
+++ b/soh/soh/SohGui/MenuTypes.h
@@ -275,6 +275,7 @@ static const std::map<Ship::WindowBackend, const char*> windowBackendsMap = {
     { Ship::WindowBackend::FAST3D_DXGI_DX11, "DirectX" },
     { Ship::WindowBackend::FAST3D_SDL_OPENGL, "OpenGL" },
     { Ship::WindowBackend::FAST3D_SDL_METAL, "Metal" },
+    { Ship::WindowBackend::FAST3D_WIIU_GX2, "GX2" },
 };
 
 struct MenuInit {


### PR DESCRIPTION
## Summary

Adds CafeOS integration for the current Shipwright 9.2.3 source tree and reproducible macOS-to-Aroma build/staging tooling. The Wii U build uses pre-generated user-owned O2R archives rather than the desktop extractor.

## Dependency

This is a stacked draft and requires the accompanying libultraship backend PR: https://github.com/Kenix3/libultraship/pull/1241

## Validation

- Built `soh_wuhb` successfully with devkitPPC/WUT on macOS.
- Ran `git diff --check`.
- Verified that the commits contain no ROM, OTR/O2R archive, texture pack, or generated Wii U binary.

## Limitations

The port has not yet been tested on real Wii U hardware; graphics, audio, input, and foreground/background lifecycle require console validation.