### PR TITLE
Enemy rando, GTG hammer room air spawn fix

### DIFF
--- a/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
+++ b/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
@@ -528,6 +528,11 @@ static u8 GetRandomizedEnemy(PlayState* play, s16* actorId, s16* posX, s16* posY
             *posY = *posY - 200;
         }
 
+        // One enemy in GTG hammer room doesn't raycast properly, move it slightly
+        if (*posY == 117 && play->sceneNum == SCENE_GERUDO_TRAINING_GROUND && play->roomCtx.curRoom.num == 5) {
+            *posY = 118;
+        }
+
         // Do a raycast from the original position of the actor to find the ground below it, then try to place
         // the new actor on the ground. This way enemies don't spawn very high in the sky, and gives us control
         // over height offsets per enemy from a proven grounded position.

--- a/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
+++ b/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
@@ -181,6 +181,8 @@ static bool IsExcludedFromClearRooms(s16 enemyId, s16 enemyParams) {
         case ACTOR_EN_FD:
         // Anubis - Needs fire
         case ACTOR_EN_ANUBICE_TAG:
+        // Withered Deku Baba - Stationary, can get stuck in air/on chests, softlock risk
+        case ACTOR_EN_KAREBABA:
             return true;
         case ACTOR_EN_MB:
             return enemyParams == 0;


### PR DESCRIPTION
Fixes an issue in #7000

For some reason the floor raycast fails for a Firefly spawn in GTG hammer room number 5. It has a Y spawn position of 117. All other enemies properly get a raycast result and move their spawn Y to -81.
Solution: Move the Y spawn position to 118. 🤯

Maybe there's an actual issue with the raycast function chosen, but I don't want to dig into it.
I don't want to move it to -81 directly, because flying enemies should still spawn in the air when replacing another flying enemy.
Tested with various enemies that don't snap to floor (Gibdo, Baby Dodongo, Lizalfos, Tailpasaran).

<img width="440" height="363" alt="gtg tailpasaran" src="https://github.com/user-attachments/assets/97f15c3c-caf0-47fc-b20e-b0a43bb66dfe" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9257209880.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9257088804.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9257086247.zip)
<!--- section:artifacts:end -->