### PR TITLE
water temple: quadruple water level change when skipping cutscene

### DIFF
--- a/soh/soh/Enhancements/TimeSavers/FasterWaterTempleLevelChange.cpp
+++ b/soh/soh/Enhancements/TimeSavers/FasterWaterTempleLevelChange.cpp
@@ -1,0 +1,20 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "soh/Enhancements/game-interactor/GameInteractor.h"
+#include "soh/ShipInit.hpp"
+#include "soh/cvar_prefixes.h"
+
+extern "C" {
+#include "z64save.h"
+extern SaveContext gSaveContext;
+}
+
+static void RegisterFasterWaterTempleLevelChange() {
+    COND_VB_SHOULD(VB_MODIFY_WATER_TEMPLE_WATER_LEVEL_SPEED,
+                   IS_RANDO || CVarGetInteger(CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.OnePoint"), 0), {
+                       f32* speed = va_arg(args, f32*);
+                       *speed = 20.0f;
+                   });
+}
+
+static RegisterShipInitFunc initFunc(RegisterFasterWaterTempleLevelChange,
+                                     { CVAR_ENHANCEMENT("TimeSavers.SkipCutscene.OnePoint"), "IS_RANDO" });

--- a/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
+++ b/soh/soh/Enhancements/game-interactor/vanilla-behavior/GIVanillaBehavior.h
@@ -1778,6 +1778,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `f32*` speed
+    VB_MODIFY_WATER_TEMPLE_WATER_LEVEL_SPEED,
+
+    // #### `result`
+    // ```c
     // this->interactInfo.talkState == NPC_TALK_STATE_ACTION
     // ```
     // #### `args`

--- a/soh/src/overlays/actors/ovl_Bg_Mizu_Water/z_bg_mizu_water.c
+++ b/soh/src/overlays/actors/ovl_Bg_Mizu_Water/z_bg_mizu_water.c
@@ -6,6 +6,7 @@
 
 #include "z_bg_mizu_water.h"
 #include "objects/object_mizu_objects/object_mizu_objects.h"
+#include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
 
 #define FLAGS (ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_DRAW_CULLING_DISABLED)
 
@@ -233,7 +234,9 @@ void BgMizuWater_ChangeWaterLevel(BgMizuWater* this, PlayState* play) {
                 Flags_UnsetSwitch(play, prevSwitchFlag);
             }
 
-            if (Math_StepToF(&this->actor.world.pos.y, this->targetY, 5.0f)) {
+            f32 speed = 5.0f;
+            GameInteractor_Should(VB_MODIFY_WATER_TEMPLE_WATER_LEVEL_SPEED, true, &speed);
+            if (Math_StepToF(&this->actor.world.pos.y, this->targetY, speed)) {
                 play->roomCtx.unk_74[0] = 0;
                 this->actionFunc = BgMizuWater_WaitForAction;
                 Message_CloseTextbox(play);


### PR DESCRIPTION
prevents falling into water while it descends, reaching 2f cracked wall without tricks

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/10040799578.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/10040749267.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/10040601917.zip)
<!--- section:artifacts:end -->