### PR TITLE
Add support for sdl2-compat on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,37 +424,40 @@ install(CODE "
     fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/../MacOS/soh\" \"\" \"${dirs}\")
     ")
 
-# Fixup SDL3 dylib symlinks. SDL3's CMake install creates a dylib with a versioned
-# name, and symlinks to it for the unversioned and major-version names.
-# The symlinks are relative, so they break when the app bundle is relocated.
-# This creates absolute symlinks in the Frameworks directory, which is where the
-# app bundle looks for them.
-INSTALL(CODE "
-    GET_FILENAME_COMPONENT(SDL3_FILENAME \"\${SDL3_LIBRARY}\" NAME)
+if(DARWIN_SDL2_IS_COMPAT)
+    # Fixup SDL3 dylib symlinks. SDL3's CMake install creates a dylib with a versioned
+    # name, and symlinks to it for the unversioned and major-version names.
+    # The symlinks are relative, so they break when the app bundle is relocated.
+    # This creates absolute symlinks in the Frameworks directory, which is where the
+    # app bundle looks for them.
+    INSTALL(CODE "
 
-    SET(FRAMEWORKS_DIR \"\${CMAKE_INSTALL_PREFIX}/../Frameworks\")
-    SET(SDL3_ACTUAL \"\${FRAMEWORKS_DIR}/\${SDL3_FILENAME}\")
+        SET(FRAMEWORKS_DIR \"\${CMAKE_INSTALL_PREFIX}/../Frameworks\")
 
-    IF(NOT SDL3_FILENAME STREQUAL \"libSDL3.dylib\")
-        IF(NOT EXISTS \"\${FRAMEWORKS_DIR}/libSDL3.dylib\")
-            FILE(CREATE_LINK
-                \"\${SDL3_FILENAME}\"
-                \"\${FRAMEWORKS_DIR}/libSDL3.dylib\"
-                SYMBOLIC
-            )
+        FILE(GLOB SDL3_FILES \"\${FRAMEWORKS_DIR}/libSDL3*\")
+        LIST(GET SDL3_FILES 0 SDL3_FILENAME)
+
+        IF(NOT SDL3_FILENAME STREQUAL \"libSDL3.dylib\")
+            IF(NOT EXISTS \"\${FRAMEWORKS_DIR}/libSDL3.dylib\")
+                FILE(CREATE_LINK
+                    \"\${SDL3_FILENAME}\"
+                    \"\${FRAMEWORKS_DIR}/libSDL3.dylib\"
+                    SYMBOLIC
+                )
+            ENDIF()
         ENDIF()
-    ENDIF()
 
-    IF(NOT SDL3_FILENAME STREQUAL \"libSDL3.0.dylib\")
-        IF(NOT EXISTS \"\${FRAMEWORKS_DIR}/libSDL3.0.dylib\")
-            FILE(CREATE_LINK
-                \"\${SDL3_FILENAME}\"
-                \"\${FRAMEWORKS_DIR}/libSDL3.0.dylib\"
-                SYMBOLIC
-            )
+        IF(NOT SDL3_FILENAME STREQUAL \"libSDL3.0.dylib\")
+            IF(NOT EXISTS \"\${FRAMEWORKS_DIR}/libSDL3.0.dylib\")
+                FILE(CREATE_LINK
+                    \"\${SDL3_FILENAME}\"
+                    \"\${FRAMEWORKS_DIR}/libSDL3.0.dylib\"
+                    SYMBOLIC
+                )
+            ENDIF()
         ENDIF()
-    ENDIF()
-")
+    ")
+endif()
 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,6 +424,38 @@ install(CODE "
     fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/../MacOS/soh\" \"\" \"${dirs}\")
     ")
 
+# Fixup SDL3 dylib symlinks. SDL3's CMake install creates a dylib with a versioned
+# name, and symlinks to it for the unversioned and major-version names.
+# The symlinks are relative, so they break when the app bundle is relocated.
+# This creates absolute symlinks in the Frameworks directory, which is where the
+# app bundle looks for them.
+INSTALL(CODE "
+    GET_FILENAME_COMPONENT(SDL3_FILENAME \"\${SDL3_LIBRARY}\" NAME)
+
+    SET(FRAMEWORKS_DIR \"\${CMAKE_INSTALL_PREFIX}/../Frameworks\")
+    SET(SDL3_ACTUAL \"\${FRAMEWORKS_DIR}/\${SDL3_FILENAME}\")
+
+    IF(NOT SDL3_FILENAME STREQUAL \"libSDL3.dylib\")
+        IF(NOT EXISTS \"\${FRAMEWORKS_DIR}/libSDL3.dylib\")
+            FILE(CREATE_LINK
+                \"\${SDL3_FILENAME}\"
+                \"\${FRAMEWORKS_DIR}/libSDL3.dylib\"
+                SYMBOLIC
+            )
+        ENDIF()
+    ENDIF()
+
+    IF(NOT SDL3_FILENAME STREQUAL \"libSDL3.0.dylib\")
+        IF(NOT EXISTS \"\${FRAMEWORKS_DIR}/libSDL3.0.dylib\")
+            FILE(CREATE_LINK
+                \"\${SDL3_FILENAME}\"
+                \"\${FRAMEWORKS_DIR}/libSDL3.0.dylib\"
+                SYMBOLIC
+            )
+        ENDIF()
+    ENDIF()
+")
+
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows|NintendoSwitch|CafeOS")

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -235,7 +235,7 @@ cmake --build build-cmake --target ExtractAssetHeaders
 ```
 
 ## macOS
-Requires Xcode (or xcode-tools) && `sdl2, sdl2_net, libpng, glew, ninja, cmake, tinyxml2, nlohmann-json, libzip, opusfile, libvorbis` (can be installed via [homebrew](https://brew.sh/), macports, etc)
+Requires Xcode (or xcode-tools) && `sdl2, sdl2_net, sdl3, libpng, glew, ninja, cmake, tinyxml2, nlohmann-json, libzip, opusfile, libvorbis` (can be installed via [homebrew](https://brew.sh/), macports, etc)
 
 **Important: For maximum performance make sure you have ninja build tools installed!**
 

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -685,6 +685,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "CafeOS")
     )
 else()
     find_package(SDL2)
+    find_package(SDL3)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
     find_package(Ogg REQUIRED)
@@ -697,6 +698,7 @@ else()
     "libultraship;"
         "torch;"
         SDL2::SDL2
+        SDL3::SDL3
         "Ogg::ogg"
         "Vorbis::vorbis"
         "Vorbis::vorbisenc"

--- a/soh/CMakeLists.txt
+++ b/soh/CMakeLists.txt
@@ -685,7 +685,6 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "CafeOS")
     )
 else()
     find_package(SDL2)
-    find_package(SDL3)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
     find_package(Ogg REQUIRED)
@@ -698,7 +697,6 @@ else()
     "libultraship;"
         "torch;"
         SDL2::SDL2
-        SDL3::SDL3
         "Ogg::ogg"
         "Vorbis::vorbis"
         "Vorbis::vorbisenc"
@@ -709,6 +707,30 @@ else()
         ${CMAKE_DL_LIBS}
         Threads::Threads
     )
+    
+    set(DARWIN_SDL2_IS_COMPAT FALSE)
+
+    if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+        execute_process(
+            COMMAND brew list --versions sdl2-compat
+            RESULT_VARIABLE BREW_SDL2_COMPAT_RESULT
+            OUTPUT_QUIET
+            ERROR_QUIET
+        )
+
+        if(BREW_SDL2_COMPAT_RESULT EQUAL 0)
+            set(DARWIN_SDL2_IS_COMPAT TRUE)
+        endif()
+    endif()
+
+    if(DARWIN_SDL2_IS_COMPAT)
+        message(STATUS "SDL2 is using SDL3 compatibility layer, adding SDL3 to link dependencies")
+        find_package(SDL3)
+        list(APPEND ADDITIONAL_LIBRARY_DEPENDENCIES SDL3::SDL3)
+    endif()
+
+    set(DARWIN_SDL2_IS_COMPAT ${DARWIN_SDL2_IS_COMPAT} PARENT_SCOPE)
+
     if(MATH_LIBRARY)
         list(APPEND ADDITIONAL_LIBRARY_DEPENDENCIES ${MATH_LIBRARY})
     endif()


### PR DESCRIPTION
### Summary
This PR adds support / verification for running with **`sdl2-compat`**.

### Context & Justification
As of mid-2026, **Homebrew has deprecated the legacy standalone SDL2 codebase** in favor of `sdl2-compat`. In the official `homebrew-core` package manager, the `sdl2` formula is now a direct alias that installs `sdl2-compat` and handles the API on top of an underlying SDL3 runtime dependency. 

Because modern macOS environments utilizing Homebrew (as well as many rolling-release Linux distros like Arch) are aggressively phasing out native SDL2 binaries, verifying and documenting compatibility with the `sdl2-compat` layer ensures our application remains fully buildable and operational for users installing dependencies via modern package managers without unexpected CMake or runtime hitches.

Without this, running from the build directory on MacOS will work as long as libSDL3 is installed, but the bundled app will fail with a "Can't load SDL3 library" error.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9966318015.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9966275952.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/9966223427.zip)
<!--- section:artifacts:end -->