### PR TITLE
Disable2DBackgrounds Fixes

### DIFF
--- a/soh/soh/Enhancements/Graphics/Disable2DBackgrounds.cpp
+++ b/soh/soh/Enhancements/Graphics/Disable2DBackgrounds.cpp
@@ -23,25 +23,6 @@ std::set<SceneID> fogControlList = {
     SCENE_TEMPLE_OF_TIME_EXTERIOR_DAY,
     SCENE_TEMPLE_OF_TIME_EXTERIOR_NIGHT,
     SCENE_TEMPLE_OF_TIME_EXTERIOR_RUINS,
-    SCENE_KNOW_IT_ALL_BROS_HOUSE,
-    SCENE_TWINS_HOUSE,
-    SCENE_MIDOS_HOUSE,
-    SCENE_SARIAS_HOUSE,
-    SCENE_BACK_ALLEY_HOUSE,
-    SCENE_BAZAAR,
-    SCENE_KOKIRI_SHOP,
-    SCENE_GORON_SHOP,
-    SCENE_ZORA_SHOP,
-    SCENE_POTION_SHOP_KAKARIKO,
-    SCENE_POTION_SHOP_MARKET,
-    SCENE_BOMBCHU_SHOP,
-    SCENE_HAPPY_MASK_SHOP,
-    SCENE_LINKS_HOUSE,
-    SCENE_DOG_LADY_HOUSE,
-    SCENE_STABLE,
-    SCENE_IMPAS_HOUSE,
-    SCENE_CARPENTERS_TENT,
-    SCENE_GRAVEKEEPERS_HUT,
 };
 
 std::set<SceneID> skyboxSceneControlList = {
@@ -84,6 +65,20 @@ std::set<SkyboxId> skyboxIdControlList = {
     SKYBOX_HOUSE_ALLEY,
 };
 
+static void SyncSkyboxTimeToCurrentTime() {
+    gSaveContext.skyboxTime = gSaveContext.dayTime;
+
+    if ((gSaveContext.skyboxTime >= 0x2AAC) && (gSaveContext.skyboxTime < 0x4555)) {
+        gSaveContext.skyboxTime = 0x3556;
+    } else if ((gSaveContext.skyboxTime >= 0x4555) && (gSaveContext.skyboxTime < 0x5556)) {
+        gSaveContext.skyboxTime = 0x5556;
+    } else if ((gSaveContext.skyboxTime >= 0xAAAB) && (gSaveContext.skyboxTime < 0xB556)) {
+        gSaveContext.skyboxTime = 0xB556;
+    } else if ((gSaveContext.skyboxTime >= 0xC001) && (gSaveContext.skyboxTime < 0xCAAC)) {
+        gSaveContext.skyboxTime = 0xCAAC;
+    }
+}
+
 void Register3DPreRenderedScenes() {
     // Runs after the scene commands have set play->skyboxId, but before Play_InitEnvironment builds the
     // skybox. Overriding the id here means Skybox_Setup loads a real sky; overriding it any later would
@@ -98,11 +93,13 @@ void Register3DPreRenderedScenes() {
         gPlayState->envCtx.skyboxDisabled = false;
 
         // Replace skybox with normal sky
+        SyncSkyboxTimeToCurrentTime();
         gPlayState->skyboxId = SKYBOX_NORMAL_SKY;
         // Apply the always cloudy skybox as an adult for Temple of Time and the Market
         if (sceneNum == SCENE_TEMPLE_OF_TIME_EXTERIOR_RUINS || sceneNum == SCENE_MARKET_RUINS ||
             sceneNum == SCENE_MARKET_ENTRANCE_RUINS) {
             gWeatherMode = 3;
+            gSaveContext.retainWeatherMode = 1;
         }
     });
 
@@ -114,12 +111,8 @@ void Register3DPreRenderedScenes() {
         if ((HREG(80) != 10) || (HREG(82) != 0)) {
             // Furthest possible fog and zFar
             gPlayState->view.zFar = 12800;
-            gPlayState->lightCtx.fogNear = 996; // Set to 1000 to complete disable fog entirely
+            gPlayState->lightCtx.fogNear = 1000;
             gPlayState->lightCtx.fogFar = 12800;
-            // General gray fog color
-            gPlayState->lightCtx.fogColor[0] = 100;
-            gPlayState->lightCtx.fogColor[1] = 100;
-            gPlayState->lightCtx.fogColor[2] = 100;
         }
     });
 

--- a/soh/soh/Enhancements/Graphics/Disable2DBackgrounds.cpp
+++ b/soh/soh/Enhancements/Graphics/Disable2DBackgrounds.cpp
@@ -1,5 +1,8 @@
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 #include "soh/ShipInit.hpp"
+#include "soh/resource/type/scenecommand/SetTimeSettings.h"
+
+bool Scene_CommandTimeSettings(PlayState* play, SOH::ISceneCommand* cmd);
 
 extern "C" {
 #include "variables.h"
@@ -66,17 +69,9 @@ std::set<SkyboxId> skyboxIdControlList = {
 };
 
 static void SyncSkyboxTimeToCurrentTime() {
-    gSaveContext.skyboxTime = gSaveContext.dayTime;
-
-    if ((gSaveContext.skyboxTime >= 0x2AAC) && (gSaveContext.skyboxTime < 0x4555)) {
-        gSaveContext.skyboxTime = 0x3556;
-    } else if ((gSaveContext.skyboxTime >= 0x4555) && (gSaveContext.skyboxTime < 0x5556)) {
-        gSaveContext.skyboxTime = 0x5556;
-    } else if ((gSaveContext.skyboxTime >= 0xAAAB) && (gSaveContext.skyboxTime < 0xB556)) {
-        gSaveContext.skyboxTime = 0xB556;
-    } else if ((gSaveContext.skyboxTime >= 0xC001) && (gSaveContext.skyboxTime < 0xCAAC)) {
-        gSaveContext.skyboxTime = 0xCAAC;
-    }
+    SOH::SetTimeSettings cmd;
+    cmd.settings = { 0xFF, 0xFF, static_cast<uint8_t>(gPlayState->envCtx.timeIncrement) };
+    Scene_CommandTimeSettings(gPlayState, &cmd);
 }
 
 void Register3DPreRenderedScenes() {

--- a/soh/soh/resource/type/scenecommand/SetTimeSettings.h
+++ b/soh/soh/resource/type/scenecommand/SetTimeSettings.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <stdint.h>
-#include <memory>
 #include "SceneCommand.h"
 
 namespace SOH {


### PR DESCRIPTION
fixes ruined market skybox not being correct when using remember save location or the debug menu to warp in

fixes the skybox in interiors not matching the current time of day outside

removed the hardcoded light colors the enhancement enables, these color settings were overriding what prelude users enter for the scenes causing their light settings to be unusable

i would have liked to entirely remove the fog settings as well but unfortunately `fogFar` controls the clipping plane, and although this could also be changed through prelude, i dont want to force modders to use prelude just to get a visually appealing clipping plane incase they want to go through the old DL replacement route (like me)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9476197432.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9476176359.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9476144222.zip)
<!--- section:artifacts:end -->