### PR TITLE
Clear fire timer when blue warp skip bypasses chamber of sage

### DIFF
--- a/soh/include/z64save.h
+++ b/soh/include/z64save.h
@@ -4,7 +4,7 @@
 #include <libultraship/libultra.h>
 #include "z64math.h"
 #include "z64audio.h"
-#include "soh/Enhancements/randomizer/randomizerTypes.h"
+#include "soh/Enhancements/randomizer/randomizerEnums.h"
 #include "soh/Enhancements/gameplaystats.h"
 #include "soh/Enhancements/randomizer/randomizer_entrance.h"
 #include "soh/Enhancements/boss-rush/BossRush.h"

--- a/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipCutscene/Story/SkipBlueWarp.cpp
@@ -157,6 +157,11 @@ void RegisterShouldPlayBlueWarp() {
             }
 
             if (isBlueWarpCutscene) {
+                // Skip bypasses Chamber of Sages, which would have cleared heat timer
+                if (gSaveContext.timerState <= TIMER_STATE_ENV_HAZARD_TICK) {
+                    gSaveContext.timerState = TIMER_STATE_OFF;
+                }
+
                 if (gSaveContext.entranceIndex != ENTR_LAKE_HYLIA_WATER_TEMPLE_BLUE_WARP) {
                     // Normally set in the blue warp cutscene
                     gSaveContext.dayTime = gSaveContext.skyboxTime = 0x8000;


### PR DESCRIPTION
Avoids timer from Volvagia carrying over to DMC

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9499069887.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9499056935.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9499023724.zip)
<!--- section:artifacts:end -->