### PR TITLE
Reduce big octo cutscene skip

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/SkipMiscInteractions/SkipChildRutoInteractions.cpp
+++ b/soh/soh/Enhancements/TimeSavers/SkipMiscInteractions/SkipChildRutoInteractions.cpp
@@ -73,11 +73,10 @@ void RegisterSkipChildRutoInteractions() {
                            enRu1->action = 42;
                            Animation_Change(&enRu1->skelAnime, (AnimationHeader*)&gRutoChildWait2Anim, 1.0f, 0,
                                             Animation_GetLastFrame((void*)&gRutoChildWait2Anim), ANIMMODE_LOOP, -8.0f);
-                           // If we aren't skipping one point cutscenes and BgBdan objects has set the camera setting
-                           // to CAM_SET_NORMAL1 (2), don't reset the camera setting to 1. This prevents the One Point
-                           // Cutscene of Ruto getting lifted up from getting queued up twice.
-                           if (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.OnePoint"), IS_RANDO) ||
-                               enRu1->unk_28C->cameraSetting != 2) {
+                           // If BgBdan objects has set the camera setting to CAM_SET_NORMAL1 (2), don't reset the
+                           // camera setting to 1. This prevents the One Point Cutscene of Ruto getting lifted up
+                           // from getting queued up twice.
+                           if (enRu1->unk_28C->cameraSetting != 2) {
                                enRu1->unk_28C->cameraSetting = 1;
                            }
                            Actor* sapphire = func_80AEB124(gPlayState);

--- a/soh/soh/Enhancements/TimeSavers/timesaver_hook_handlers.cpp
+++ b/soh/soh/Enhancements/TimeSavers/timesaver_hook_handlers.cpp
@@ -31,7 +31,6 @@ extern "C" {
 #include "src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.h"
 #include "src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.h"
 #include "src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.h"
-#include "src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h"
 #include <overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h>
 #include <overlays/actors/ovl_En_Ik/z_en_ik.h>
 #include <objects/object_gnd/object_gnd.h>
@@ -283,6 +282,11 @@ void TimeSaverOnVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_li
                         }
                         // This is handled in the FasterHeavyBlockLift enhancement
                         if (actor->id == ACTOR_BG_HEAVY_BLOCK) {
+                            break;
+                        }
+
+                        // No point giving control while Big Octo platform goes up & down
+                        if (actor->id == ACTOR_BG_BDAN_OBJECTS && actor->params == 0) {
                             break;
                         }
 
@@ -948,8 +952,6 @@ static uint32_t bgSpot03UpdateHook = 0;
 static uint32_t bgSpot03KillHook = 0;
 static uint32_t enPoSistersUpdateHook = 0;
 static uint32_t enPoSistersKillHook = 0;
-static uint32_t enBigokutaUpdateHook = 0;
-static uint32_t enBigokutaKillHook = 0;
 void TimeSaverOnActorInitHandler(void* actorRef) {
     Actor* actor = static_cast<Actor*>(actorRef);
 
@@ -1175,38 +1177,6 @@ void TimeSaverOnActorInitHandler(void* actorRef) {
             EnRu2_SetEncounterSwitchFlag(enRu2, gPlayState);
             Actor_Kill(actor);
         }
-    }
-
-    // Prevent softlock from pre-battle early hit on Bigocto (possible by cutscene skip)
-    if (actor->id == ACTOR_EN_BIGOKUTA) {
-        enBigokutaUpdateHook =
-            GameInteractor::Instance->RegisterGameHook<GameInteractor::OnActorUpdate>([](void* innerActorRef) mutable {
-                Actor* innerActor = static_cast<Actor*>(innerActorRef);
-                if (innerActor->id == ACTOR_EN_BIGOKUTA &&
-                    (CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.OnePoint"), IS_RANDO))) {
-                    EnBigokuta* enBigokuta = static_cast<EnBigokuta*>(innerActorRef);
-                    if (enBigokuta->actor.params == 2) { // Platform already active
-                        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnActorUpdate>(
-                            enBigokutaUpdateHook);
-                        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSceneInit>(enBigokutaKillHook);
-                        enBigokutaUpdateHook = 0;
-                        enBigokutaKillHook = 0;
-                        // Possible action functions after taken damage
-                    } else if (enBigokuta->actionFunc == func_809BE058 || enBigokuta->actionFunc == func_809BDF34 ||
-                               enBigokuta->actionFunc == func_809BE180) {
-                        enBigokuta->actor.home.pos.y = enBigokuta->actor.world.pos.y = -1025.0f;
-                        Actor_ChangeCategory(gPlayState, &gPlayState->actorCtx, &enBigokuta->actor, ACTORCAT_ENEMY);
-                        enBigokuta->actor.params = 2; // Activate platform
-                    }
-                }
-            });
-        enBigokutaKillHook =
-            GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>([](int16_t sceneNum) mutable {
-                GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnActorUpdate>(enBigokutaUpdateHook);
-                GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSceneInit>(enBigokutaKillHook);
-                enBigokutaUpdateHook = 0;
-                enBigokutaKillHook = 0;
-            });
     }
 }
 

--- a/soh/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h
+++ b/soh/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h
@@ -24,8 +24,4 @@ typedef struct EnBigokuta {
     /* 0x02EC */ ColliderCylinder cylinder[2];
 } EnBigokuta; // size = 0x0384
 
-void func_809BE058(EnBigokuta*, PlayState*);
-void func_809BDF34(EnBigokuta*, PlayState*);
-void func_809BE180(EnBigokuta*, PlayState*);
-
 #endif


### PR DESCRIPTION
Pointless to give control while player waits for big octo to descend (& still play cutscene),
just opens up complications & speedrun discussion raised concern about backflip to get behind Big Octo

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/10037695890.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/10037691311.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/10037607331.zip)
<!--- section:artifacts:end -->