### PR TITLE
Fix megadives with jump clamping

### DIFF
--- a/soh/soh/Enhancements/SpeedModifiers.cpp
+++ b/soh/soh/Enhancements/SpeedModifiers.cpp
@@ -11,7 +11,6 @@ extern "C" {
 extern PlayState* gPlayState;
 extern void func_8083DF68(Player* player, f32 arg1, s16 arg2);
 extern void func_8083DDC8(Player* player, PlayState* play);
-
 }
 
 #define CVAR_SPEED_MODIFIER_VALUE_NAME CVAR_CHEAT("SpeedModifier.Value")
@@ -52,8 +51,9 @@ static bool ShouldAmplifyJump(Player* player) {
 static void RegisterSpeedModifiers() {
     bool speedModifierActive = CVarGetFloat(CVAR_SPEED_MODIFIER_VALUE_NAME, 1.0f) != 1.0f;
     bool bunnyHoodActive = Ship_GetBunnyHoodMode() != BUNNY_HOOD_VANILLA;
-    bool jumpsClamped = Ship_GetBunnyHoodMode() == BUNNY_HOOD_FAST || 
-                        (CVarGetFloat(CVAR_SPEED_MODIFIER_VALUE_NAME, 1.0f) != 1.0f && CVarGetInteger(CVAR_SPEED_MODIFIER_JUMP_TOGGLE, 0) == 1);
+    bool jumpsClamped =
+        Ship_GetBunnyHoodMode() == BUNNY_HOOD_FAST || (CVarGetFloat(CVAR_SPEED_MODIFIER_VALUE_NAME, 1.0f) != 1.0f &&
+                                                       CVarGetInteger(CVAR_SPEED_MODIFIER_JUMP_TOGGLE, 0) == 1);
 
     static f32 lastRunSpeed = 0.0f;
 
@@ -90,7 +90,7 @@ static void RegisterSpeedModifiers() {
         func_8083DDC8(player, gPlayState);
 
         lastRunSpeed = player->linearVelocity;
-        
+
         *should = false;
     });
 
@@ -103,5 +103,5 @@ static void RegisterSpeedModifiers() {
     });
 }
 
-static RegisterShipInitFunc initFunc(RegisterSpeedModifiers,
-                                     { "IS_RANDO", CVAR_SPEED_MODIFIER_VALUE_NAME, CVAR_BUNNY_HOOD_NAME, CVAR_SPEED_MODIFIER_JUMP_TOGGLE });
+static RegisterShipInitFunc initFunc(RegisterSpeedModifiers, { "IS_RANDO", CVAR_SPEED_MODIFIER_VALUE_NAME,
+                                                               CVAR_BUNNY_HOOD_NAME, CVAR_SPEED_MODIFIER_JUMP_TOGGLE });

