### PR TITLE
Fix flare dancer crash

### DIFF
--- a/soh/include/z64.h
+++ b/soh/include/z64.h
@@ -93,15 +93,22 @@ typedef struct {
     /* 0x14 */ s16  data[REG_GROUPS * REG_PER_GROUP]; // 0xAE0 entries
 } GameInfo; // size = 0x15D4
 
+#define KiB 0x400
+#define MiB KiB * KiB
+
+// Changed the main buffers to be 1MiB to make them basically impossible to overflow
 typedef struct {
     /* 0x00000 */ u16 headMagic; // GFXPOOL_HEAD_MAGIC
-    /* 0x00008 */ Gfx polyOpaBuffer[0x2FC0];
-    /* 0x0BF08 */ Gfx polyXluBuffer[0x1000];
-    /* 0x0FF08 */ Gfx overlayBuffer[0x800];
-    /* 0x11F08 */ Gfx workBuffer[0x100];
-    /* 0x11308 */ Gfx unusedBuffer[0x40];
+    /* 0x00008 */ Gfx polyOpaBuffer[1 * MiB]; // original size was 0x17E0
+    /* 0x0BF08 */ Gfx polyXluBuffer[1 * MiB]; // original size was 0x800
+    /* 0x0FF08 */ Gfx overlayBuffer[1 * MiB]; // original size was 0x400
+    /* 0x11F08 */ Gfx workBuffer[0x80];
+    /* 0x11308 */ Gfx unusedBuffer[0x20];
     /* 0x12408 */ u16 tailMagic; // GFXPOOL_TAIL_MAGIC
-} GfxPool; // size = 0x24820
+} GfxPool; // size = 0x12410
+
+#undef MiB
+#undef KiB
 
 typedef struct {
     /* 0x0000 */ u32    size;

--- a/soh/include/z64.h
+++ b/soh/include/z64.h
@@ -93,22 +93,16 @@ typedef struct {
     /* 0x14 */ s16  data[REG_GROUPS * REG_PER_GROUP]; // 0xAE0 entries
 } GameInfo; // size = 0x15D4
 
-#define KiB 0x400
-#define MiB KiB * KiB
-
 // Changed the main buffers to be 1MiB to make them basically impossible to overflow
 typedef struct {
     /* 0x00000 */ u16 headMagic; // GFXPOOL_HEAD_MAGIC
-    /* 0x00008 */ Gfx polyOpaBuffer[1 * MiB]; // original size was 0x17E0
-    /* 0x0BF08 */ Gfx polyXluBuffer[1 * MiB]; // original size was 0x800
-    /* 0x0FF08 */ Gfx overlayBuffer[1 * MiB]; // original size was 0x400
+    /* 0x00008 */ Gfx polyOpaBuffer[1 * 1024 * 1024]; // original size was 0x17E0
+    /* 0x0BF08 */ Gfx polyXluBuffer[1 * 1024 * 1024]; // original size was 0x800
+    /* 0x0FF08 */ Gfx overlayBuffer[1 * 1024 * 1024]; // original size was 0x400
     /* 0x11F08 */ Gfx workBuffer[0x80];
     /* 0x11308 */ Gfx unusedBuffer[0x20];
     /* 0x12408 */ u16 tailMagic; // GFXPOOL_TAIL_MAGIC
 } GfxPool; // size = 0x12410
-
-#undef MiB
-#undef KiB
 
 typedef struct {
     /* 0x0000 */ u32    size;

--- a/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
+++ b/soh/soh/Enhancements/ExtraModes/EnemyRandomizer.cpp
@@ -62,7 +62,7 @@ static EnemyEntry randomizedEnemySpawnTable[] = {
     { CVAR_ENHANCEMENT("RandomizedEnemyList.Dinolfos"),         "Dinolfos",              ACTOR_EN_ZF,                                -2 }, // Dinolfos
     { CVAR_ENHANCEMENT("RandomizedEnemyList.Dodongo"),          "Dodongo",               ACTOR_EN_DODONGO,                           -1 }, // Dodongo
     { CVAR_ENHANCEMENT("RandomizedEnemyList.FireKeese"),        "Fire Keese",            ACTOR_EN_FIREFLY,                            1 }, // Fire Keese
-    // { CVAR_ENHANCEMENT("RandomizedEnemyList.FlareDancer"),      "Flare Dancer",          ACTOR_EN_FD,                                 0 }, // Flare Dancer (possible cause of crashes because of spawning flame actors on sloped ground or overloading)
+    { CVAR_ENHANCEMENT("RandomizedEnemyList.FlareDancer"),      "Flare Dancer",          ACTOR_EN_FD,                                 0 }, // Flare Dancer
     { CVAR_ENHANCEMENT("RandomizedEnemyList.FloorTile"),        "Floor Tile",            ACTOR_EN_YUKABYUN,                           0 }, // Flying Floor Tile
     { CVAR_ENHANCEMENT("RandomizedEnemyList.Floormaster"),      "Floormaster",           ACTOR_EN_FLOORMAS,                           0 }, // Floormaster
     { CVAR_ENHANCEMENT("RandomizedEnemyList.FlyingPeahat"),     "Flying Peahat",         ACTOR_EN_PEEHAT,                            -1 }, // Flying Peahat (big grounded, doesn't spawn larva)


### PR DESCRIPTION
Fix the flare dancer crash by increasing the `GfxPool` main buffers to 1MiB.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9649429813.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9649120557.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9649096057.zip)
<!--- section:artifacts:end -->