### PR TITLE
generate-builds.yml: consistently use max-size 2G, prefer j4 over j3, evict-old-files: job

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -17,6 +17,8 @@ jobs:
     - name: Configure ccache
       uses: hendrikmuhs/ccache-action@v1.2.23
       with:
+        max-size: "2G"
+        evict-old-files: job
         save: ${{ github.ref_name == github.event.repository.default_branch }}
         key: ${{ runner.os }}-otr-ccache-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
@@ -33,7 +35,7 @@ jobs:
     - name: Generate soh.o2r
       run: |
         cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DSOH_TOOLS_ONLY=ON
-        cmake --build build-cmake --config Release --target GenerateSohOtr -j3
+        cmake --build build-cmake --config Release --target GenerateSohOtr -j4
     - name: Upload soh.o2r
       uses: actions/upload-artifact@v7
       with:
@@ -96,6 +98,8 @@ jobs:
     - name: Configure ccache
       uses: hendrikmuhs/ccache-action@v1.2.23
       with:
+        max-size: "2G"
+        evict-old-files: job
         save: ${{ github.ref_name == github.event.repository.default_branch }}
         key: ${{ runner.os }}-ccache-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
@@ -155,7 +159,7 @@ jobs:
     - name: Build SoH
       run: |
         cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_REMOTE_CONTROL=1
-        cmake --build build-cmake --config Release -j3
+        cmake --build build-cmake --config Release -j4
         (cd build-cmake && cpack -G External)
 
         mv README.md readme.txt


### PR DESCRIPTION
null

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9266791456.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9266660339.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9266656023.zip)
<!--- section:artifacts:end -->