### PR TITLE
Shuffle Silver: fix gtg room setting room cleared instead of flag

### DIFF
--- a/soh/soh/Enhancements/randomizer/ShuffleSilver.cpp
+++ b/soh/soh/Enhancements/randomizer/ShuffleSilver.cpp
@@ -221,14 +221,7 @@ s8 Randomizer::SilverTotal(RandomizerGet rg) {
                                                                                                    : 5;
 }
 
-bool IsSilverCleared(s16 switchFlag) {
-    RandomizerGet rg = SilverFromSwitchFlag(switchFlag);
-    return *Randomizer::SilverFieldFromSaveContext(&gSaveContext, rg) >= Randomizer::SilverTotal(rg);
-}
-
 bool IsSilverCleared(RandomizerGet rg) {
-    auto test = *Randomizer::SilverFieldFromSaveContext(&gSaveContext, rg);
-    auto test2 = Randomizer::SilverTotal(rg);
     return *Randomizer::SilverFieldFromSaveContext(&gSaveContext, rg) >= Randomizer::SilverTotal(rg);
 }
 
@@ -254,6 +247,14 @@ extern "C" void EnGSwitch_RandomizerDraw(Actor* thisx, PlayState* play) {
     }
 }
 
+static void SetSilverCleared(EnGSwitch* silver) {
+    if (gPlayState->sceneNum == SCENE_GERUDO_TRAINING_GROUND && silver->actor.room == 2) {
+        Flags_SetTempClear(gPlayState, silver->actor.room);
+        Flags_SetClear(gPlayState, silver->actor.room);
+    }
+    Flags_SetSwitch(gPlayState, silver->switchFlag);
+}
+
 void RegisterShuffleSilver() {
     bool shouldRegister = IS_RANDO && RAND_GET_OPTION(RSK_SHUFFLE_SILVER);
 
@@ -271,8 +272,8 @@ void RegisterShuffleSilver() {
     COND_VB_SHOULD(VB_SILVER_COUNT_CHECK, shouldRegister, {
         EnGSwitch* silver = va_arg(args, EnGSwitch*);
         *should = false;
-        if (IsSilverCleared(silver->switchFlag)) {
-            Flags_SetSwitch(gPlayState, silver->switchFlag);
+        if (IsSilverCleared(SilverFromSwitchFlag(silver->switchFlag))) {
+            SetSilverCleared(silver);
             Actor_Kill(&silver->actor);
         }
     });
@@ -288,8 +289,9 @@ void RegisterShuffleSilver() {
                 *should = false;
                 silver->actor.draw = EnGSwitch_RandomizerDraw;
             }
-        } else if (silver->type == ENGSWITCH_SILVER_TRACKER && IsSilverCleared(silver->switchFlag)) {
-            Flags_SetSwitch(gPlayState, silver->switchFlag);
+        } else if (silver->type == ENGSWITCH_SILVER_TRACKER &&
+                   IsSilverCleared(SilverFromSwitchFlag(silver->switchFlag))) {
+            SetSilverCleared(silver);
             *should = true;
         }
     });

--- a/soh/soh/Enhancements/randomizer/ShuffleSilver.h
+++ b/soh/soh/Enhancements/randomizer/ShuffleSilver.h
@@ -7,6 +7,5 @@
 
 bool IsSilverInPool(RandomizerGet rg);
 RandomizerGet SilverFromSwitchFlag(s16 switchFlag);
-bool IsSilverCleared(s16 switchFlag);
 bool IsSilverCleared(RandomizerGet rg);
 bool IsSilver(RandomizerGet rg);


### PR DESCRIPTION
Fixes #7080

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9268203200.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9268138255.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9268091165.zip)
<!--- section:artifacts:end -->