### PR TITLE
Bugfix for AlwaysOnFixes.cpp as well as a fallback to prevent crashes when attempting to display an textId 0

### DIFF
--- a/soh/soh/Enhancements/AlwaysOnFixes.cpp
+++ b/soh/soh/Enhancements/AlwaysOnFixes.cpp
@@ -130,27 +130,24 @@ void RegisterAlwaysOnFixes() {
         s8* heldItemAction = va_arg(args, s8*);
         s32* camMode = va_arg(args, s32*);
 
-        if (*camMode != CAM_MODE_FIRST_PERSON) {
-            if (*heldItemAction == PLAYER_IA_BOW || *heldItemAction == PLAYER_IA_BOW_FIRE ||
-                *heldItemAction == PLAYER_IA_BOW_ICE || *heldItemAction == PLAYER_IA_BOW_LIGHT) {
-                if (CVarGetInteger(CVAR_ENHANCEMENT("BowSlingshotAmmoFix"), false) ||
-                    CVarGetInteger(CVAR_ENHANCEMENT("EquipmentAlwaysVisible"), false)) {
-                    *camMode = CAM_MODE_AIM_ADULT;
-                }
-            } else if (*heldItemAction == PLAYER_IA_SLINGSHOT) {
-                if (CVarGetInteger(CVAR_ENHANCEMENT("BowSlingshotAmmoFix"), false) ||
-                    CVarGetInteger(CVAR_ENHANCEMENT("EquipmentAlwaysVisible"), false)) {
-                    *camMode = CAM_MODE_AIM_CHILD;
-                }
-            } else if (*heldItemAction == PLAYER_IA_HOOKSHOT || *heldItemAction == PLAYER_IA_LONGSHOT) {
-                if (CVarGetInteger(CVAR_ENHANCEMENT("EquipmentAlwaysVisible"), false)) {
-                    *camMode = CAM_MODE_AIM_ADULT;
-                } else if (gPlayState->sceneNum == SCENE_LAKESIDE_LABORATORY) {
-                    *camMode = CAM_MODE_AIM_ADULT; // Fix child Hookshot aiming in lab (CAM_MODE_AIM_CHILD is invalid there)
-                }
+        if (*heldItemAction == PLAYER_IA_BOW || *heldItemAction == PLAYER_IA_BOW_FIRE ||
+            *heldItemAction == PLAYER_IA_BOW_ICE || *heldItemAction == PLAYER_IA_BOW_LIGHT) {
+            if (CVarGetInteger(CVAR_ENHANCEMENT("BowSlingshotAmmoFix"), false) ||
+                CVarGetInteger(CVAR_ENHANCEMENT("EquipmentAlwaysVisible"), false)) {
+                *camMode = CAM_MODE_AIM_ADULT;
             }
-        }
-        if (*heldItemAction == PLAYER_IA_BOOMERANG) {
+        } else if (*heldItemAction == PLAYER_IA_SLINGSHOT) {
+            if (CVarGetInteger(CVAR_ENHANCEMENT("BowSlingshotAmmoFix"), false) ||
+                CVarGetInteger(CVAR_ENHANCEMENT("EquipmentAlwaysVisible"), false)) {
+                *camMode = CAM_MODE_AIM_CHILD;
+            }
+        } else if (*heldItemAction == PLAYER_IA_HOOKSHOT || *heldItemAction == PLAYER_IA_LONGSHOT) {
+            if (CVarGetInteger(CVAR_ENHANCEMENT("EquipmentAlwaysVisible"), false)) {
+                *camMode = CAM_MODE_AIM_ADULT;
+            } else if (gPlayState->sceneNum == SCENE_LAKESIDE_LABORATORY) {
+                *camMode = CAM_MODE_AIM_ADULT; // Fix child Hookshot aiming in lab (CAM_MODE_AIM_CHILD is invalid there)
+            }
+        } else if (*heldItemAction == PLAYER_IA_BOOMERANG) {
             if (CVarGetInteger(CVAR_ENHANCEMENT("BoomerangFirstPerson"), false)) {
                 *camMode = CAM_MODE_FIRST_PERSON;
             }

--- a/soh/soh/Enhancements/AlwaysOnFixes.cpp
+++ b/soh/soh/Enhancements/AlwaysOnFixes.cpp
@@ -130,21 +130,27 @@ void RegisterAlwaysOnFixes() {
         s8* heldItemAction = va_arg(args, s8*);
         s32* camMode = va_arg(args, s32*);
 
-        if (*heldItemAction == PLAYER_IA_BOW) {
-            if (CVarGetInteger(CVAR_ENHANCEMENT("BowSlingshotAmmoFix"), false) ||
-                CVarGetInteger(CVAR_ENHANCEMENT("EquipmentAlwaysVisible"), false)) {
-                *camMode = CAM_MODE_AIM_ADULT;
+        if (*camMode != CAM_MODE_FIRST_PERSON) {
+            if (*heldItemAction == PLAYER_IA_BOW || *heldItemAction == PLAYER_IA_BOW_FIRE ||
+                *heldItemAction == PLAYER_IA_BOW_ICE || *heldItemAction == PLAYER_IA_BOW_LIGHT) {
+                if (CVarGetInteger(CVAR_ENHANCEMENT("BowSlingshotAmmoFix"), false) ||
+                    CVarGetInteger(CVAR_ENHANCEMENT("EquipmentAlwaysVisible"), false)) {
+                    *camMode = CAM_MODE_AIM_ADULT;
+                }
+            } else if (*heldItemAction == PLAYER_IA_SLINGSHOT) {
+                if (CVarGetInteger(CVAR_ENHANCEMENT("BowSlingshotAmmoFix"), false) ||
+                    CVarGetInteger(CVAR_ENHANCEMENT("EquipmentAlwaysVisible"), false)) {
+                    *camMode = CAM_MODE_AIM_CHILD;
+                }
+            } else if (*heldItemAction == PLAYER_IA_HOOKSHOT || *heldItemAction == PLAYER_IA_LONGSHOT) {
+                if (CVarGetInteger(CVAR_ENHANCEMENT("EquipmentAlwaysVisible"), false)) {
+                    *camMode = CAM_MODE_AIM_ADULT;
+                } else if (gPlayState->sceneNum == SCENE_LAKESIDE_LABORATORY) {
+                    *camMode = CAM_MODE_AIM_ADULT; // Fix child Hookshot aiming in lab (CAM_MODE_AIM_CHILD is invalid there)
+                }
             }
-        } else if (*heldItemAction == PLAYER_IA_SLINGSHOT) {
-            if (CVarGetInteger(CVAR_ENHANCEMENT("BowSlingshotAmmoFix"), false) ||
-                CVarGetInteger(CVAR_ENHANCEMENT("EquipmentAlwaysVisible"), false)) {
-                *camMode = CAM_MODE_AIM_CHILD;
-            }
-        } else if (*heldItemAction == PLAYER_IA_HOOKSHOT || *heldItemAction == PLAYER_IA_LONGSHOT) {
-            if (gPlayState->sceneNum == SCENE_LAKESIDE_LABORATORY) {
-                *camMode = CAM_MODE_AIM_ADULT; // Fix child Hookshot aiming in lab (CAM_MODE_AIM_CHILD is invalid there)
-            }
-        } else if (*heldItemAction == PLAYER_IA_BOOMERANG) {
+        }
+        if (*heldItemAction == PLAYER_IA_BOOMERANG) {
             if (CVarGetInteger(CVAR_ENHANCEMENT("BoomerangFirstPerson"), false)) {
                 *camMode = CAM_MODE_FIRST_PERSON;
             }

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -2681,6 +2681,9 @@ void Message_Decode(PlayState* play) {
 extern const char* msgStaticTbl[];
 
 void Message_OpenText(PlayState* play, u16 textId) {
+    if (textId == 0x0000) {
+        textId = 0x0140; // Fallback to navi text to prevent assign crash
+    }
     lusprintf(__FILE__, __LINE__, 2, "Display Text - textId: %#x", textId);
     static s16 messageStaticIndices[] = { 0, 1, 3, 2 };
     MessageContext* msgCtx = &play->msgCtx;

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -2681,9 +2681,6 @@ void Message_Decode(PlayState* play) {
 extern const char* msgStaticTbl[];
 
 void Message_OpenText(PlayState* play, u16 textId) {
-    if (textId == 0x0000) {
-        textId = 0x0140; // Fallback to navi text to prevent assign crash
-    }
     lusprintf(__FILE__, __LINE__, 2, "Display Text - textId: %#x", textId);
     static s16 messageStaticIndices[] = { 0, 1, 3, 2 };
     MessageContext* msgCtx = &play->msgCtx;

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -5858,12 +5858,11 @@ s32 func_8083AD4C(PlayState* play, Player* this) {
         } else {
             camMode = CAM_MODE_AIM_BOOMERANG;
         }
+        // Check if aiming camera mode should be overridden due to player settings
+        GameInteractor_Should(VB_CHANGE_AIMING_CAMERA, true, &this->heldItemAction, &camMode);
     } else {
         camMode = CAM_MODE_FIRST_PERSON;
     }
-
-    // Check if aiming camera mode should be overridden due to player settings
-    GameInteractor_Should(VB_CHANGE_AIMING_CAMERA, true, &this->heldItemAction, &camMode);
 
     return Camera_RequestMode(Play_GetCamera(play, CAM_ID_MAIN), camMode);
 }


### PR DESCRIPTION
In the `VB_CHANGE_AIMING_CAMERA` block within  AlwaysOnFixes.cpp, the code simply checks if link is holding opposite-age equipment before overwriting the camera mode. In normal circumstances this is fine, but you are no longer able to peek through walls with the camera while holding said equipment, as `CAMERA_MODE_FIRST_PERSON` is overwritten with one of the aiming modes. I added a guard that checks if the current mode is `CAMERA_MODE_FIRST_PERSON` before attempting to overwrite it.

Additionally, magic arrows were previously not accounted for, and Hookshot/Longshot never had camera fixes as Child outside of Lakeside Laboratory, even if Scaled Equipment was enabled.

There is also a bug that seems to be related to AssignableTunicsAndBoots.cpp that very often triggers when turning in Ruto's Letter, which somehow overwrites King Zora's textbox and causes `textId` to be `0` which crashes. This isn't exclusive to just this interaction, but it seems to most commonly apply there; see the attached log file for a crash I was able to reproduce by turning in Ruto's Letter until it happened on _9.2.3 stable_.

The temporary fix provided in the pull request simply falls back to a random Navi text, 0x140, preventing the crash. In the case of turning in Ruto's Letter, the player need only trade it in again to move King Zora; the bottle isn't lost when the fallback occurs.
[Ship of Harkinian.log](https://github.com/user-attachments/files/31510579/Ship.of.Harkinian.log)

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9648000167.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9647733762.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9647701388.zip)
<!--- section:artifacts:end -->