### PR TITLE
Reopen the OPUS decoder when a note moves to another sample

### DIFF
--- a/soh/include/z64audio.h
+++ b/soh/include/z64audio.h
@@ -468,7 +468,7 @@ typedef struct {
     /* 0x00F0 */ s16 dummyResampleState[0x10];
 } NoteSynthesisBuffers; // size = 0x110
 
-struct OggOpusFile;
+struct OpusDecState;
 
 typedef struct {
     /* 0x00 */ u8 restart;
@@ -488,8 +488,7 @@ typedef struct {
     /* 0x1A */ u8 unk_1A;
     /* 0x1C */ u16 unk_1C;
     /* 0x1E */ u16 unk_1E;
-    struct OggOpusFile* opusFile; // Only for streamed opus audio
-    uintptr_t opusSampleAddr;     // sample opusFile was opened for
+    struct OpusDecState* opusFile; // Only for streamed opus audio
 } NoteSynthesisState; // size = 0x20
 
 typedef struct {

--- a/soh/include/z64audio.h
+++ b/soh/include/z64audio.h
@@ -489,6 +489,7 @@ typedef struct {
     /* 0x1C */ u16 unk_1C;
     /* 0x1E */ u16 unk_1E;
     struct OggOpusFile* opusFile; // Only for streamed opus audio
+    uintptr_t opusSampleAddr;     // sample opusFile was opened for
 } NoteSynthesisState; // size = 0x20
 
 typedef struct {

--- a/soh/soh/mixer.c
+++ b/soh/soh/mixer.c
@@ -2,6 +2,7 @@
 //! when unoptimized and clang does not allow optimizing a single function.
 
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "mixer.h"
@@ -108,28 +109,52 @@ void aLoadBufferImpl(const void* source_addr, uint16_t dest_addr, uint16_t nbyte
 
 #include <opusfile.h>
 
-void aOPUSdecImpl(void* source_addr, uint16_t dest_addr, uint16_t nbytes, struct OggOpusFile** decState, int32_t pos,
+// The decoder is cached on the note, so remember which buffer it was opened for.
+struct OpusDecState {
+    OggOpusFile* file;
+    const void* source;
+};
+
+void aOPUSdecImpl(void* source_addr, uint16_t dest_addr, uint16_t nbytes, struct OpusDecState** decState, int32_t pos,
                   uint32_t size) {
     int readSamples = 0;
-    if (*decState == NULL) {
-        *decState = op_open_memory(source_addr, size, NULL);
+    struct OpusDecState* dec = *decState;
+
+    // Note reused for another streamed sample may have previous decoder opened,
+    // which would keep playing the previous track under new note.
+    if (dec != NULL && dec->source != source_addr) {
+        aOPUSFree(dec);
+        dec = NULL;
+        *decState = NULL;
     }
-    op_pcm_seek(*decState, pos);
-    int ret = op_read(*decState, BUF_S16(dest_addr), nbytes / 2, NULL);
+    if (dec == NULL) {
+        OggOpusFile* file = op_open_memory(source_addr, size, NULL);
+        if (file == NULL) {
+            return;
+        }
+        dec = malloc(sizeof(struct OpusDecState));
+        dec->file = file;
+        dec->source = source_addr;
+        *decState = dec;
+    }
+
+    op_pcm_seek(dec->file, pos);
+    int ret = op_read(dec->file, BUF_S16(dest_addr), nbytes / 2, NULL);
     if (ret < 0) {
         return;
     }
     readSamples += ret;
     while (readSamples < nbytes / 2) {
-        ret = op_read(*decState, BUF_S16(dest_addr + readSamples * 2), (nbytes - readSamples * 2) / 2, NULL);
+        ret = op_read(dec->file, BUF_S16(dest_addr + readSamples * 2), (nbytes - readSamples * 2) / 2, NULL);
         if (ret == 0)
             break;
         readSamples += ret;
     }
 }
 
-void aOPUSFree(struct OggOpusFile* opusFile) {
-    op_free(opusFile);
+void aOPUSFree(struct OpusDecState* dec) {
+    op_free(dec->file);
+    free(dec);
 }
 
 void aSaveBufferImpl(uint16_t source_addr, int16_t* dest_addr, uint16_t nbytes) {

--- a/soh/soh/mixer.h
+++ b/soh/soh/mixer.h
@@ -57,11 +57,11 @@ void aHiLoGainImpl(uint8_t g, uint16_t count, uint16_t addr);
 void aUnkCmd3Impl(uint16_t a, uint16_t b, uint16_t c);
 void aUnkCmd19Impl(uint8_t f, uint16_t count, uint16_t out_addr, uint16_t in_addr);
 
-struct OggOpusFile;
+struct OpusDecState;
 
-void aOPUSdecImpl(void* source_addr, uint16_t dest_addr, uint16_t nbytes, struct OggOpusFile** decState, int32_t pos,
+void aOPUSdecImpl(void* source_addr, uint16_t dest_addr, uint16_t nbytes, struct OpusDecState** decState, int32_t pos,
                   uint32_t size);
-void aOPUSFree(struct OggOpusFile* opusFile);
+void aOPUSFree(struct OpusDecState* dec);
 
 #define aSegment(pkt, s, b) \
     do {                    \

--- a/soh/soh/mixer.h
+++ b/soh/soh/mixer.h
@@ -61,6 +61,7 @@ struct OggOpusFile;
 
 void aOPUSdecImpl(void* source_addr, uint16_t dest_addr, uint16_t nbytes, struct OggOpusFile** decState, int32_t pos,
                   uint32_t size);
+void aOPUSFree(struct OggOpusFile* opusFile);
 
 #define aSegment(pkt, s, b) \
     do {                    \

--- a/soh/src/code/audio_playback.c
+++ b/soh/src/code/audio_playback.c
@@ -1,5 +1,6 @@
 #include "global.h"
 #include "soh/ResourceManagerHelpers.h"
+#include "soh/mixer.h"
 
 extern bool gUseLegacySD;
 
@@ -150,7 +151,6 @@ void Audio_NoteInit(Note* note) {
     note->noteSubEu = gDefaultNoteSub;
 }
 
-extern void aOPUSFree(struct OggOpusFile* opusFile);
 void Audio_NoteDisable(Note* note) {
     if (note->noteSubEu.bitField0.needsInit == true) {
         note->noteSubEu.bitField0.needsInit = false;
@@ -166,6 +166,7 @@ void Audio_NoteDisable(Note* note) {
     if (note->synthesisState.opusFile != NULL) {
         aOPUSFree(note->synthesisState.opusFile);
         note->synthesisState.opusFile = NULL;
+        note->synthesisState.opusSampleAddr = 0;
     }
 }
 

--- a/soh/src/code/audio_playback.c
+++ b/soh/src/code/audio_playback.c
@@ -1,6 +1,5 @@
 #include "global.h"
 #include "soh/ResourceManagerHelpers.h"
-#include "soh/mixer.h"
 
 extern bool gUseLegacySD;
 
@@ -151,6 +150,7 @@ void Audio_NoteInit(Note* note) {
     note->noteSubEu = gDefaultNoteSub;
 }
 
+extern void aOPUSFree(struct OpusDecState* dec);
 void Audio_NoteDisable(Note* note) {
     if (note->noteSubEu.bitField0.needsInit == true) {
         note->noteSubEu.bitField0.needsInit = false;
@@ -166,7 +166,6 @@ void Audio_NoteDisable(Note* note) {
     if (note->synthesisState.opusFile != NULL) {
         aOPUSFree(note->synthesisState.opusFile);
         note->synthesisState.opusFile = NULL;
-        note->synthesisState.opusSampleAddr = 0;
     }
 }
 

--- a/soh/src/code/audio_synthesis.c
+++ b/soh/src/code/audio_synthesis.c
@@ -876,6 +876,13 @@ Acmd* AudioSynth_ProcessNote(s32 noteIndex, NoteSubEu* noteSubEu, NoteSynthesisS
 
                         // 2S2H [Port] [Custom audio] Handle decoding OPUS data
                         if (audioFontSample->codec == CODEC_OPUS) {
+                            // A note reused for another streamed sample keeps the decoder its predecessor opened,
+                            // so the previous track carries on playing under the new note.
+                            if (synthState->opusFile != NULL && synthState->opusSampleAddr != sampleAddr) {
+                                aOPUSFree(synthState->opusFile);
+                                synthState->opusFile = NULL;
+                            }
+                            synthState->opusSampleAddr = sampleAddr;
                             aOPUSdecImpl(sampleAddr, DMEM_UNCOMPRESSED_NOTE + s5, bytesToRead, &synthState->opusFile,
                                          synthState->samplePosInt, audioFontSample->fileSize);
                         } else {

--- a/soh/src/code/audio_synthesis.c
+++ b/soh/src/code/audio_synthesis.c
@@ -876,13 +876,6 @@ Acmd* AudioSynth_ProcessNote(s32 noteIndex, NoteSubEu* noteSubEu, NoteSynthesisS
 
                         // 2S2H [Port] [Custom audio] Handle decoding OPUS data
                         if (audioFontSample->codec == CODEC_OPUS) {
-                            // A note reused for another streamed sample keeps the decoder its predecessor opened,
-                            // so the previous track carries on playing under the new note.
-                            if (synthState->opusFile != NULL && synthState->opusSampleAddr != sampleAddr) {
-                                aOPUSFree(synthState->opusFile);
-                                synthState->opusFile = NULL;
-                            }
-                            synthState->opusSampleAddr = sampleAddr;
                             aOPUSdecImpl(sampleAddr, DMEM_UNCOMPRESSED_NOTE + s5, bytesToRead, &synthState->opusFile,
                                          synthState->samplePosInt, audioFontSample->fileSize);
                         } else {


### PR DESCRIPTION
Fixes #5684.

`aOPUSdecImpl` caches its `OggOpusFile` on the note and keys it on nothing, so a note reused for a different streamed sample carries on decoding the track the previous note was playing. `Audio_NoteDisable` frees the handle, but `Audio_NoteInitForLayer` can run on a note that still owns one.

This is why the audio editor looks right: sequence and soundfont selection are correct, only the samples reaching the mixer are not. #6736 fixed the selection half of the issue; this is the rest.

Reproduced on the game-start cutscene chain with a streamed music pack (OOT OST Enhanced) in 4 of 6 runs, 0 of 6 after. Detected with a probe on `aOPUSdecImpl` comparing the source buffer against the one the open handle was created for.


<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9982543377.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9982489724.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9982438673.zip)
<!--- section:artifacts:end -->