### PR TITLE
Drop the seqLoadStatus bounds checks made redundant by #6932

### DIFF
--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -315,19 +315,13 @@ s32 AudioLoad_IsFontLoadComplete(s32 fontId) {
 s32 AudioLoad_IsSeqLoadComplete(s32 seqId) {
     if (seqId == 0xFF) {
         return true;
-    }
-    if ((size_t)seqId >= sequenceMapSize) {
-        // Custom SAF sequence whose seqId exceeds the status table — not async-loading, treat as ready.
+    } else if (gAudioContext.seqLoadStatus[seqId] >= 2) {
         return true;
-    }
-    if (gAudioContext.seqLoadStatus[seqId] >= 2) {
+    } else if (gAudioContext.seqLoadStatus[AudioLoad_GetRealTableIndex(SEQUENCE_TABLE, seqId)] >= 2) {
         return true;
+    } else {
+        return false;
     }
-    s32 realId = (s32)AudioLoad_GetRealTableIndex(SEQUENCE_TABLE, seqId);
-    if ((size_t)realId < sequenceMapSize && gAudioContext.seqLoadStatus[realId] >= 2) {
-        return true;
-    }
-    return false;
 }
 
 s32 AudioLoad_IsSampleLoadComplete(s32 sampleBankId) {
@@ -349,7 +343,7 @@ void AudioLoad_SetFontLoadStatus(s32 fontId, s32 status) {
 }
 
 void AudioLoad_SetSeqLoadStatus(s32 seqId, s32 status) {
-    if ((seqId != 0xFF) && ((size_t)seqId < sequenceMapSize) && (gAudioContext.seqLoadStatus[seqId] != 5)) {
+    if ((seqId != 0xFF) && (gAudioContext.seqLoadStatus[seqId] != 5)) {
         gAudioContext.seqLoadStatus[seqId] = status;
     }
 }
@@ -643,7 +637,7 @@ u8* AudioLoad_SyncLoadSeq(s32 seqId) {
     s32 pad;
     s32 didAllocate;
 
-    if ((size_t)seqId < sequenceMapSize && gAudioContext.seqLoadStatus[seqId] == 1) {
+    if (gAudioContext.seqLoadStatus[AudioLoad_GetRealTableIndex(SEQUENCE_TABLE, seqId)] == 1) {
         return NULL;
     }
 


### PR DESCRIPTION
Follow-up to @serprex's question on #6917.

#6917 guarded the three `seqLoadStatus` accessors against `sequenceMapSize` because the array was allocated at exactly that size, so a custom sequence id past it read and wrote off the end.

#6932 then sized the array to `sequenceMapSize + 0xF` to match `sequenceMap`. That covers the whole id space instead of rejecting the ids outside it, and it also protects the writers those guards never saw - `AudioHeap_AllocCached` and `AudioHeap_PopCache` index `seqLoadStatus` directly.

So the guards are now redundant, and bounded wrong on top of that: they treat the ids in `[sequenceMapSize, sequenceMapSize + 0xF)` as absent from a table that now has room for them. Nothing breaks today because every entry starts at 5, so `AudioLoad_IsSeqLoadComplete` answers true regardless and `AudioLoad_SetSeqLoadStatus` already declines to overwrite a 5 - but once the heap cache path moves such an entry off 5, the guard blocks an update that should happen.

This reverts them, restoring the three functions to their decompiled form. The sizing from #6932 and the id check in `AudioLoad_SyncInitSeqPlayerInternal` (#6736) remain the actual protection.

**Testing.** Built this branch and ran it with a 46-track streamed music pack, where the assigned ids run to 161 against a `sequenceMapSize` of ~156 - so both the scene music and the battle music sit in or past the range the removed guards used to special-case. Scene music loads (custom id 144) and the battle music starts on every encounter (custom id 158, i.e. past `sequenceMapSize`), across repeated approach/retreat cycles.