### PR TITLE
Enemy rando, play and stop miniboss music

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -2163,7 +2163,7 @@ void func_800F9474(u8, u16);
 void func_800F94FC(u32);
 void Audio_ProcessSeqCmd(u32);
 void Audio_ProcessSeqCmds(void);
-u16 func_800FA0B4(u8 a0);
+u16 Audio_GetActiveSeqId(u8 seqPlayerIndex);
 s32 func_800FA11C(u32 arg0, u32 arg1);
 void func_800FA174(u8);
 void func_800FA18C(u8, u8);

--- a/soh/soh/Enhancements/AlwaysOnFixes.cpp
+++ b/soh/soh/Enhancements/AlwaysOnFixes.cpp
@@ -106,6 +106,11 @@ void RegisterAlwaysOnFixes() {
 
     COND_ID_HOOK(OnActorDestroy, ACTOR_EN_TEST, true, [](void* refActor) {
         Actor* actor = reinterpret_cast<Actor*>(refActor);
+        if (CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0) &&
+            (CVarGetInteger(CVAR_ENHANCEMENT("EnemyRandoMinibossBgm"), false) ||
+             CVarGetInteger(CVAR_ENHANCEMENT("EnemyRandoInvisStalfosBgm"), false))) {
+            return;
+        }
         if (actor->params != STALFOS_TYPE_2 && !EnTest_HasLivingNearby(actor)) {
             func_800F5B58();
         }
@@ -130,7 +135,8 @@ void RegisterAlwaysOnFixes() {
         s8* heldItemAction = va_arg(args, s8*);
         s32* camMode = va_arg(args, s32*);
 
-        if (*heldItemAction == PLAYER_IA_BOW) {
+        if (*heldItemAction == PLAYER_IA_BOW || *heldItemAction == PLAYER_IA_BOW_FIRE ||
+            *heldItemAction == PLAYER_IA_BOW_ICE || *heldItemAction == PLAYER_IA_BOW_LIGHT) {
             if (CVarGetInteger(CVAR_ENHANCEMENT("BowSlingshotAmmoFix"), false) ||
                 CVarGetInteger(CVAR_ENHANCEMENT("EquipmentAlwaysVisible"), false)) {
                 *camMode = CAM_MODE_AIM_ADULT;
@@ -141,7 +147,9 @@ void RegisterAlwaysOnFixes() {
                 *camMode = CAM_MODE_AIM_CHILD;
             }
         } else if (*heldItemAction == PLAYER_IA_HOOKSHOT || *heldItemAction == PLAYER_IA_LONGSHOT) {
-            if (gPlayState->sceneNum == SCENE_LAKESIDE_LABORATORY) {
+            if (CVarGetInteger(CVAR_ENHANCEMENT("EquipmentAlwaysVisible"), false)) {
+                *camMode = CAM_MODE_AIM_ADULT;
+            } else if (gPlayState->sceneNum == SCENE_LAKESIDE_LABORATORY) {
                 *camMode = CAM_MODE_AIM_ADULT; // Fix child Hookshot aiming in lab (CAM_MODE_AIM_CHILD is invalid there)
             }
         } else if (*heldItemAction == PLAYER_IA_BOOMERANG) {

--- a/soh/soh/Enhancements/ExtraModes/EnemyRandoMinibossMusic.cpp
+++ b/soh/soh/Enhancements/ExtraModes/EnemyRandoMinibossMusic.cpp
@@ -31,17 +31,96 @@ extern bool IsTimedRoom(bool mq, s16 sceneNum, s8 roomNum);
 #define CVAR_MINIBOSS_BGM_NAME CVAR_ENHANCEMENT("EnemyRandoMinibossBgm")
 #define CVAR_MINIBOSS_BGM_DEFAULT false
 #define MINIBOSS_BGM_ENABLED CVarGetInteger(CVAR_MINIBOSS_BGM_NAME, CVAR_MINIBOSS_BGM_DEFAULT)
+#define CVAR_INVIS_STALFOS_NAME CVAR_ENHANCEMENT("EnemyRandoInvisStalfosBgm")
+#define CVAR_INVIS_STALFOS_DEFAULT false
+#define INVIS_STALFOS_ENABLED CVarGetInteger(CVAR_INVIS_STALFOS_NAME, CVAR_INVIS_STALFOS_DEFAULT)
 
-static u8 sControlMusicArea = false;
+static u8 sControlMusicArea = false; // Area that player update should control miniboss music for
 
-void RegisterEnemyRandoMinibossMusic(void) {
+// Check if active Invisible Stalfos present for stop music check.
+// Return false if any present, true if none present or setting disabled
+u8 EnemyRando_CheckInvisStalfos(Actor* actor) {
+    if (INVIS_STALFOS_ENABLED) {
+        Actor* enemy = gPlayState->actorCtx.actorLists[ACTORCAT_ENEMY].head;
+        while (enemy != NULL) {
+            if ((enemy->id == ACTOR_EN_TEST && enemy->params == STALFOS_TYPE_INVISIBLE) && enemy != actor &&
+                enemy->update != NULL && ((EnTest*)enemy)->actionFunc != EnTest_WaitGround &&
+                Actor_WorldDistXYZToActor(actor, enemy) <= 8000.0f) {
+                return false;
+            }
+            enemy = enemy->next;
+        }
+    }
+    return true;
+}
+
+// Miniboss music hooks for all enemy randomizer, regardless of music settings
+void RegisterEnemyRando_MinibossMusicGeneral(void) {
+    // Stop miniboss music on room switch. Always stop, in case any cvar was toggled during miniboss music
+    COND_HOOK(AfterSceneCommands, ENEMY_RANDOMIZER_ENABLED, [](int16_t sceneId) {
+        if (Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN) == NA_BGM_MINI_BOSS) {
+            func_800F5B58();
+        }
+    });
+
+    // Never let randomized miniboss enemy play music by itself, with exception below
+    COND_VB_SHOULD(VB_PLAY_MINIBOSS_MUSIC, ENEMY_RANDOMIZER_ENABLED, { *should = false; });
+
+    // Ensure non-randomized hooked minibosses play music
+    COND_VB_SHOULD(VB_PLAY_MINIBOSS_MUSIC_IK, ENEMY_RANDOMIZER_ENABLED, {
+        EnIk* enIk = va_arg(args, EnIk*);
+        if (enIk->actor.params == 1280 ||
+            (gPlayState->sceneNum == SCENE_INSIDE_GANONS_CASTLE &&
+             !ResourceMgr_IsSceneMasterQuest(gPlayState->sceneNum) && gPlayState->roomCtx.curRoom.num == 17)) {
+            *should = true;
+        } else {
+            *should = false;
+        }
+    });
+
+    COND_VB_SHOULD(VB_PLAY_MINIBOSS_MUSIC_GELDB, ENEMY_RANDOMIZER_ENABLED, {
+        EnGeldB* enGeldB = va_arg(args, EnGeldB*);
+        if (enGeldB->keyFlag) {
+            *should = true;
+        } else {
+            *should = false;
+        }
+    });
+
+    COND_VB_SHOULD(VB_PLAY_MINIBOSS_MUSIC_TORCH2, ENEMY_RANDOMIZER_ENABLED, {
+        Player* enTorch2 = va_arg(args, Player*);
+        if (!(gPlayState->sceneNum == SCENE_WATER_TEMPLE && gPlayState->roomCtx.curRoom.num == 13)) {
+            *should = false;
+        }
+    });
+
+    // Always play miniboss music for Invisible Stalfos if setting enabled
+    COND_VB_SHOULD(VB_PLAY_MINIBOSS_MUSIC_TEST, ENEMY_RANDOMIZER_ENABLED && !MINIBOSS_BGM_ENABLED, {
+        EnTest* enTest = va_arg(args, EnTest*);
+        if (enTest->actor.params == STALFOS_TYPE_INVISIBLE && INVIS_STALFOS_ENABLED) {
+            *should = true;
+        } else {
+            *should = false;
+        }
+    });
+
+    // Only let non-randomized minibosses stop miniboss music by themselves,
+    // but ensure no Invisible Stalfos active
+    COND_VB_SHOULD(VB_STOP_MINIBOSS_MUSIC, ENEMY_RANDOMIZER_ENABLED && !MINIBOSS_BGM_ENABLED, {
+        Actor* actor = va_arg(args, Actor*);
+        *should = EnemyRando_CheckInvisStalfos(actor);
+    });
+}
+
+// Hooks specific to miniboss music settings
+void RegisterEnemyRando_MinibossMusicSpecific(void) {
     // On scene/room switch, set appropriate sControlMusicArea value
     COND_HOOK(AfterSceneCommands, MINIBOSS_BGM_ENABLED, [](int16_t sceneId) {
         s8 roomNum = gPlayState->roomCtx.curRoom.num;
         bool mq = ResourceMgr_IsSceneMasterQuest(sceneId);
 
         // Control music in clear and timed rooms, but not in rooms with non-randomized minibosses
-        // Exclude Shadow room 11 as doors are not controlled by enemy death
+        // Exclude Shadow clear room 11 as doors are not controlled by enemy death
         if ((IsClearRoom(mq, sceneId, roomNum) || IsTimedRoom(mq, sceneId, roomNum)) &&
             !Flags_GetClear(gPlayState, roomNum) &&
             (!(sceneId == SCENE_BOTTOM_OF_THE_WELL && roomNum == 4) &&
@@ -56,12 +135,11 @@ void RegisterEnemyRandoMinibossMusic(void) {
         }
     });
 
-    // Always play miniboss music for Invisible Stalfos if setting enabled, but let
-    // normal hook handle it if clear/timed room
+    // Always play miniboss music for Invisible Stalfos if Stalfos setting enabled, but let
+    // player hook handle it if clear/timed room
     COND_VB_SHOULD(VB_PLAY_MINIBOSS_MUSIC_TEST, MINIBOSS_BGM_ENABLED, {
         EnTest* enTest = va_arg(args, EnTest*);
-        if (!sControlMusicArea && enTest->actor.params == STALFOS_TYPE_INVISIBLE &&
-            CVarGetInteger(CVAR_ENHANCEMENT("EnemyRandoInvisStalfosBgm"), false)) {
+        if (!sControlMusicArea && enTest->actor.params == STALFOS_TYPE_INVISIBLE && INVIS_STALFOS_ENABLED) {
             *should = true;
         } else {
             *should = false;
@@ -69,26 +147,14 @@ void RegisterEnemyRandoMinibossMusic(void) {
     });
 
     // Only let non-randomized minibosses stop miniboss music by themselves.
-    // Exception: Invisible Stalfos anywhere, if setting is enabled
+    // Exception: Invisible Stalfos anywhere, if setting is enabled and not in control area
     COND_VB_SHOULD(VB_STOP_MINIBOSS_MUSIC, MINIBOSS_BGM_ENABLED, {
         Actor* actor = va_arg(args, Actor*);
 
         if (sControlMusicArea) {
             *should = false;
-        } else if ((actor->id == ACTOR_EN_TEST && actor->params == STALFOS_TYPE_INVISIBLE) &&
-                   CVarGetInteger(CVAR_ENHANCEMENT("EnemyRandoInvisStalfosBgm"), false)) {
-            Actor* enemy = gPlayState->actorCtx.actorLists[ACTORCAT_ENEMY].head;
-            // Rerun proximity check with actor update check as per fix in AlwaysOnFixes,
-            // but also ensure the Stalfos is activated
-            while (enemy != NULL) {
-                if ((enemy->id == ACTOR_EN_TEST && enemy->params == STALFOS_TYPE_INVISIBLE) && enemy != actor &&
-                    enemy->update != NULL && ((EnTest*)enemy)->actionFunc != EnTest_WaitGround &&
-                    Actor_WorldDistXYZToActor(actor, enemy) <= 8000.0f) {
-                    *should = false; // Another active Invisible Stalfos found, continue music
-                    return;
-                }
-                enemy = enemy->next;
-            }
+        } else if (INVIS_STALFOS_ENABLED) {
+            *should = EnemyRando_CheckInvisStalfos(actor);
         }
     });
 
@@ -143,5 +209,8 @@ void RegisterEnemyRandoMinibossMusic(void) {
     });
 }
 
-static RegisterShipInitFunc initFunc(RegisterEnemyRandoMinibossMusic,
-                                     { CVAR_ENEMY_RANDOMIZER_NAME, CVAR_MINIBOSS_BGM_NAME });
+static RegisterShipInitFunc initEnemyRando_MinibossMusicGeneral(RegisterEnemyRando_MinibossMusicGeneral,
+                                                                { CVAR_ENEMY_RANDOMIZER_NAME });
+static RegisterShipInitFunc initEnemyRando_MinibossMusicSpecific(RegisterEnemyRando_MinibossMusicSpecific,
+                                                                 { CVAR_ENEMY_RANDOMIZER_NAME,
+                                                                   CVAR_MINIBOSS_BGM_NAME });

--- a/soh/soh/Enhancements/ExtraModes/EnemyRandoMinibossMusic.cpp
+++ b/soh/soh/Enhancements/ExtraModes/EnemyRandoMinibossMusic.cpp
@@ -1,0 +1,147 @@
+#include "functions.h"
+#include "macros.h"
+#include "variables.h"
+#include "soh/ShipUtils.h"
+#include "soh/Enhancements/enhancementTypes.h"
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/ResourceManagerHelpers.h"
+#include "soh/ShipInit.hpp"
+
+extern "C" {
+#include <z64.h>
+#include "src/overlays/actors/ovl_Door_Shutter/z_door_shutter.h"
+#include "src/overlays/actors/ovl_En_GeldB/z_en_geldb.h"
+#include "src/overlays/actors/ovl_En_Ik/z_en_ik.h"
+#include "src/overlays/actors/ovl_En_Test/z_en_test.h"
+#include "src/overlays/actors/ovl_En_Zf/z_en_zf.h"
+
+extern PlayState* gPlayState;
+extern void EnTest_WaitGround(EnTest*, PlayState*);
+extern void Player_Action_80845EF8(Player*, PlayState*);
+extern void Player_Action_80845CA4(Player*, PlayState*);
+}
+
+extern bool IsClearRoom(bool mq, s16 sceneNum, s8 roomNum);
+extern bool IsTimedRoom(bool mq, s16 sceneNum, s8 roomNum);
+
+#define CVAR_ENEMY_RANDOMIZER_NAME CVAR_ENHANCEMENT("RandomizedEnemies")
+#define CVAR_ENEMY_RANDOMIZER_DEFAULT ENEMY_RANDOMIZER_OFF
+#define CVAR_ENEMY_RANDOMIZER_VALUE CVarGetInteger(CVAR_ENEMY_RANDOMIZER_NAME, CVAR_ENEMY_RANDOMIZER_DEFAULT)
+#define ENEMY_RANDOMIZER_ENABLED CVAR_ENEMY_RANDOMIZER_VALUE != CVAR_ENEMY_RANDOMIZER_DEFAULT
+#define CVAR_MINIBOSS_BGM_NAME CVAR_ENHANCEMENT("EnemyRandoMinibossBgm")
+#define CVAR_MINIBOSS_BGM_DEFAULT false
+#define MINIBOSS_BGM_ENABLED CVarGetInteger(CVAR_MINIBOSS_BGM_NAME, CVAR_MINIBOSS_BGM_DEFAULT)
+
+static u8 sControlMusicArea = false;
+
+void RegisterEnemyRandoMinibossMusic(void) {
+    // On scene/room switch, set appropriate sControlMusicArea value
+    COND_HOOK(AfterSceneCommands, MINIBOSS_BGM_ENABLED, [](int16_t sceneId) {
+        s8 roomNum = gPlayState->roomCtx.curRoom.num;
+        bool mq = ResourceMgr_IsSceneMasterQuest(sceneId);
+
+        // Control music in clear and timed rooms, but not in rooms with non-randomized minibosses
+        // Exclude Shadow room 11 as doors are not controlled by enemy death
+        if ((IsClearRoom(mq, sceneId, roomNum) || IsTimedRoom(mq, sceneId, roomNum)) &&
+            !Flags_GetClear(gPlayState, roomNum) &&
+            (!(sceneId == SCENE_BOTTOM_OF_THE_WELL && roomNum == 4) &&
+             !(sceneId == SCENE_SHADOW_TEMPLE && (roomNum == 4 || roomNum == 11 || roomNum == 21)) &&
+             !(sceneId == SCENE_FOREST_TEMPLE && roomNum == 2) &&
+             !(sceneId == SCENE_SPIRIT_TEMPLE_BOSS && roomNum == 1) && !(sceneId == SCENE_JABU_JABU && roomNum == 6) &&
+             !(sceneId == SCENE_DODONGOS_CAVERN && (roomNum == 3 || roomNum == 5)) &&
+             !(sceneId == SCENE_INSIDE_GANONS_CASTLE && roomNum == 17 && mq) && !(sceneId == SCENE_THIEVES_HIDEOUT))) {
+            sControlMusicArea = true;
+        } else {
+            sControlMusicArea = false;
+        }
+    });
+
+    // Always play miniboss music for Invisible Stalfos if setting enabled, but let
+    // normal hook handle it if clear/timed room
+    COND_VB_SHOULD(VB_PLAY_MINIBOSS_MUSIC_TEST, MINIBOSS_BGM_ENABLED, {
+        EnTest* enTest = va_arg(args, EnTest*);
+        if (!sControlMusicArea && enTest->actor.params == STALFOS_TYPE_INVISIBLE &&
+            CVarGetInteger(CVAR_ENHANCEMENT("EnemyRandoInvisStalfosBgm"), false)) {
+            *should = true;
+        } else {
+            *should = false;
+        }
+    });
+
+    // Only let non-randomized minibosses stop miniboss music by themselves.
+    // Exception: Invisible Stalfos anywhere, if setting is enabled
+    COND_VB_SHOULD(VB_STOP_MINIBOSS_MUSIC, MINIBOSS_BGM_ENABLED, {
+        Actor* actor = va_arg(args, Actor*);
+
+        if (sControlMusicArea) {
+            *should = false;
+        } else if ((actor->id == ACTOR_EN_TEST && actor->params == STALFOS_TYPE_INVISIBLE) &&
+                   CVarGetInteger(CVAR_ENHANCEMENT("EnemyRandoInvisStalfosBgm"), false)) {
+            Actor* enemy = gPlayState->actorCtx.actorLists[ACTORCAT_ENEMY].head;
+            // Rerun proximity check with actor update check as per fix in AlwaysOnFixes,
+            // but also ensure the Stalfos is activated
+            while (enemy != NULL) {
+                if ((enemy->id == ACTOR_EN_TEST && enemy->params == STALFOS_TYPE_INVISIBLE) && enemy != actor &&
+                    enemy->update != NULL && ((EnTest*)enemy)->actionFunc != EnTest_WaitGround &&
+                    Actor_WorldDistXYZToActor(actor, enemy) <= 8000.0f) {
+                    *should = false; // Another active Invisible Stalfos found, continue music
+                    return;
+                }
+                enemy = enemy->next;
+            }
+        }
+    });
+
+    // Let player update decide whether to play miniboss music for randomized miniboss enemies
+    COND_HOOK(OnPlayerUpdate, MINIBOSS_BGM_ENABLED, [&]() {
+        Player* player = GET_PLAYER(gPlayState);
+        Actor* actor;
+        s16 curSeq;
+        static u8 switchTimer = 0;
+
+        if (!sControlMusicArea) {
+            return; // Miniboss or similar area
+        } else if (curSeq = Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN), curSeq == 65535) {
+            switchTimer = 0; // Original music not started, won't get stored
+            return;
+        } else if (gPlayState->transitionTrigger != TRANS_TRIGGER_OFF ||
+                   (player->stateFlags1 & PLAYER_STATE1_LOADING) || player->actionFunc == Player_Action_80845EF8 ||
+                   player->actionFunc == Player_Action_80845CA4 ||
+                   (player->csAction == 2 && player->doorActor != NULL && player->doorActor->xzDistToPlayer < 100.0f)) {
+            switchTimer = 28; // Ready to instantly play on room switch (and after door barred),
+            return;           // but previous room enemy actors need to unload first
+        } else if (switchTimer != 30) {
+            switchTimer++;
+            return;
+        }
+
+        // Check enemy actors for miniboss enemies
+        actor = gPlayState->actorCtx.actorLists[ACTORCAT_ENEMY].head;
+        while (actor != NULL) {
+            if (actor->id == ACTOR_EN_TORCH2 || actor->id == ACTOR_EN_IK ||
+                (actor->id == ACTOR_EN_GELDB && !(actor->shape.shadowScale != 90.0f)) ||
+                (actor->id == ACTOR_EN_TEST && !(((EnTest*)actor)->actionFunc == EnTest_WaitGround)) ||
+                (actor->id == ACTOR_EN_ZF &&
+                 ((actor->params == ENZF_TYPE_LIZALFOS_LONE && actor->shape.shadowAlpha > 60) ||
+                  (actor->params == ENZF_TYPE_DINOLFOS)))) {
+                if (curSeq != NA_BGM_MINI_BOSS) {
+                    func_800F5ACC(NA_BGM_MINI_BOSS);
+                    switchTimer = 0;
+                }
+                return; // Music is playing or started now
+            }
+            actor = actor->next;
+        }
+        // No enemy found. Restore music. But unless cleared, could still be enemies hiding, don't stop control
+        if (curSeq == NA_BGM_MINI_BOSS) {
+            func_800F5B58();
+            switchTimer = 0;
+            if (Flags_GetClear(gPlayState, gPlayState->roomCtx.curRoom.num)) {
+                sControlMusicArea = false;
+            }
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterEnemyRandoMinibossMusic,
+                                     { CVAR_ENEMY_RANDOMIZER_NAME, CVAR_MINIBOSS_BGM_NAME });

--- a/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
+++ b/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
@@ -23,6 +23,9 @@ extern "C" {
 #include "src/overlays/actors/ovl_En_Vali/z_en_vali.h"
 #include "src/overlays/actors/ovl_En_Skb/z_en_skb.h"
 #include "src/overlays/actors/ovl_En_Tp/z_en_tp.h"
+#include "src/overlays/actors/ovl_En_Ik/z_en_ik.h"
+#include "src/overlays/actors/ovl_En_Test/z_en_test.h"
+#include "src/overlays/actors/ovl_En_Zf/z_en_zf.h"
 
 extern PlayState* gPlayState;
 }
@@ -35,6 +38,8 @@ extern std::shared_ptr<SohMenu> mSohMenu;
 #define CVAR_ENEMY_RANDOMIZER_DEFAULT ENEMY_RANDOMIZER_OFF
 #define CVAR_ENEMY_RANDOMIZER_VALUE CVarGetInteger(CVAR_ENEMY_RANDOMIZER_NAME, CVAR_ENEMY_RANDOMIZER_DEFAULT)
 #define ENEMY_RANDOMIZER_ENABLED CVAR_ENEMY_RANDOMIZER_VALUE != CVAR_ENEMY_RANDOMIZER_DEFAULT
+#define CVAR_MINIBOSS_BGM_DEFAULT false
+#define MINIBOSS_BGM_ENABLED CVarGetInteger(CVAR_ENHANCEMENT("EnemyRandoMinibossBgm"), CVAR_MINIBOSS_BGM_DEFAULT)
 
 typedef struct EnemyEntry {
     const char* cvar;
@@ -202,7 +207,7 @@ static bool IsExcludedFromTimedRooms(s16 enemyId, s16 enemyParams) {
     }
 }
 
-static bool IsClearRoom(bool mq, s16 sceneNum, s8 roomNum) {
+bool IsClearRoom(bool mq, s16 sceneNum, s8 roomNum) {
     switch (sceneNum) {
         case SCENE_DEKU_TREE:
             if (mq) {
@@ -283,7 +288,7 @@ static bool IsClearRoom(bool mq, s16 sceneNum, s8 roomNum) {
     }
 }
 
-static bool IsTimedRoom(bool mq, s16 sceneNum, s8 roomNum) {
+bool IsTimedRoom(bool mq, s16 sceneNum, s8 roomNum) {
     switch (sceneNum) {
         case SCENE_JABU_JABU:
             return !mq && roomNum == 12;
@@ -707,6 +712,85 @@ void RegisterEnemyRandomizer() {
     COND_ID_HOOK(OnActorInit, ACTOR_EN_SKB, ENEMY_RANDOMIZER_ENABLED, EnemyRando_SetColliderPosSkb);
     COND_ID_HOOK(OnActorInit, ACTOR_EN_PEEHAT, ENEMY_RANDOMIZER_ENABLED, EnemyRando_SetColliderPosPeehat);
 
+    // Don't let randomized miniboss enemy play music (if setting enabled, handled by OnPlayerUpdate hook)
+    COND_VB_SHOULD(VB_PLAY_MINIBOSS_MUSIC, ENEMY_RANDOMIZER_ENABLED, { *should = false; });
+
+    // Ensure non-randomized hooked minibosses play music
+    COND_VB_SHOULD(VB_PLAY_MINIBOSS_MUSIC_IK, ENEMY_RANDOMIZER_ENABLED, {
+        EnIk* enIk = va_arg(args, EnIk*);
+        if (enIk->actor.params == 1280 ||
+            (gPlayState->sceneNum == SCENE_INSIDE_GANONS_CASTLE &&
+             !ResourceMgr_IsSceneMasterQuest(gPlayState->sceneNum) && gPlayState->roomCtx.curRoom.num == 17)) {
+            *should = true;
+        } else {
+            *should = false;
+        }
+    });
+
+    COND_VB_SHOULD(VB_PLAY_MINIBOSS_MUSIC_GELDB, ENEMY_RANDOMIZER_ENABLED, {
+        EnGeldB* enGeldB = va_arg(args, EnGeldB*);
+        if (enGeldB->keyFlag) {
+            *should = true;
+        } else {
+            *should = false;
+        }
+    });
+
+    // Always play miniboss music for Invisible Stalfos if setting enabled
+    // (miniboss BGM setting uses own version)
+    COND_VB_SHOULD(VB_PLAY_MINIBOSS_MUSIC_TEST, ENEMY_RANDOMIZER_ENABLED, {
+        EnTest* enTest = va_arg(args, EnTest*);
+        if (!MINIBOSS_BGM_ENABLED) {
+            if (enTest->actor.params == STALFOS_TYPE_INVISIBLE &&
+                CVarGetInteger(CVAR_ENHANCEMENT("EnemyRandoInvisStalfosBgm"), false)) {
+                *should = true;
+            } else {
+                *should = false;
+            }
+        }
+    });
+
+    // Stop miniboss music on room switch. Always stop, in case cvar was toggled during miniboss music
+    COND_HOOK(AfterSceneCommands, ENEMY_RANDOMIZER_ENABLED, [](int16_t sceneId) {
+        if (Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN) == NA_BGM_MINI_BOSS) {
+            func_800F5B58();
+        }
+    });
+
+    // Activate Iron Knuckles
+    COND_VB_SHOULD(VB_IK_ACTIVATE, ENEMY_RANDOMIZER_ENABLED, {
+        EnIk* enIk = va_arg(args, EnIk*);
+        bool mq = ResourceMgr_IsSceneMasterQuest(gPlayState->sceneNum);
+
+        if (enIk->skelAnime.playSpeed == 1.0f) {
+            return; // Already activated, but not changed action function yet
+        }
+
+        if (enIk->actor.params != 0) {
+            *should = false;
+            enIk->skelAnime.playSpeed = 1.0f;
+
+            // Sounds and effects only for clear/timed rooms
+            if (IsClearRoom(mq, gPlayState->sceneNum, gPlayState->roomCtx.curRoom.num) ||
+                IsTimedRoom(mq, gPlayState->sceneNum, gPlayState->roomCtx.curRoom.num)) {
+                Vec3f effectPos = enIk->actor.world.pos;
+                Audio_PlayActorSound2(&enIk->actor, NA_SE_EN_IRONNACK_ARMOR_HIT);
+                effectPos.y += 30.0f;
+                func_8003424C(gPlayState, &effectPos);
+            }
+        }
+    });
+
+    // Activate Dark Link, unless in own room
+    COND_VB_SHOULD(VB_TORCH2_ACTIVATE, ENEMY_RANDOMIZER_ENABLED, {
+        Player* enTorch2 = va_arg(args, Player*);
+        Player* player = GET_PLAYER(gPlayState);
+
+        if (!(gPlayState->sceneNum == SCENE_WATER_TEMPLE && gPlayState->roomCtx.curRoom.num == 13)) {
+            *should = true;
+        }
+    });
+
     // Allow Random Gerudo Fighters (contain no keys) to spawn without any switch flags
     COND_VB_SHOULD(VB_GERUDO_FIGHTER_CONTINUE_WAITING, ENEMY_RANDOMIZER_ENABLED, {
         EnGeldB* enGeldB = va_arg(args, EnGeldB*);
@@ -715,15 +799,6 @@ void RegisterEnemyRandomizer() {
             if (!enGeldB->invisible || enGeldB->actor.xzDistToPlayer <= 300.0f) {
                 *should = false;
             }
-        }
-    });
-
-    // Don't play Miniboss music for Random Gerudo Fighters
-    COND_VB_SHOULD(VB_GERUDO_FIGHTER_PLAY_MINIBOSS_MUSIC, ENEMY_RANDOMIZER_ENABLED, {
-        EnGeldB* enGeldB = va_arg(args, EnGeldB*);
-
-        if (enGeldB->keyFlag == 0) {
-            *should = false;
         }
     });
 
@@ -1177,6 +1252,18 @@ void RegisterEnemyRandomizerWidgets() {
             UIWidgets::CheckboxOptions().Tooltip("Ground enemies will air walk over pits/floors that void out Link\n"
                                                  "to prevent softlocks. Can be toggled to make enemies fall down\n"
                                                  "or fly back up from a void pit."));
+
+    SohGui::mSohMenu->AddWidget(path, "Miniboss Music for Randomized Minibosses", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("EnemyRandoMinibossBgm"))
+        .Options(UIWidgets::CheckboxOptions().Tooltip(
+            "Play miniboss music for the following enemies when randomized into a miniboss, clear or timed room:\n"
+            "Dark Link, Iron Knuckle, Stalfos, Gerudo Fighter, Lizalfos, Dinolfos."));
+
+    SohGui::mSohMenu->AddWidget(path, "Invisible Stalfos play Miniboss Music", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("EnemyRandoInvisStalfosBgm"))
+        .Options(UIWidgets::CheckboxOptions().Tooltip(
+            "Always play miniboss music when an active Invisible Stalfos is present (i.e. not waiting in the ground) "
+            "regardless of area."));
 
     SohGui::mSohMenu->AddWidget(path, "Enemy List", WIDGET_SEPARATOR_TEXT).PreFunc([](WidgetInfo& info) {
         info.isHidden = !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0);

--- a/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
+++ b/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
@@ -712,51 +712,6 @@ void RegisterEnemyRandomizer() {
     COND_ID_HOOK(OnActorInit, ACTOR_EN_SKB, ENEMY_RANDOMIZER_ENABLED, EnemyRando_SetColliderPosSkb);
     COND_ID_HOOK(OnActorInit, ACTOR_EN_PEEHAT, ENEMY_RANDOMIZER_ENABLED, EnemyRando_SetColliderPosPeehat);
 
-    // Don't let randomized miniboss enemy play music (if setting enabled, handled by OnPlayerUpdate hook)
-    COND_VB_SHOULD(VB_PLAY_MINIBOSS_MUSIC, ENEMY_RANDOMIZER_ENABLED, { *should = false; });
-
-    // Ensure non-randomized hooked minibosses play music
-    COND_VB_SHOULD(VB_PLAY_MINIBOSS_MUSIC_IK, ENEMY_RANDOMIZER_ENABLED, {
-        EnIk* enIk = va_arg(args, EnIk*);
-        if (enIk->actor.params == 1280 ||
-            (gPlayState->sceneNum == SCENE_INSIDE_GANONS_CASTLE &&
-             !ResourceMgr_IsSceneMasterQuest(gPlayState->sceneNum) && gPlayState->roomCtx.curRoom.num == 17)) {
-            *should = true;
-        } else {
-            *should = false;
-        }
-    });
-
-    COND_VB_SHOULD(VB_PLAY_MINIBOSS_MUSIC_GELDB, ENEMY_RANDOMIZER_ENABLED, {
-        EnGeldB* enGeldB = va_arg(args, EnGeldB*);
-        if (enGeldB->keyFlag) {
-            *should = true;
-        } else {
-            *should = false;
-        }
-    });
-
-    // Always play miniboss music for Invisible Stalfos if setting enabled
-    // (miniboss BGM setting uses own version)
-    COND_VB_SHOULD(VB_PLAY_MINIBOSS_MUSIC_TEST, ENEMY_RANDOMIZER_ENABLED, {
-        EnTest* enTest = va_arg(args, EnTest*);
-        if (!MINIBOSS_BGM_ENABLED) {
-            if (enTest->actor.params == STALFOS_TYPE_INVISIBLE &&
-                CVarGetInteger(CVAR_ENHANCEMENT("EnemyRandoInvisStalfosBgm"), false)) {
-                *should = true;
-            } else {
-                *should = false;
-            }
-        }
-    });
-
-    // Stop miniboss music on room switch. Always stop, in case cvar was toggled during miniboss music
-    COND_HOOK(AfterSceneCommands, ENEMY_RANDOMIZER_ENABLED, [](int16_t sceneId) {
-        if (Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN) == NA_BGM_MINI_BOSS) {
-            func_800F5B58();
-        }
-    });
-
     // Activate Iron Knuckles
     COND_VB_SHOULD(VB_IK_ACTIVATE, ENEMY_RANDOMIZER_ENABLED, {
         EnIk* enIk = va_arg(args, EnIk*);
@@ -784,7 +739,6 @@ void RegisterEnemyRandomizer() {
     // Activate Dark Link, unless in own room
     COND_VB_SHOULD(VB_TORCH2_ACTIVATE, ENEMY_RANDOMIZER_ENABLED, {
         Player* enTorch2 = va_arg(args, Player*);
-        Player* player = GET_PLAYER(gPlayState);
 
         if (!(gPlayState->sceneNum == SCENE_WATER_TEMPLE && gPlayState->roomCtx.curRoom.num == 13)) {
             *should = true;

--- a/soh/soh/Enhancements/TimeSavers/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/TimeSavers/timesaver_hook_handlers.cpp
@@ -901,6 +901,7 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                         EffectSsDeadDb_Spawn(gPlayState, &pos, &sp7C, &sp7C, 100, 0, 255, 255, 255, 255, 0, 0, 255, 1,
                                              9, true);
                     }
+                    func_800F5B58(); // Restore non-miniboss music
                     Actor_Kill(&ik->actor);
                 }
                 *should = false;

--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -93,7 +93,7 @@ static const std::map<int32_t, const char*> audioRandomizerModes = {
 // Grabs the current BGM sequence ID and replays it
 // which will lookup the proper override, or reset back to vanilla
 void ReplayCurrentBGM() {
-    u16 curSeqId = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
+    u16 curSeqId = Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN);
     // TODO: replace with Audio_StartSeq when the macro is shared
     // The fade time and audio player flags will always be 0 in the case of replaying the BGM, so they are not set here
     Audio_QueueSeqCmd(0x00000000 | curSeqId);
@@ -106,7 +106,7 @@ void UpdateCurrentBGM(u16 seqKey, SeqType seqType) {
         return;
     }
 
-    u16 curSeqId = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
+    u16 curSeqId = Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN);
     if (curSeqId == seqKey) {
         ReplayCurrentBGM();
     }
@@ -262,7 +262,7 @@ void Draw_SfxTab(const std::string& tabId, SeqType type, const std::string& tabN
     ImGui::SeparatorText(tabName.c_str());
     if (UIWidgets::Button(resetAllButton.c_str(),
                           UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline).Color(THEME_COLOR))) {
-        auto currentBGM = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
+        auto currentBGM = Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN);
         auto prevReplacement = AudioCollection::Instance->GetReplacementSequence(currentBGM);
         ResetGroup(map, type);
         Ship::Context::GetRawInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
@@ -274,7 +274,7 @@ void Draw_SfxTab(const std::string& tabId, SeqType type, const std::string& tabN
     ImGui::SameLine();
     if (UIWidgets::Button(randomizeAllButton.c_str(),
                           UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline).Color(THEME_COLOR))) {
-        auto currentBGM = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
+        auto currentBGM = Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN);
         auto prevReplacement = AudioCollection::Instance->GetReplacementSequence(currentBGM);
         RandomizeGroup(type);
         Ship::Context::GetRawInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
@@ -286,7 +286,7 @@ void Draw_SfxTab(const std::string& tabId, SeqType type, const std::string& tabN
     ImGui::SameLine();
     if (UIWidgets::Button(lockAllButton.c_str(),
                           UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline).Color(THEME_COLOR))) {
-        auto currentBGM = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
+        auto currentBGM = Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN);
         auto prevReplacement = AudioCollection::Instance->GetReplacementSequence(currentBGM);
         LockGroup(map, type);
         Ship::Context::GetRawInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
@@ -298,7 +298,7 @@ void Draw_SfxTab(const std::string& tabId, SeqType type, const std::string& tabN
     ImGui::SameLine();
     if (UIWidgets::Button(unlockAllButton.c_str(),
                           UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline).Color(THEME_COLOR))) {
-        auto currentBGM = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
+        auto currentBGM = Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN);
         auto prevReplacement = AudioCollection::Instance->GetReplacementSequence(currentBGM);
         UnlockGroup(map, type);
         Ship::Context::GetRawInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
@@ -309,7 +309,7 @@ void Draw_SfxTab(const std::string& tabId, SeqType type, const std::string& tabN
     }
 
     auto playingFromMenu = CVarGetInteger(CVAR_AUDIO("Playing"), 0);
-    auto currentBGM = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
+    auto currentBGM = Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN);
 
     // Longest text in Audio Editor
     ImVec2 columnSize = ImGui::CalcTextSize("Navi - Look/Hey/Watchout (Target Enemy)");

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_RawAction.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_RawAction.cpp
@@ -78,7 +78,7 @@ void GameInteractor::RawAction::SetWeatherStorm(bool active) {
         gPlayState->envCtx.unk_F2[0] = 0;
         if (gPlayState->csCtx.state == CS_STATE_IDLE) {
             Environment_StopStormNatureAmbience(gPlayState);
-        } else if (func_800FA0B4(SEQ_PLAYER_BGM_MAIN) == NA_BGM_NATURE_AMBIENCE) {
+        } else if (Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN) == NA_BGM_NATURE_AMBIENCE) {
             Audio_SetNatureAmbienceChannelIO(NATURE_CHANNEL_LIGHTNING, CHANNEL_IO_PORT_1, 0);
             Audio_SetNatureAmbienceChannelIO(NATURE_CHANNEL_RAIN, CHANNEL_IO_PORT_1, 0);
         }

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -970,6 +970,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `Player*`
+    VB_PLAY_MINIBOSS_MUSIC_TORCH2,
+
+    // #### `result`
+    // ```c
     // varies
     // ```
     // #### `args`

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -937,6 +937,63 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // true
+    // ```
+    // #### `args`
+    // - None
+    VB_PLAY_MINIBOSS_MUSIC,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `EnIk*`
+    VB_PLAY_MINIBOSS_MUSIC_IK,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `EnGeldB*`
+    VB_PLAY_MINIBOSS_MUSIC_GELDB,
+
+    // #### `result`
+    // ```c
+    // (this->actor.params != STALFOS_TYPE_2) && !Actor_FindNearby(play, &this->actor, ACTOR_EN_TEST, ACTORCAT_ENEMY,
+    // 8000.0f)
+    // ```
+    // #### `args`
+    // - `EnTest*`
+    VB_PLAY_MINIBOSS_MUSIC_TEST,
+
+    // #### `result`
+    // ```c
+    // varies
+    // ```
+    // #### `args`
+    // - `Actor*`
+    VB_STOP_MINIBOSS_MUSIC,
+
+    // #### `result`
+    // ```c
+    // this->bodyCollider.base.acFlags & AC_HIT
+    // ```
+    // #### `args`
+    // - `EnIk*`
+    VB_IK_ACTIVATE,
+
+    // #### `result`
+    // ```c
+    // (this->actor.xzDistToPlayer <= 120.0f) || Actor_IsTargeted(play, &this->actor) || (attackItem != NULL)
+    // ```
+    // #### `args`
+    // - `EnTorch2*`
+    VB_TORCH2_ACTIVATE,
+
+    // #### `result`
+    // ```c
     // (this->invisible && !Flags_GetSwitch(play, this->actor.home.rot.z)) || this->actor.xzDistToPlayer > 300.0f
     // ```
     // #### `args`

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -3867,7 +3867,7 @@ void AudioDebug_ProcessInput(void) {
             if (CHECK_BTN_ANY(sDebugPadPress, BTN_A)) {
                 sAudioSndContWork[5] ^= 1;
                 Audio_SeqCmdE01(SEQ_PLAYER_BGM_MAIN, sAudioSndContWork[5]);
-                if (func_800FA0B4(SEQ_PLAYER_BGM_MAIN) != NA_BGM_NATURE_AMBIENCE) {
+                if (Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN) != NA_BGM_NATURE_AMBIENCE) {
                     Audio_SeqCmd1(SEQ_PLAYER_BGM_MAIN, 0);
                 }
                 Audio_SeqCmd1(SEQ_PLAYER_FANFARE, 0);
@@ -4740,8 +4740,8 @@ void Audio_SplitBgmChannels(s8 volSplit) {
     u8 channelIdx;
     u8 i;
 
-    if ((func_800FA0B4(SEQ_PLAYER_FANFARE) == NA_BGM_DISABLED) &&
-        (func_800FA0B4(SEQ_PLAYER_BGM_SUB) != NA_BGM_LONLON)) {
+    if ((Audio_GetActiveSeqId(SEQ_PLAYER_FANFARE) == NA_BGM_DISABLED) &&
+        (Audio_GetActiveSeqId(SEQ_PLAYER_BGM_SUB) != NA_BGM_LONLON)) {
         for (i = 0; i < ARRAY_COUNT(bgmPlayers); i++) {
             if (i == 0) {
                 // Main Bgm SeqPlayer
@@ -4833,8 +4833,8 @@ void Audio_PlaySceneSequence(u16 seqId) {
     u8 sp27 = 0;
     u16 nv;
 
-    if (func_800FA0B4(SEQ_PLAYER_BGM_MAIN) != NA_BGM_WINDMILL) {
-        if (func_800FA0B4(SEQ_PLAYER_BGM_SUB) == NA_BGM_LONLON) {
+    if (Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN) != NA_BGM_WINDMILL) {
+        if (Audio_GetActiveSeqId(SEQ_PLAYER_BGM_SUB) == NA_BGM_LONLON) {
             func_800F9474(SEQ_PLAYER_BGM_SUB, 0);
             Audio_QueueCmdS32(0xF8000000, 0);
         }
@@ -4863,7 +4863,7 @@ void Audio_UpdateSceneSequenceResumePoint(void) {
     u16 temp_v0;
     u8 bvar;
 
-    temp_v0 = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
+    temp_v0 = Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN);
     bvar = temp_v0 & 0xFF;
     if ((temp_v0 != NA_BGM_DISABLED) && (Audio_GetSeqFlags(bvar) & 0x10)) {
         if (sSeqResumePoint != 0xC0) {
@@ -4875,7 +4875,7 @@ void Audio_UpdateSceneSequenceResumePoint(void) {
 }
 
 void Audio_PlayWindmillBgm(void) {
-    if (func_800FA0B4(SEQ_PLAYER_BGM_MAIN) != NA_BGM_WINDMILL) {
+    if (Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN) != NA_BGM_WINDMILL) {
         Audio_StartSeq(SEQ_PLAYER_BGM_MAIN, 0, NA_BGM_WINDMILL);
     }
 }
@@ -4890,7 +4890,7 @@ void Audio_SetMainBgmTempoFreqAfterFanfare(f32 arg0, u8 arg2) {
 }
 
 void Audio_SetFastTempoForTimedMinigame(void) {
-    if (func_800FA0B4(SEQ_PLAYER_BGM_MAIN) == NA_BGM_TIMED_MINI_GAME && func_800FA11C(0, 0xF0000000)) {
+    if (Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN) == NA_BGM_TIMED_MINI_GAME && func_800FA11C(0, 0xF0000000)) {
         Audio_SeqCmdB(SEQ_PLAYER_BGM_MAIN, 5, 0, 0xD2);
     }
 }
@@ -4930,7 +4930,7 @@ s32 Audio_IsSequencePlaying(u8 arg0) {
         phi_a1 = 1;
     }
 
-    if (arg0 == (u8)func_800FA0B4(phi_a1)) {
+    if (arg0 == (u8)Audio_GetActiveSeqId(phi_a1)) {
         return 1;
     } else {
         return 0;
@@ -4942,7 +4942,7 @@ s32 Audio_IsSequencePlaying(u8 arg0) {
  * Designed for the mini-boss sequence, but also used by mini-game 2 sequence
  */
 void func_800F5ACC(u16 seqId) {
-    u16 curSeqId = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
+    u16 curSeqId = Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN);
 
     if ((curSeqId & 0xFF) != NA_BGM_GANON_TOWER && (curSeqId & 0xFF) != NA_BGM_ESCAPE && curSeqId != seqId) {
         Audio_SetSequenceMode(SEQ_MODE_IGNORE);
@@ -4956,9 +4956,9 @@ void func_800F5ACC(u16 seqId) {
     }
 }
 
-// based on func_800F5ACC
+// SoH: based on func_800F5ACC
 void PreviewSequence(u16 seqId) {
-    u16 curSeqId = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
+    u16 curSeqId = Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN);
 
     if ((curSeqId & 0xFF) != NA_BGM_GANON_TOWER && (curSeqId & 0xFF) != NA_BGM_ESCAPE && curSeqId != seqId) {
         Audio_SetSequenceMode(SEQ_MODE_IGNORE);
@@ -4976,8 +4976,8 @@ void PreviewSequence(u16 seqId) {
  * Restores the previous sequence to the main bgm player before func_800F5ACC was called
  */
 void func_800F5B58(void) {
-    if ((func_800FA0B4(SEQ_PLAYER_BGM_MAIN) != NA_BGM_DISABLED) && (sPrevMainBgmSeqId != NA_BGM_DISABLED) &&
-        (Audio_GetSeqFlags(func_800FA0B4(SEQ_PLAYER_BGM_MAIN) & 0xFF) & 8)) {
+    if ((Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN) != NA_BGM_DISABLED) && (sPrevMainBgmSeqId != NA_BGM_DISABLED) &&
+        (Audio_GetSeqFlags(Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN) & 0xFF) & 8)) {
         if (sPrevMainBgmSeqId == NA_BGM_DISABLED) {
             Audio_SeqCmd1(SEQ_PLAYER_BGM_MAIN, 0);
         } else {
@@ -4992,7 +4992,7 @@ void func_800F5B58(void) {
  * Plays the nature ambience sequence on the main bgm player, but stores the previous sequence to return to later
  */
 void func_800F5BF0(u8 natureAmbienceId) {
-    u16 curSeqId = func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
+    u16 curSeqId = Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN);
 
     if (curSeqId != NA_BGM_NATURE_AMBIENCE) {
         sPrevMainBgmSeqId = curSeqId;
@@ -5017,7 +5017,7 @@ void Audio_PlayFanfare(u16 seqId) {
     u8* curFontId;
     u8* requestedFontId;
 
-    curSeqId = func_800FA0B4(SEQ_PLAYER_FANFARE);
+    curSeqId = Audio_GetActiveSeqId(SEQ_PLAYER_FANFARE);
 
     // Although seqIds are u16, there is no fanfare that is above 0xFF
     // Sometimes the game will add 0x900 to a requested fanfare ID
@@ -5050,9 +5050,9 @@ void Audio_UpdateFanfare(void) {
         if (sFanfareStartTimer == 0) {
             Audio_QueueCmdS32(0xE3000000, SEQUENCE_TABLE);
             Audio_QueueCmdS32(0xE3000000, FONT_TABLE);
-            func_800FA0B4(SEQ_PLAYER_BGM_MAIN);
-            sp26 = func_800FA0B4(SEQ_PLAYER_FANFARE);
-            sp22 = func_800FA0B4(SEQ_PLAYER_BGM_SUB);
+            Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN);
+            sp26 = Audio_GetActiveSeqId(SEQ_PLAYER_FANFARE);
+            sp22 = Audio_GetActiveSeqId(SEQ_PLAYER_BGM_SUB);
             if (sp26 == NA_BGM_DISABLED) {
                 Audio_SetVolScale(SEQ_PLAYER_BGM_MAIN, 1, 0, 5);
                 Audio_SetVolScale(SEQ_PLAYER_BGM_SUB, 1, 0, 5);
@@ -5090,7 +5090,7 @@ void Audio_SetSequenceMode(u8 seqMode) {
 
         seqId = gActiveSeqs[SEQ_PLAYER_BGM_MAIN].seqId;
 
-        if (seqId == NA_BGM_FIELD_LOGIC && func_800FA0B4(SEQ_PLAYER_BGM_SUB) == (NA_BGM_ENEMY | 0x800)) {
+        if (seqId == NA_BGM_FIELD_LOGIC && Audio_GetActiveSeqId(SEQ_PLAYER_BGM_SUB) == (NA_BGM_ENEMY | 0x800)) {
             seqMode = SEQ_MODE_IGNORE;
         }
 
@@ -5184,7 +5184,7 @@ void Audio_UpdateMalonSinging(f32 dist, u16 arg1) {
     sIsMalonSinging = true;
     sMalonSingingDist = dist;
     if (sMalonSingingDisabled == 0) {
-        temp_a0 = (s8)(func_800FA0B4(SEQ_PLAYER_BGM_MAIN) & 0xFF);
+        temp_a0 = (s8)(Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN) & 0xFF);
         if (temp_a0 == (arg1 & 0xFF)) {
             if ((arg1 & 0xFF) == NA_BGM_LONLON) {
 
@@ -5204,7 +5204,7 @@ void Audio_UpdateMalonSinging(f32 dist, u16 arg1) {
                 }
             }
         } else if ((temp_a0 == NA_BGM_NATURE_AMBIENCE) && ((arg1 & 0xFF) == NA_BGM_LONLON)) {
-            temp_a0 = (s8)(func_800FA0B4(SEQ_PLAYER_BGM_SUB) & 0xFF);
+            temp_a0 = (s8)(Audio_GetActiveSeqId(SEQ_PLAYER_BGM_SUB) & 0xFF);
             if ((temp_a0 != (arg1 & 0xFF)) && (sMalonSingingTimer < 10)) {
                 Audio_PlaySequenceWithSeqPlayerIO(SEQ_PLAYER_BGM_SUB, NA_BGM_LONLON, 0, 0, 0);
                 Audio_SeqCmdA(SEQ_PLAYER_BGM_SUB, 0xFFFC);
@@ -5247,10 +5247,10 @@ void Audio_ToggleMalonSinging(u8 arg0) {
     u16 sp34;
 
     sMalonSingingDisabled = arg0;
-    if ((func_800FA0B4(SEQ_PLAYER_BGM_MAIN) & 0xFF) == NA_BGM_LONLON) {
+    if ((Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN) & 0xFF) == NA_BGM_LONLON) {
         playerIdx = SEQ_PLAYER_BGM_MAIN;
         sp34 = 0;
-    } else if ((func_800FA0B4(SEQ_PLAYER_BGM_SUB) & 0xFF) == NA_BGM_LONLON) {
+    } else if ((Audio_GetActiveSeqId(SEQ_PLAYER_BGM_SUB) & 0xFF) == NA_BGM_LONLON) {
         playerIdx = SEQ_PLAYER_BGM_SUB;
         sp34 = 0xFFFC;
     } else {
@@ -5469,7 +5469,7 @@ void Audio_SetNatureAmbienceChannelIO(u8 channelIdxRange, u8 port, u8 val) {
 
     // channelIdxRange = 01 on port 1
     if (((channelIdxRange << 8) + port) == ((NATURE_CHANNEL_CRITTER_0 << 8) + CHANNEL_IO_PORT_1)) {
-        if (func_800FA0B4(SEQ_PLAYER_BGM_SUB) != NA_BGM_LONLON) {
+        if (Audio_GetActiveSeqId(SEQ_PLAYER_BGM_SUB) != NA_BGM_LONLON) {
             sMalonSingingTimer = 0;
         }
     }
@@ -5489,7 +5489,7 @@ void Audio_SetNatureAmbienceChannelIO(u8 channelIdxRange, u8 port, u8 val) {
 void Audio_StartNatureAmbienceSequence(u16 playerIO, u16 channelMask) {
     u8 channelIdx;
 
-    if (func_800FA0B4(SEQ_PLAYER_BGM_MAIN) == NA_BGM_WINDMILL) {
+    if (Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN) == NA_BGM_WINDMILL) {
         func_800F3F3C(0xF);
         return;
     }

--- a/soh/src/code/code_800F9280.c
+++ b/soh/src/code/code_800F9280.c
@@ -397,11 +397,11 @@ void Audio_ProcessSeqCmds(void) {
     }
 }
 
-u16 func_800FA0B4(u8 playerIdx) {
-    if (!gAudioContext.seqPlayers[playerIdx].enabled) {
+u16 Audio_GetActiveSeqId(u8 seqPlayerIndex) {
+    if (!gAudioContext.seqPlayers[seqPlayerIndex].enabled) {
         return NA_BGM_DISABLED;
     }
-    return gActiveSeqs[playerIdx].seqId;
+    return gActiveSeqs[seqPlayerIndex].seqId;
 }
 
 s32 func_800FA11C(u32 arg0, u32 arg1) {

--- a/soh/src/code/z_kankyo.c
+++ b/soh/src/code/z_kankyo.c
@@ -2520,7 +2520,7 @@ void Environment_StopStormNatureAmbience(PlayState* play) {
     Audio_SetNatureAmbienceChannelIO(NATURE_CHANNEL_RAIN, CHANNEL_IO_PORT_1, 0);
     Audio_SetNatureAmbienceChannelIO(NATURE_CHANNEL_LIGHTNING, CHANNEL_IO_PORT_1, 0);
 
-    if (func_800FA0B4(SEQ_PLAYER_BGM_MAIN) == NA_BGM_NATURE_AMBIENCE) {
+    if (Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN) == NA_BGM_NATURE_AMBIENCE) {
         gSaveContext.seqId = NA_BGM_NATURE_SFX_RAIN;
         Environment_PlaySceneSequence(play);
     }

--- a/soh/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
+++ b/soh/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
@@ -265,7 +265,9 @@ void EnGeldB_Destroy(Actor* thisx, PlayState* play) {
     s32 pad;
     EnGeldB* this = (EnGeldB*)thisx;
 
-    func_800F5B58();
+    if (GameInteractor_Should(VB_STOP_MINIBOSS_MUSIC, true, &this->actor)) {
+        func_800F5B58();
+    }
     Effect_Delete(play, this->blureIndex);
     Collider_DestroyTris(play, &this->blockCollider);
     Collider_DestroyCylinder(play, &this->bodyCollider);
@@ -365,7 +367,7 @@ void EnGeldB_Wait(EnGeldB* this, PlayState* play) {
     } else {
         this->invisible = false;
         this->actor.shape.shadowScale = 90.0f;
-        if (GameInteractor_Should(VB_GERUDO_FIGHTER_PLAY_MINIBOSS_MUSIC, true, this)) {
+        if (GameInteractor_Should(VB_PLAY_MINIBOSS_MUSIC_GELDB, true, this)) {
             func_800F5ACC(NA_BGM_MINI_BOSS);
         }
     }
@@ -1340,7 +1342,9 @@ void EnGeldB_Defeated(EnGeldB* this, PlayState* play) {
         EnGeldB_SetupFlee(this);
     } else if ((s32)this->skelAnime.curFrame == 10) {
         Audio_PlayActorSound2(&this->actor, NA_SE_EN_RIZA_DOWN);
-        func_800F5B58();
+        if (GameInteractor_Should(VB_STOP_MINIBOSS_MUSIC, true, &this->actor)) {
+            func_800F5B58();
+        }
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Ik/z_en_ik.c
+++ b/soh/src/overlays/actors/ovl_En_Ik/z_en_ik.c
@@ -168,8 +168,9 @@ static DamageTable sDamageTable = {
 
 void EnIk_Destroy(Actor* thisx, PlayState* play) {
     EnIk* this = (EnIk*)thisx;
-
-    if (Actor_FindNearby(play, &this->actor, ACTOR_EN_IK, ACTORCAT_ENEMY, 8000.0f) == NULL) {
+    if (GameInteractor_Should(VB_STOP_MINIBOSS_MUSIC,
+                              (Actor_FindNearby(play, &this->actor, ACTOR_EN_IK, ACTORCAT_ENEMY, 8000.0f) == NULL),
+                              &this->actor)) {
         func_800F5B58();
     }
 
@@ -295,15 +296,16 @@ void func_80A74714(EnIk* this) {
 void func_80A747C0(EnIk* this, PlayState* play) {
     Vec3f sp24;
 
-    if (this->bodyCollider.base.acFlags & AC_HIT) {
+    if (GameInteractor_Should(VB_IK_ACTIVATE,
+                              (this->bodyCollider.base.acFlags & AC_HIT) ||
+                                  CVarGetInteger(CVAR_REMOTE_CROWD_CONTROL("Enabled"), 0),
+                              this)) {
         sp24 = this->actor.world.pos;
         Audio_PlayActorSound2(&this->actor, NA_SE_EN_IRONNACK_ARMOR_HIT);
         sp24.y += 30.0f;
         func_8003424C(play, &sp24);
         this->skelAnime.playSpeed = 1.0f;
-        // Disable miniboss music with Enemy Randomizer because the music would keep
-        // playing if the enemy was never defeated, which is common with Enemy Randomizer.
-        if (!CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0)) {
+        if (GameInteractor_Should(VB_PLAY_MINIBOSS_MUSIC_IK, true, this)) {
             func_800F5ACC(NA_BGM_MINI_BOSS);
         }
     }
@@ -1456,13 +1458,6 @@ void EnIk_Init(Actor* thisx, PlayState* play) {
                            this->jointTable, this->morphTable, 30);
         func_80A74398(&this->actor, play);
         func_80A780D0(this, play);
-    }
-
-    // Immediately trigger Iron Knuckle for Enemy Rando and Crowd Control
-    if ((CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0) ||
-         (CVarGetInteger(CVAR_REMOTE_CROWD_CONTROL("Enabled"), 0))) &&
-        (thisx->params == 2 || thisx->params == 3)) {
-        this->skelAnime.playSpeed = 1.0f;
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
+++ b/soh/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
@@ -93,7 +93,7 @@ void EnOkarinaEffect_ManageStorm(EnOkarinaEffect* this, PlayState* play) {
         play->envCtx.unk_F2[0] = 0;
         if (play->csCtx.state == CS_STATE_IDLE) {
             Environment_StopStormNatureAmbience(play);
-        } else if (func_800FA0B4(SEQ_PLAYER_BGM_MAIN) == NA_BGM_NATURE_AMBIENCE) {
+        } else if (Audio_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN) == NA_BGM_NATURE_AMBIENCE) {
             Audio_SetNatureAmbienceChannelIO(NATURE_CHANNEL_LIGHTNING, CHANNEL_IO_PORT_1, 0);
             Audio_SetNatureAmbienceChannelIO(NATURE_CHANNEL_RAIN, CHANNEL_IO_PORT_1, 0);
         }

--- a/soh/src/overlays/actors/ovl_En_Test/z_en_test.c
+++ b/soh/src/overlays/actors/ovl_En_Test/z_en_test.c
@@ -313,8 +313,10 @@ void EnTest_Init(Actor* thisx, PlayState* play) {
 void EnTest_Destroy(Actor* thisx, PlayState* play) {
     EnTest* this = (EnTest*)thisx;
 
-    if ((this->actor.params != STALFOS_TYPE_2) &&
-        !Actor_FindNearby(play, &this->actor, ACTOR_EN_TEST, ACTORCAT_ENEMY, 8000.0f)) {
+    if (GameInteractor_Should(VB_STOP_MINIBOSS_MUSIC,
+                              (this->actor.params != STALFOS_TYPE_2) &&
+                                  !Actor_FindNearby(play, &this->actor, ACTOR_EN_TEST, ACTORCAT_ENEMY, 8000.0f),
+                              &this->actor)) {
         func_800F5B58();
     }
 
@@ -442,7 +444,7 @@ void EnTest_WaitGround(EnTest* this, PlayState* play) {
         this->actor.world.rot.y = this->actor.yawTowardsPlayer;
         this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
 
-        if (this->actor.params != STALFOS_TYPE_2) {
+        if (GameInteractor_Should(VB_PLAY_MINIBOSS_MUSIC_TEST, this->actor.params != STALFOS_TYPE_2, this)) {
             func_800F5ACC(NA_BGM_MINI_BOSS);
         }
     } else {

--- a/soh/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
+++ b/soh/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
@@ -173,7 +173,9 @@ void EnTorch2_Destroy(Actor* thisx, PlayState* play) {
     Player* this = (Player*)thisx;
 
     Effect_Delete(play, this->meleeWeaponEffectIndex);
-    func_800F5B58();
+    if (GameInteractor_Should(VB_STOP_MINIBOSS_MUSIC, true, &this->actor)) {
+        func_800F5B58();
+    }
     Collider_DestroyCylinder(play, &this->cylinder);
     Collider_DestroyQuad(play, &this->meleeWeaponQuads[0]);
     Collider_DestroyQuad(play, &this->meleeWeaponQuads[1]);
@@ -265,8 +267,10 @@ void EnTorch2_Update(Actor* thisx, PlayState* play2) {
             this->skelAnime.playSpeed = 0.0f;
             this->actor.world.pos.x = (Math_SinS(this->actor.world.rot.y) * 25.0f) + sSpawnPoint.x;
             this->actor.world.pos.z = (Math_CosS(this->actor.world.rot.y) * 25.0f) + sSpawnPoint.z;
-            if ((this->actor.xzDistToPlayer <= 120.0f) || Actor_IsTargeted(play, &this->actor) ||
-                (attackItem != NULL)) {
+            if (GameInteractor_Should(VB_TORCH2_ACTIVATE,
+                                      (this->actor.xzDistToPlayer <= 120.0f) || Actor_IsTargeted(play, &this->actor) ||
+                                          (attackItem != NULL),
+                                      this)) {
                 if (attackItem != NULL) {
                     sDodgeRollState = 1;
                     sStickAngle = this->actor.yawTowardsPlayer;
@@ -279,9 +283,7 @@ void EnTorch2_Update(Actor* thisx, PlayState* play2) {
                     if (stickY) {}
                     sInput.cur.stick_y = stickY;
                 }
-                // Disable miniboss music with Enemy Randomizer because the music would keep
-                // playing if the enemy was never defeated, which is common with Enemy Randomizer.
-                if (!CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0)) {
+                if (GameInteractor_Should(VB_PLAY_MINIBOSS_MUSIC, true)) {
                     func_800F5ACC(NA_BGM_MINI_BOSS);
                 }
                 sActionState = ENTORCH2_ATTACK;
@@ -620,7 +622,9 @@ void EnTorch2_Update(Actor* thisx, PlayState* play2) {
         !(this->meleeWeaponQuads[0].base.atFlags & AT_HIT) && !(this->meleeWeaponQuads[1].base.atFlags & AT_HIT)) {
 
         if (!Actor_ApplyDamage(&this->actor)) {
-            func_800F5B58();
+            if (GameInteractor_Should(VB_STOP_MINIBOSS_MUSIC, true, &this->actor)) {
+                func_800F5B58();
+            }
             this->actor.flags &= ~(ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE);
             this->knockbackType = 2;
             this->knockbackSpeed = 6.0f;
@@ -633,7 +637,9 @@ void EnTorch2_Update(Actor* thisx, PlayState* play2) {
             Item_DropCollectibleRandom(play, &this->actor, &thisx->world.pos, 0xC0);
             this->stateFlags3 &= ~PLAYER_STATE3_PAUSE_ACTION_FUNC;
         } else {
-            func_800F5ACC(NA_BGM_MINI_BOSS);
+            if (GameInteractor_Should(VB_PLAY_MINIBOSS_MUSIC, true)) {
+                func_800F5ACC(NA_BGM_MINI_BOSS);
+            }
             if (this->actor.colChkInfo.damageEffect == 1) {
                 if (sAlpha == 255) {
                     Actor_SetColorFilter(&this->actor, 0, 0xFF, 0, 0x50);

--- a/soh/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
+++ b/soh/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
@@ -283,7 +283,7 @@ void EnTorch2_Update(Actor* thisx, PlayState* play2) {
                     if (stickY) {}
                     sInput.cur.stick_y = stickY;
                 }
-                if (GameInteractor_Should(VB_PLAY_MINIBOSS_MUSIC, true)) {
+                if (GameInteractor_Should(VB_PLAY_MINIBOSS_MUSIC_TORCH2, true, this)) {
                     func_800F5ACC(NA_BGM_MINI_BOSS);
                 }
                 sActionState = ENTORCH2_ATTACK;
@@ -637,7 +637,7 @@ void EnTorch2_Update(Actor* thisx, PlayState* play2) {
             Item_DropCollectibleRandom(play, &this->actor, &thisx->world.pos, 0xC0);
             this->stateFlags3 &= ~PLAYER_STATE3_PAUSE_ACTION_FUNC;
         } else {
-            if (GameInteractor_Should(VB_PLAY_MINIBOSS_MUSIC, true)) {
+            if (GameInteractor_Should(VB_PLAY_MINIBOSS_MUSIC_TORCH2, true, this)) {
                 func_800F5ACC(NA_BGM_MINI_BOSS);
             }
             if (this->actor.colChkInfo.damageEffect == 1) {

--- a/soh/src/overlays/actors/ovl_En_Wf/z_en_wf.c
+++ b/soh/src/overlays/actors/ovl_En_Wf/z_en_wf.c
@@ -261,8 +261,7 @@ void EnWf_Destroy(Actor* thisx, PlayState* play) {
     Collider_DestroyJntSph(play, &this->colliderSpheres);
     Collider_DestroyCylinder(play, &this->colliderCylinderBody);
     Collider_DestroyCylinder(play, &this->colliderCylinderTail);
-
-    if ((this->actor.params != WOLFOS_NORMAL) && (this->switchFlag != 0xFF)) {
+    if (this->actor.params != WOLFOS_NORMAL && (this->switchFlag != 0xFF)) {
         func_800F5B58();
     }
 
@@ -388,10 +387,7 @@ void EnWf_WaitToAppear(EnWf* this, PlayState* play) {
             this->actionTimer = 5;
             this->actor.flags |= ACTOR_FLAG_ATTENTION_ENABLED;
 
-            // Disable miniboss music with Enemy Randomizer because the music would keep
-            // playing if the enemy was never defeated, which is common with Enemy Randomizer.
-            if ((this->actor.params != WOLFOS_NORMAL) && (this->switchFlag != 0xFF) &&
-                !CVarGetInteger(CVAR_ENHANCEMENT("RandomizedEnemies"), 0)) {
+            if ((this->actor.params != WOLFOS_NORMAL) && (this->switchFlag != 0xFF)) {
                 func_800F5ACC(NA_BGM_MINI_BOSS);
             }
         }

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -5858,12 +5858,11 @@ s32 func_8083AD4C(PlayState* play, Player* this) {
         } else {
             camMode = CAM_MODE_AIM_BOOMERANG;
         }
+        // Check if aiming camera mode should be overridden due to player settings
+        GameInteractor_Should(VB_CHANGE_AIMING_CAMERA, true, &this->heldItemAction, &camMode);
     } else {
         camMode = CAM_MODE_FIRST_PERSON;
     }
-
-    // Check if aiming camera mode should be overridden due to player settings
-    GameInteractor_Should(VB_CHANGE_AIMING_CAMERA, true, &this->heldItemAction, &camMode);
 
     return Camera_RequestMode(Play_GetCamera(play, CAM_ID_MAIN), camMode);
 }


### PR DESCRIPTION
Miniboss music is currently not played for randomized miniboss enemies due to problems with music not being stopped.
This lets miniboss music play for Dark Link, Iron Knuckle, Stalfos, Gerudo Fighter and Lizalfos/Dinolfos.

- If rando miniboss music is off, it is only played for non-randomized minibosses.
- If on and player is not in a non-randomized miniboss room, an `OnPlayerUpdate` hook controls which music is played based on distance to any active miniboss enemies in the room (ignores non-activated Gerudo Fighters, Stalfos and Lizalfos).
- If player is in a non-randomized miniboss room, the miniboss controls the music played like normal.
- Miniboss music is always stopped on room change.

The music play distances are currently XYZ 1200.0f and Y 350.0f (stop distance 1250.0f and 400.0f).

Some new actor hooks:

- Activation of Iron Knuckle moved to the first action function (previously in init), this is both more native and more dramatic as miniboss music doesn't play instantly and you can hear and see them activate.
- Similar hook to Dark Link as the very short activation distance was hindering its activity.
- For Gerudo Fighter, Stalfos and Lizalfos, if music is enabled, a Y distance check is added to activation that is consistent with music distance check to prevent them from activating without music.
- And, `func_800FA0B4` replaced with decomp `Audio_GetActiveSeqId`

There were a lot of tricky parts to this so needs to be playtested a bit.
This is what is looks and sounds like: https://www.youtube.com/watch?v=OOLlFBY0IV8

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9887455928.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9887389810.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9887335219.zip)
<!--- section:artifacts:end -->