### PR TITLE
Fix loop condition in WriteExcludedLocations function in spoiler_log.cpp

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/spoiler_log.cpp
@@ -162,7 +162,7 @@ std::string RemoveLineBreaks(std::string s) {
 static void WriteExcludedLocations() {
     auto ctx = Rando::Context::GetInstance();
 
-    for (size_t i = 0; i < Rando::Settings::GetInstance()->GetExcludeLocationsOptions().size() - 1; i++) {
+    for (size_t i = 0; i < Rando::Settings::GetInstance()->GetExcludeLocationsOptions().size(); i++) {
         for (const auto& location : Rando::Settings::GetInstance()->GetExcludeLocationsOptions()[i]) {
             if (ctx->GetLocationOption(static_cast<RandomizerCheck>(location->GetKey())).Get() == RO_LOCATION_INCLUDE) {
                 continue;


### PR DESCRIPTION
In `spoiler_log.cpp` at line 165, `for (size_t i = 0; i < Rando::Settings::GetInstance()->GetExcludeLocationsOptions().size() - 1; i++)`, `GetExcludeLocationsOptions().size()` returns `mExcludeLocationsOptionsAreas` which is already sized to RCAREA_INVALID. Adding `- 1` causes RCAREA_GANONS_CASTLE exclusions to not be written to the spoiler log.

Currently, this is inconsequential (at least I think it is?), but can cause issues down the road for features or whatever that need to query the excludedLocations block in the spoiler log. This did cause issues on a fork of my own, so I figured why not fix it upstream too.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9675878431.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9675858313.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9675809378.zip)
<!--- section:artifacts:end -->