### PR TITLE
Restore the realId assignment in AudioLoad_AsyncLoadInner

### DIFF
--- a/soh/src/code/audio_load.c
+++ b/soh/src/code/audio_load.c
@@ -1006,6 +1006,7 @@ void* AudioLoad_AsyncLoadInner(s32 tableType, s32 id, s32 nChunks, s32 retData, 
     u32 temp_v0;
     u32 realId;
 
+    realId = AudioLoad_GetRealTableIndex(tableType, id);
     switch (tableType) {
         case SEQUENCE_TABLE:
             if (gAudioContext.seqLoadStatus[realId] == 1) {


### PR DESCRIPTION
`AudioLoad_AsyncLoadInner` declares `realId` and then indexes with it thirteen times - `seqLoadStatus` / `fontLoadStatus` / `sampleFontLoadStatus`, `AudioLoad_SearchCaches`, the table entry it reads `size` and `romAddr` from, all four cache allocations, and the status write at the end - but nothing ever assigns it.

The assignment was dropped by "Custom Sequences" (#2066) in 2022, which removed the `realId = AudioLoad_GetRealTableIndex(tableType, id);` line and left the declaration behind. This restores it.

For `SEQUENCE_TABLE` and `FONT_TABLE`, `AudioLoad_GetRealTableIndex` returns the id unchanged, so in practice this is a correctness fix rather than a behaviour change. Noting it because it is the last place an unbounded id can still reach the load-status tables - it came up while looking at the bounds checks in #6917 and #7100.

The only caller that reaches it today is the sequence script's async load command (`AudioLoad_ScriptLoad`); nothing queues the `0xF4`/`0xF5`/`0xFC` audio commands any more.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9486889828.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9486865288.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9486837545.zip)
<!--- section:artifacts:end -->