--- a/soh/soh/Enhancements/SpeedModifiers.cpp
+++ b/soh/soh/Enhancements/SpeedModifiers.cpp
@@ -72,8 +72,7 @@ static void RegisterSpeedModifiers() {
     COND_VB_SHOULD(VB_PLAYER_LIMIT_DIVE_XZ_SPEED, jumpsClamped, {
         Player* player = va_arg(args, Player*);
         if (player->linearVelocity <= lastRunSpeed) {
-            f32 maxSpeed = R_RUN_SPEED_LIMIT / 100.0f;
-            maxSpeed = maxSpeed * Ship_GetBunnyHoodJumpFactor(player) * GetSpeedModifierJumpFactor();
+f32 maxSpeed = (R_RUN_SPEED_LIMIT / 100.0f) * Ship_GetBunnyHoodJumpFactor(player) * GetSpeedModifierJumpFactor();
             player->linearVelocity = CLAMP(player->linearVelocity, -maxSpeed, maxSpeed);
         }
     });

--- a/soh/soh/Enhancements/SpeedModifiers.cpp
+++ b/soh/soh/Enhancements/SpeedModifiers.cpp
@@ -72,7 +72,8 @@ static void RegisterSpeedModifiers() {
     COND_VB_SHOULD(VB_PLAYER_LIMIT_DIVE_XZ_SPEED, jumpsClamped, {
         Player* player = va_arg(args, Player*);
         if (player->linearVelocity <= lastRunSpeed) {
-f32 maxSpeed = (R_RUN_SPEED_LIMIT / 100.0f) * Ship_GetBunnyHoodJumpFactor(player) * GetSpeedModifierJumpFactor();
+            f32 maxSpeed =
+                (R_RUN_SPEED_LIMIT / 100.0f) * Ship_GetBunnyHoodJumpFactor(player) * GetSpeedModifierJumpFactor();
             player->linearVelocity = CLAMP(player->linearVelocity, -maxSpeed, maxSpeed);
         }
     });

--- a/soh/soh/Enhancements/SpeedModifiers.cpp
+++ b/soh/soh/Enhancements/SpeedModifiers.cpp
@@ -1,3 +1,4 @@
+#include "soh/Enhancements/enhancementTypes.h"
 #include "soh/Enhancements/game-interactor/GameInteractor.h"
 #include "soh/ShipInit.hpp"
 #include "soh/OTRGlobals.h"
@@ -8,9 +9,13 @@ extern "C" {
 #include "macros.h"
 #include "variables.h"
 extern PlayState* gPlayState;
+extern void func_8083DF68(Player* player, f32 arg1, s16 arg2);
+extern void func_8083DDC8(Player* player, PlayState* play);
+
 }
 
 #define CVAR_SPEED_MODIFIER_VALUE_NAME CVAR_CHEAT("SpeedModifier.Value")
+#define CVAR_SPEED_MODIFIER_JUMP_TOGGLE CVAR_CHEAT("SpeedModifier.DoesntChangeJump")
 
 static f32 GetSpeedModifierFactor(bool inputAvailable) {
     f32 value = CVarGetFloat(CVAR_SPEED_MODIFIER_VALUE_NAME, 1.0f);
@@ -47,6 +52,10 @@ static bool ShouldAmplifyJump(Player* player) {
 static void RegisterSpeedModifiers() {
     bool speedModifierActive = CVarGetFloat(CVAR_SPEED_MODIFIER_VALUE_NAME, 1.0f) != 1.0f;
     bool bunnyHoodActive = Ship_GetBunnyHoodMode() != BUNNY_HOOD_VANILLA;
+    bool jumpsClamped = Ship_GetBunnyHoodMode() == BUNNY_HOOD_FAST || 
+                        (CVarGetFloat(CVAR_SPEED_MODIFIER_VALUE_NAME, 1.0f) != 1.0f && CVarGetInteger(CVAR_SPEED_MODIFIER_JUMP_TOGGLE, 0) == 1);
+
+    static f32 lastRunSpeed = 0.0f;
 
     // Airborne (jump) velocity. z_player clamps linearVelocity to the vanilla run speed limit when this returns true;
     // skip that clamp so the amplified running velocity carries into the jump.
@@ -60,10 +69,11 @@ static void RegisterSpeedModifiers() {
     // dive-into-water animation never clamped by vanilla, so re-clamp to vanilla run speed limit here unless jump be
     // amplified. This keeps dive vanilla-distance (e.g. Gerudo Valley canyon) for bunny hood "fast run" & "Don't affect
     // jump distance" option.
-    COND_VB_SHOULD(VB_PLAYER_LIMIT_DIVE_XZ_SPEED, speedModifierActive || bunnyHoodActive, {
+    COND_VB_SHOULD(VB_PLAYER_LIMIT_DIVE_XZ_SPEED, jumpsClamped, {
         Player* player = va_arg(args, Player*);
-        if (!ShouldAmplifyJump(player)) {
+        if (player->linearVelocity <= lastRunSpeed) {
             f32 maxSpeed = R_RUN_SPEED_LIMIT / 100.0f;
+            maxSpeed = maxSpeed * Ship_GetBunnyHoodJumpFactor(player) * GetSpeedModifierJumpFactor();
             player->linearVelocity = CLAMP(player->linearVelocity, -maxSpeed, maxSpeed);
         }
     });
@@ -72,7 +82,16 @@ static void RegisterSpeedModifiers() {
     COND_VB_SHOULD(VB_PLAYER_MODIFY_RUN_SPEED, speedModifierActive || bunnyHoodActive, {
         Player* player = va_arg(args, Player*);
         f32* speedTarget = va_arg(args, f32*);
+        s16* yawTarget = va_arg(args, s16*);
+
         *speedTarget *= Ship_GetBunnyHoodRunFactor(player) * GetSpeedModifierFactor(true);
+
+        func_8083DF68(player, *speedTarget, *yawTarget);
+        func_8083DDC8(player, gPlayState);
+
+        lastRunSpeed = player->linearVelocity;
+        
+        *should = false;
     });
 
     // Swim speed multiplied in place. Called per speed z_player scales; bunny hood does not apply underwater.
@@ -85,4 +104,4 @@ static void RegisterSpeedModifiers() {
 }
 
 static RegisterShipInitFunc initFunc(RegisterSpeedModifiers,
-                                     { "IS_RANDO", CVAR_SPEED_MODIFIER_VALUE_NAME, CVAR_BUNNY_HOOD_NAME });
+                                     { "IS_RANDO", CVAR_SPEED_MODIFIER_VALUE_NAME, CVAR_BUNNY_HOOD_NAME, CVAR_SPEED_MODIFIER_JUMP_TOGGLE });

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -8870,7 +8870,7 @@ void Player_Action_80842180(Player* this, PlayState* play) {
         Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_CURVED, play);
 
         if (!func_8083C484(this, &speedTarget, &yawTarget)) {
-            if (GameInteractor_Should(VB_PLAYER_MODIFY_RUN_SPEED, true, this, &speedTarget, &yawTarget)){
+            if (GameInteractor_Should(VB_PLAYER_MODIFY_RUN_SPEED, true, this, &speedTarget, &yawTarget)) {
                 func_8083DF68(this, speedTarget, yawTarget);
                 func_8083DDC8(this, play);
             };

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -8870,10 +8870,10 @@ void Player_Action_80842180(Player* this, PlayState* play) {
         Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_CURVED, play);
 
         if (!func_8083C484(this, &speedTarget, &yawTarget)) {
-            GameInteractor_Should(VB_PLAYER_MODIFY_RUN_SPEED, true, this, &speedTarget);
-
-            func_8083DF68(this, speedTarget, yawTarget);
-            func_8083DDC8(this, play);
+            if (GameInteractor_Should(VB_PLAYER_MODIFY_RUN_SPEED, true, this, &speedTarget, &yawTarget)){
+                func_8083DF68(this, speedTarget, yawTarget);
+                func_8083DDC8(this, play);
+            };
 
             if ((this->linearVelocity == 0.0f) && (speedTarget == 0.0f)) {
                 func_8083C0B8(this, play);


### PR DESCRIPTION
The new dive clamping code broke a trick known as megadive.

By placing a bomb behind you and facing a ledge you would dive from, the recoil of the bomb would trigger a dive with the speed of the damage recoil. However the dive clamping assumed that all speed increases came from speed up enhancements if any of them are on, and thus clamped the recoil speed, ruining the trick. The conditions for doing this were also set top be too aggressive, clamping even when settings are set not to clamp, and clamping bunny hood jumps when they are enabled.

This PR should fix all those issues by tracking the last run speed and only clamping if the current speed is equal or lower than that. There may be edge cases where this allows long dives when it shouldn't, but the places you can dive are limited enough that I cannot think of a place this would apply.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/10061687701.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/10061647667.zip)
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/10061418184.zip)
<!--- section:artifacts:end -->