### PR TITLE
Honour the loop end when reading streamed music

### DIFF
--- a/soh/src/code/audio_synthesis.c
+++ b/soh/src/code/audio_synthesis.c
@@ -851,28 +851,43 @@ Acmd* AudioSynth_ProcessNote(s32 noteIndex, NoteSubEu* noteSubEu, NoteSynthesisS
                         s5 = samplesLenAdjusted;
                         goto skip;
                     case CODEC_S16:
-                    case CODEC_OPUS:
-                        AudioSynth_ClearBuffer(cmd++, DMEM_UNCOMPRESSED_NOTE, (samplesLenAdjusted + 16) * 2);
+                    case CODEC_OPUS: {
+                        if (nSamplesProcessed == 0) {
+                            AudioSynth_ClearBuffer(cmd++, DMEM_UNCOMPRESSED_NOTE, (samplesLenAdjusted + 16) * 2);
+                        }
                         flags = A_CONTINUE;
                         skipBytes = 0;
-                        size_t bytesToRead;
-                        nSamplesProcessed += samplesLenAdjusted;
+                        s32 nSamplesToRead = nSamplesToProcess;
 
-                        if (((synthState->samplePosInt * 2) + (samplesLenAdjusted)*2) < audioFontSample->size) {
-                            bytesToRead = (samplesLenAdjusted)*2;
-                        } else {
-                            bytesToRead = audioFontSample->size - (synthState->samplePosInt * 2);
+                        // Reading a whole block past the loop end plays back whatever the song has after
+                        // it and only then jumps, landing the seam at a random offset rather than the one
+                        // the sample asked for.
+                        if (nSamplesUntilLoopEnd > 0 && nSamplesToRead > nSamplesUntilLoopEnd) {
+                            nSamplesToRead = nSamplesUntilLoopEnd;
                         }
+
+                        size_t bytesToRead = nSamplesToRead * 2;
+                        size_t bytesAvailable = (synthState->samplePosInt * 2) < audioFontSample->size
+                                                    ? audioFontSample->size - (synthState->samplePosInt * 2)
+                                                    : 0;
+                        if (bytesToRead > bytesAvailable) {
+                            bytesToRead = bytesAvailable;
+                        }
+
                         // 2S2H [Port] [Custom audio] Handle decoding OPUS data
                         if (audioFontSample->codec == CODEC_OPUS) {
-                            aOPUSdecImpl(sampleAddr, DMEM_UNCOMPRESSED_NOTE, bytesToRead, &synthState->opusFile,
+                            aOPUSdecImpl(sampleAddr, DMEM_UNCOMPRESSED_NOTE + s5, bytesToRead, &synthState->opusFile,
                                          synthState->samplePosInt, audioFontSample->fileSize);
                         } else {
-                            aLoadBuffer(cmd++, sampleAddr + (synthState->samplePosInt * 2), DMEM_UNCOMPRESSED_NOTE,
+                            aLoadBuffer(cmd++, sampleAddr + (synthState->samplePosInt * 2), DMEM_UNCOMPRESSED_NOTE + s5,
                                         bytesToRead);
                         }
 
+                        nSamplesProcessed += nSamplesToRead;
+                        s5 += nSamplesToRead * 2;
+
                         goto skip;
+                    }
                     case CODEC_REVERB:
                         break;
                 }


### PR DESCRIPTION
Fixes #5780.

`AudioSynth_ProcessNote` reads streamed samples a block at a time and never consults the loop end, so playback runs past it and only then jumps back. The seam lands wherever the block boundary fell - up to 264 samples late on the usual spec - instead of at the loop point. `nSamplesUntilLoopEnd` and `restart` were already computed correctly, just ignored; the read now stops at the loop end and the enclosing loop fetches the rest of the block from the loop start.

## Testing

Decoded each song of OOT OST Enhanced offline and scored the click at the seam (4 kHz high-pass, peak in a 2 ms window over the local baseline):

| | seam as authored | seam where it lands today |
|---|---|---|
| Goron City | 6.0 | 75.5 |
| Zora's Domain | 11.5 | 41.0 |
| Lost Woods | 2.2 | 9.0 |
| Ingo | 3.6 | 10.6 |
| Horse Race | 9.8 | 17.8 |

Some loop points in that pack click on their own (House 217, Owl 141, Zelda's Courtyard 80, measured at the authored seam) and nothing the port does about *where* the seam lands helps those. A 2 ms crossfade would cover them too - median click 10.8 to 2.4, worst case 217 to 6.2 - but that is a behaviour change, so not here.

Confirmed in game by the pack author: https://github.com/HarbourMasters/Shipwright/pull/7129#issuecomment-5464228419

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9733386155.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9733377497.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9733338635.zip)
<!--- section:artifacts:end -->
