### PR TITLE
Don't erase __attribute__ under clang-cl

### DIFF
--- a/soh/include/attributes.h
+++ b/soh/include/attributes.h
@@ -1,7 +1,9 @@
 #ifndef ATTRIBUTES_H
 #define ATTRIBUTES_H
 
-#if !defined(__GNUC__) && !defined(__attribute__)
+// clang-cl supports __attribute__ but does not define __GNUC__, and clang's own intrinsics headers
+// rely on it - erasing it turns __m64 and friends into scalars.
+#if !defined(__GNUC__) && !defined(__clang__) && !defined(__attribute__)
 #define __attribute__(x)
 #endif
 

--- a/soh/include/attributes.h
+++ b/soh/include/attributes.h
@@ -1,8 +1,6 @@
 #ifndef ATTRIBUTES_H
 #define ATTRIBUTES_H
 
-// clang-cl supports __attribute__ but does not define __GNUC__, and clang's own intrinsics headers
-// rely on it - erasing it turns __m64 and friends into scalars.
 #if !defined(__GNUC__) && !defined(__clang__) && !defined(__attribute__)
 #define __attribute__(x)
 #endif


### PR DESCRIPTION
The shim in `soh/include/attributes.h` defines `__attribute__(x)` to nothing whenever `__GNUC__` is absent. clang-cl does not define `__GNUC__` — it emulates MSVC — but it supports `__attribute__` fully, and clang's own intrinsics headers depend on it.

With the macro erased, `mmintrin.h`'s `typedef long long __m64 __attribute__((__vector_size__(8)))` degrades to a plain scalar, so every use of it fails:

```
mmintrin.h: error: subscripted value is not an array, pointer, or vector
mmintrin.h: error: first two arguments to '__builtin_shufflevector' must be vectors
```

Adding `!defined(__clang__)` to the guard fixes it; clang always defines that, clang-cl included. `cl` is unaffected — it defines neither macro, so it still gets the shim.

Found building SoH with clang-cl.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/10311942043.zip)
  - [soh-mac.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/10311872564.zip)
  - [soh-windows.zip](https://nightly.link/HarbourMasters/Shipwright/actions/artifacts/10311263627.zip)
<!--- section:artifacts:end -->