### PR TITLE
Scale enemy bgm to the current distance when it starts

### DIFF
--- a/soh/soh/SohGui/SohMenuEnhancements.cpp
+++ b/soh/soh/SohGui/SohMenuEnhancements.cpp
@@ -1101,6 +1101,12 @@ void SohMenu::AddMenuEnhancements() {
         .CVar(CVAR_ENHANCEMENT("BushDropFix"))
         .Options(CheckboxOptions().Tooltip(
             "Fixes the bushes to drop items correctly rather than spawning undefined items."));
+    AddWidget(path, "Fix Enemy Background Music Volume", WIDGET_CVAR_CHECKBOX)
+        .CVar(CVAR_ENHANCEMENT("FixEnemyBgmVolume"))
+        .Options(CheckboxOptions().Tooltip(
+            "Enemy background music fades in at a volume set by how far away the enemy was during the previous "
+            "encounter rather than the current one, so it can start silent next to an enemy, or drown out the "
+            "area music when the enemy is far away. This scales it to the current distance instead."));
     AddWidget(path, "Fix Flex Drops", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_ENHANCEMENT("FixFlexDrops"))
         .Options(CheckboxOptions().Tooltip(

--- a/soh/src/code/code_800EC960.c
+++ b/soh/src/code/code_800EC960.c
@@ -5077,6 +5077,22 @@ void Audio_PlaySequenceWithSeqPlayerIO(u8 playerIdx, u16 seqId, u8 fadeTimer, s8
     Audio_StartSeq(playerIdx, fadeTimer, seqId);
 }
 
+// SOH [Bugfix] Shared with the enemy branch of Audio_SetSequenceMode(), so entering enemy mode
+// scales to the distance the enemy is at now rather than the one the last encounter ended on.
+static s8 Audio_GetBgmEnemyVolume(f32 dist) {
+    f32 adjDist;
+
+    if (dist < 150.0f) {
+        adjDist = 0.0f;
+    } else if (dist > 500.0f) {
+        adjDist = 350.0f;
+    } else {
+        adjDist = dist - 150.0f;
+    }
+
+    return ((350.0f - adjDist) * 127.0f) / 350.0f;
+}
+
 void Audio_SetSequenceMode(u8 seqMode) {
     s32 volumeFadeInTimer;
     u16 seqId;
@@ -5099,6 +5115,12 @@ void Audio_SetSequenceMode(u8 seqMode) {
             if (seqMode != (sPrevSeqMode & 0x7F)) {
                 if (seqMode == SEQ_MODE_ENEMY) {
                     // Start playing enemy bgm
+                    // SOH [Enhancement] Audio_SetBgmEnemyVolume() records the distance every frame but
+                    // only rescales while enemy bgm is already playing, so on this frame sAudioEnemyVol
+                    // still holds the value the previous encounter ended on.
+                    if (CVarGetInteger(CVAR_ENHANCEMENT("FixEnemyBgmVolume"), 0)) {
+                        sAudioEnemyVol = Audio_GetBgmEnemyVolume(sAudioEnemyDist);
+                    }
                     if (gActiveSeqs[SEQ_PLAYER_BGM_SUB].volScales[1] - sAudioEnemyVol < 0) {
                         volumeFadeInTimer = -(gActiveSeqs[SEQ_PLAYER_BGM_SUB].volScales[1] - sAudioEnemyVol);
                     } else {
@@ -5151,19 +5173,9 @@ void Audio_SetSequenceMode(u8 seqMode) {
 }
 
 void Audio_SetBgmEnemyVolume(f32 dist) {
-    f32 adjDist;
-
     if (sPrevSeqMode == (0x80 | SEQ_MODE_ENEMY)) {
         if (dist != sAudioEnemyDist) {
-            if (dist < 150.0f) {
-                adjDist = 0.0f;
-            } else if (dist > 500.0f) {
-                adjDist = 350.0f;
-            } else {
-                adjDist = dist - 150.0f;
-            }
-
-            sAudioEnemyVol = ((350.0f - adjDist) * 127.0f) / 350.0f;
+            sAudioEnemyVol = Audio_GetBgmEnemyVolume(dist);
             Audio_SetVolScale(SEQ_PLAYER_BGM_SUB, 3, sAudioEnemyVol, 10);
             if (gActiveSeqs[SEQ_PLAYER_BGM_MAIN].seqId != NA_BGM_NATURE_AMBIENCE) {
                 Audio_SetVolScale(SEQ_PLAYER_BGM_MAIN, 3, (0x7F - sAudioEnemyVol), 10);


### PR DESCRIPTION
Fixes #5706.

Enemy bgm starts at the volume of the *previous* encounter.

Every frame an enemy is within range, `z_player.c` calls `Audio_SetBgmEnemyVolume()` and then `Audio_SetSequenceMode()`. The first records the distance unconditionally but only rescales while enemy bgm is already playing:

```c
if (sPrevSeqMode == (0x80 | SEQ_MODE_ENEMY)) {
    if (dist != sAudioEnemyDist) { ...rescale... }
}
sAudioEnemyDist = dist;
```

On the frame enemy mode begins, `sPrevSeqMode` is still the old mode, so it stores the new distance and returns without touching `sAudioEnemyVol`. `Audio_SetSequenceMode()` then runs its crossfade against a value that belongs to the last encounter. It also never corrects itself if nothing moves afterwards, because the rescale is guarded on the distance having changed.

**Both directions are audible.** Entering far from an enemy after an encounter that ended close, the area music is ducked to zero while the enemy bgm fades in loud and then straight back down to nothing - the area goes quiet with nothing replacing it, which is what #5706 describes. Entering next to an enemy after one that ended far, the enemy bgm starts inaudible.

**Reproduction.** Instrumented build logging the distance, the volume in use, and the volume that distance actually calls for:

```
before   ENTER dist=0   inUse=2  forThisDistance=127  -> enemy=2  area=125
after    ENTER dist=495 inUse=1  forThisDistance=1    -> enemy=1  area=126
```

The first is an enemy spawned on top of the player right after an encounter that ended 494 units away: adjacent enemy, enemy bgm at 2/127. The second is the reported case - an enemy picked up at 495 units, where the previous encounter had ended at full volume; before the change that entry used 127, silencing the area music.

**Behind a switch.** This is original game behaviour, not a port regression, so the rescale sits behind `FixEnemyBgmVolume` under Enhancements -> Fixes, off by default. Lifting the curve into a helper is unconditional, since it changes nothing on its own.

It is easiest to notice with a custom music pack, because each track is a single streamed channel, so a player scaled to zero goes silent rather than merely thinning out. Nothing about the bug is specific to custom sequences.

Thanks @lankv2 for the log that pinned this down.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9526837526.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9526774473.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9526667272.zip)
<!--- section:artifacts:end -->