### PR TITLE
Diagnostics: log the enemy BGM path (#5706)

### DIFF
--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -596,6 +596,8 @@ s32 AudioLoad_SyncInitSeqPlayerInternal(s32 playerIdx, s32 seqId, s32 arg2) {
     // seqId is the resolved 16-bit id from func_800F9280(). Reject ids with no loaded sequence; the
     // map has sequenceMapSize + 0xF slots (custom ids skip the reserved 129-135 range).
     if (seqId < 0 || (size_t)seqId >= sequenceMapSize + 0xF || sequenceMap[seqId] == NULL) {
+        LUSLOG_ERROR("BGM-DIAG reject player=%d seqId=%d mapSize=%d entry=%s", playerIdx, seqId, (int)sequenceMapSize,
+                     ((size_t)seqId < sequenceMapSize + 0xF && seqId >= 0) ? "NULL" : "OOB");
         return 0;
     }
     SequenceData seqData2 = ResourceMgr_LoadSeqByName(sequenceMap[seqId]);
@@ -609,8 +611,12 @@ s32 AudioLoad_SyncInitSeqPlayerInternal(s32 playerIdx, s32 seqId, s32 arg2) {
     seqData = AudioLoad_SyncLoadSeq(seqId);
 
     if (seqData == NULL) {
+        LUSLOG_ERROR("BGM-DIAG seqData NULL player=%d seqId=%d name=%s", playerIdx, seqId,
+                     sequenceMap[seqId] ? sequenceMap[seqId] : "(null)");
         return 0;
     }
+    LUSLOG_INFO("BGM-DIAG started player=%d seqId=%d name=%s", playerIdx, seqId,
+                sequenceMap[seqId] ? sequenceMap[seqId] : "(null)");
 
     AudioSeq_ResetSequencePlayer(seqPlayer);
     seqPlayer->seqId = seqId;
@@ -644,6 +650,7 @@ u8* AudioLoad_SyncLoadSeq(s32 seqId) {
     s32 didAllocate;
 
     if ((size_t)seqId < sequenceMapSize && gAudioContext.seqLoadStatus[seqId] == 1) {
+        LUSLOG_ERROR("BGM-DIAG SyncLoadSeq in-progress seqId=%d", seqId);
         return NULL;
     }
 
@@ -774,18 +781,24 @@ uintptr_t AudioLoad_SyncLoad(u32 tableType, u32 id, s32* didAllocate) {
             case 0:
                 ret = AudioHeap_AllocPermanent(tableType, realId, size);
                 if (ret == NULL) {
+                    LUSLOG_ERROR("BGM-DIAG alloc fail table=%d id=%d size=%d policy=%d", tableType, (int)id, (int)size,
+                                 cachePolicy);
                     return ret;
                 }
                 break;
             case 1:
                 ret = AudioHeap_AllocCached(tableType, size, CACHE_PERSISTENT, realId);
                 if (ret == NULL) {
+                    LUSLOG_ERROR("BGM-DIAG alloc fail table=%d id=%d size=%d policy=%d", tableType, (int)id, (int)size,
+                                 cachePolicy);
                     return ret;
                 }
                 break;
             case 2:
                 ret = AudioHeap_AllocCached(tableType, size, CACHE_TEMPORARY, realId);
                 if (ret == NULL) {
+                    LUSLOG_ERROR("BGM-DIAG alloc fail table=%d id=%d size=%d policy=%d", tableType, (int)id, (int)size,
+                                 cachePolicy);
                     return ret;
                 }
                 break;
@@ -793,6 +806,8 @@ uintptr_t AudioLoad_SyncLoad(u32 tableType, u32 id, s32* didAllocate) {
             case 4:
                 ret = AudioHeap_AllocCached(tableType, size, CACHE_EITHER, realId);
                 if (ret == NULL) {
+                    LUSLOG_ERROR("BGM-DIAG alloc fail table=%d id=%d size=%d policy=%d", tableType, (int)id, (int)size,
+                                 cachePolicy);
                     return ret;
                 }
                 break;
@@ -1012,6 +1027,7 @@ void* AudioLoad_AsyncLoadInner(s32 tableType, s32 id, s32 nChunks, s32 retData, 
     u32 temp_v0;
     u32 realId;
 
+    LUSLOG_ERROR("BGM-DIAG AsyncLoadInner reached: table=%d id=%d", tableType, id);
     switch (tableType) {
         case SEQUENCE_TABLE:
             if (gAudioContext.seqLoadStatus[realId] == 1) {
@@ -1450,6 +1466,7 @@ void AudioLoad_Init(void* heap, size_t heapSize) {
         }
 
         AudioCollection_AddToCollection(customSeqList[j], seqNum);
+        LUSLOG_INFO("BGM-DIAG custom seq id=%d name=%s", seqNum, customSeqList[j]);
 
         sDat->seqNumber = seqNum;
         LUSLOG_DEBUG("Registered custom sequence \"%s\" as seqNum %d", customSeqList[j], seqNum);

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -5083,6 +5083,15 @@ void Audio_SetSequenceMode(u8 seqMode) {
     u8 volumeFadeOutTimer;
 
     sSeqModeInput = seqMode;
+    {
+        static u8 sDbgLastMode = 0xFF;
+        if (seqMode != sDbgLastMode) {
+            sDbgLastMode = seqMode;
+            LUSLOG_INFO("BGM-DIAG SetSeqMode in=%d prevMode=0x%x mainBgm=0x%x prevMainBgm=0x%x dist=%.0f cut=%d",
+                        seqMode, sPrevSeqMode, gActiveSeqs[SEQ_PLAYER_BGM_MAIN].seqId, sPrevMainBgmSeqId,
+                        sAudioEnemyDist, sAudioCutsceneFlag);
+        }
+    }
     if (sPrevMainBgmSeqId == NA_BGM_DISABLED) {
         if (sAudioCutsceneFlag) {
             seqMode = SEQ_MODE_IGNORE;
@@ -5094,6 +5103,20 @@ void Audio_SetSequenceMode(u8 seqMode) {
             seqMode = SEQ_MODE_IGNORE;
         }
 
+        if (seqMode == SEQ_MODE_ENEMY) {
+            // Log only when the decision changes, otherwise this fires every frame.
+            u8 gate = (seqId == NA_BGM_DISABLED) || (Audio_GetSeqFlags((u8)(seqId & 0xFF)) & 1) ||
+                      ((sPrevSeqMode & 0x7F) == SEQ_MODE_ENEMY);
+            u8 changed = seqMode != (sPrevSeqMode & 0x7F);
+            static u8 sDiagLastGate = 0xFF;
+            static u8 sDiagLastChanged = 0xFF;
+            if (gate != sDiagLastGate || changed != sDiagLastChanged) {
+                sDiagLastGate = gate;
+                sDiagLastChanged = changed;
+                LUSLOG_INFO("BGM-DIAG enemy requested: mainSeq=0x%x flags=0x%x prevMode=0x%x gate=%d changed=%d", seqId,
+                            Audio_GetSeqFlags((u8)(seqId & 0xFF)), sPrevSeqMode, gate, changed);
+            }
+        }
         if ((seqId == NA_BGM_DISABLED) || (Audio_GetSeqFlags((u8)(seqId & 0xFF)) & 1) ||
             ((sPrevSeqMode & 0x7F) == SEQ_MODE_ENEMY)) {
             if (seqMode != (sPrevSeqMode & 0x7F)) {
@@ -5106,6 +5129,7 @@ void Audio_SetSequenceMode(u8 seqMode) {
                     }
 
                     Audio_SetVolScale(SEQ_PLAYER_BGM_SUB, 3, sAudioEnemyVol, volumeFadeInTimer);
+                    LUSLOG_INFO("BGM-DIAG enemy-mode ENTER (start NA_BGM_ENEMY on SUB)");
                     Audio_StartSeq(SEQ_PLAYER_BGM_SUB, 10, NA_BGM_ENEMY | 0x800);
 
                     if (seqId != NA_BGM_NATURE_AMBIENCE) {
@@ -5114,6 +5138,7 @@ void Audio_SetSequenceMode(u8 seqMode) {
                     }
                 } else if ((sPrevSeqMode & 0x7F) == SEQ_MODE_ENEMY) {
                     // Stop playing enemy bgm
+                    LUSLOG_INFO("BGM-DIAG enemy-mode EXIT (stop SUB)");
                     Audio_SeqCmd1(SEQ_PLAYER_BGM_SUB, 10);
                     if (seqMode == SEQ_MODE_IGNORE) {
                         volumeFadeOutTimer = 0;

--- a/soh/src/code/code_800F9280.c
+++ b/soh/src/code/code_800F9280.c
@@ -53,6 +53,9 @@ void Audio_StartSequence(u8 playerIdx, u8 seqId, u8 arg2, u16 fadeTimer) {
             resolvedSeqId = AudioEditor_GetReplacementSeq(seqId);
         }
 
+        if (playerIdx == SEQ_PLAYER_BGM_SUB) {
+            LUSLOG_INFO("BGM-DIAG StartSequence SUB seqId=%d -> resolved=%d", seqId, resolvedSeqId);
+        }
         arg2 &= 0x7F;
         if (arg2 == 0x7F) {
             dur = (fadeTimer >> 3) * 60 * gAudioContext.audioBufferParameters.updatesPerFrame;


### PR DESCRIPTION
Not for merge - this exists so anyone hitting #5706 can produce a log that says exactly where the battle music gives up.

**Background.** #6917 fixed out-of-bounds accesses on `seqLoadStatus` for custom sequence ids, but @lankv2 still loses battle music on the latest nightly with a streamed music pack: approach enemies, back off far enough to stop the music, come back, and the main BGM ducks while nothing plays over it.

That symptom is what the code does when the sequence fails to start: `Audio_SetSequenceMode` queues the enemy sequence on the sub player and then lowers the main BGM regardless of whether the sub player actually started, so a silent failure downstream looks exactly like this.

I could not reproduce it locally - 9 out of 9 encounters started the sequence, with streamed custom tracks on both the main and the sub player - so the next step is a log from a setup where it does happen.

**What this logs.**

- `AudioLoad_SyncInitSeqPlayerInternal` rejecting an id, or `AudioLoad_SyncLoadSeq` returning nothing, with the sequence name
- the "already loading" bail
- every allocation failure in `AudioLoad_SyncLoad`, with the size and cache policy
- the enemy state machine entering and leaving enemy mode, and the gate that can block it
- the id assigned to each custom sequence at boot, so the log identifies the pack

All lines are tagged `BGM-DIAG`. The per-frame ones are deduplicated so the log stays readable.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9469970401.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9469922854.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9469912133.zip)
<!--- section:artifacts:end -->